### PR TITLE
Fix Hyperliquid limit price rejected by tick-size rule

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -133,6 +133,13 @@ class Exchange < ApplicationRecord
     raise NotImplementedError, "#{self.class.name} must implement limit_sell"
   end
 
+  # Format a price to the exchange's tick rule before it is sent to the API.
+  # Default: fixed decimal places. Exchanges with significant-figure tick rules
+  # (e.g. Hyperliquid) override this.
+  def adjusted_price(ticker:, price:, method: :floor)
+    price.public_send(method, ticker.price_decimals)
+  end
+
   def get_order(order_id:)
     raise NotImplementedError, "#{self.class.name} must implement get_order"
   end

--- a/app/models/exchanges/hyperliquid.rb
+++ b/app/models/exchanges/hyperliquid.rb
@@ -5,6 +5,11 @@ class Exchanges::Hyperliquid < Exchange
     invalid_key: ['Invalid API key', 'Authentication failed', 'Invalid signature']
   }.freeze
 
+  # Hyperliquid price rule: at most SIGNIFICANT_FIGURES significant figures and,
+  # for spot, at most (SPOT_MAX_DECIMALS - szDecimals) decimal places.
+  SIGNIFICANT_FIGURES = 5
+  SPOT_MAX_DECIMALS   = 8
+
   include Exchange::Dryable
 
   attr_reader :api_key
@@ -218,6 +223,22 @@ class Exchanges::Hyperliquid < Exchange
       side: :sell,
       price:
     )
+  end
+
+  # Hyperliquid rejects prices that aren't on tick size: at most 5 significant
+  # figures and, for spot, at most (8 - szDecimals) decimal places. We translate
+  # the significant-figure rule into a decimal-place count so floor/ceil/round
+  # semantics are preserved (a buy limit set below market must never round up).
+  # BigDecimal#exponent gives the power-of-ten magnitude exactly: 66.6 => 2,
+  # 3.5 => 1, 0.0234 => -1. szDecimals is stored on the ticker as base_decimals.
+  def adjusted_price(ticker:, price:, method: :floor)
+    price = price.to_d
+    return price if price.zero?
+
+    max_decimals = SPOT_MAX_DECIMALS - ticker.base_decimals.to_i
+    sig_decimals = SIGNIFICANT_FIGURES - price.exponent
+    decimals     = sig_decimals.clamp(0, max_decimals) # >=10k clamps to 0 dp; integers are always valid
+    price.public_send(method, decimals).to_d           # to_d: floor/ceil/round(0) returns an Integer
   end
 
   def get_order(order_id:)

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -86,7 +86,7 @@ class Ticker < ApplicationRecord
   end
 
   def adjusted_price(price:, method: :floor)
-    price.send(method, price_decimals)
+    exchange.adjusted_price(ticker: self, price:, method:)
   end
 
   private

--- a/test/models/exchanges/hyperliquid_test.rb
+++ b/test/models/exchanges/hyperliquid_test.rb
@@ -202,4 +202,106 @@ class Exchanges::HyperliquidTest < ActiveSupport::TestCase
     assert_kind_of Numeric, captured[:size]
     assert_kind_of Numeric, captured[:limit_px]
   end
+
+  # == adjusted_price: Hyperliquid tick size (<=5 significant figures, <= 8 - szDecimals decimals) ==
+
+  test 'adjusted_price floors a >$10 price to 5 significant figures (HYPE regression)' do
+    ticker = hyperliquid_ticker(base_decimals: 2)
+    input = BigDecimal('66.60455877')
+    price = ticker.adjusted_price(price: input)
+
+    assert_equal BigDecimal('66.604'), price
+    assert price <= input, 'a buy limit must not be rounded up past the requested price'
+    assert_operator significant_figures(price), :<=, 5
+  end
+
+  test 'adjusted_price floors a mid-range price to 5 significant figures' do
+    ticker = hyperliquid_ticker(base_decimals: 1)
+    price = ticker.adjusted_price(price: BigDecimal('3.50882766'))
+
+    assert_equal BigDecimal('3.5088'), price
+    assert_operator significant_figures(price), :<=, 5
+  end
+
+  test 'adjusted_price keeps a sub-$1 price at 5 significant figures' do
+    ticker = hyperliquid_ticker(base_decimals: 0)
+    price = ticker.adjusted_price(price: BigDecimal('0.451865682'))
+
+    assert_equal BigDecimal('0.45186'), price
+    assert_operator significant_figures(price), :<=, 5
+  end
+
+  test 'adjusted_price respects the 8 - szDecimals decimal cap for tiny prices' do
+    ticker = hyperliquid_ticker(base_decimals: 0)
+    price = ticker.adjusted_price(price: BigDecimal('0.0233952813'))
+
+    assert_equal BigDecimal('0.023395'), price
+    assert_operator significant_figures(price), :<=, 5
+    assert_operator price.to_s('F').split('.').last.length, :<=, 8
+  end
+
+  test 'adjusted_price floors a >=$10k price to a valid integer price' do
+    ticker = hyperliquid_ticker(base_decimals: 2)
+    price = ticker.adjusted_price(price: BigDecimal('123456.78'))
+
+    assert_equal BigDecimal('123456'), price
+    assert_kind_of BigDecimal, price # integers are always valid on Hyperliquid
+  end
+
+  test 'adjusted_price with :ceil never returns below the requested price' do
+    ticker = hyperliquid_ticker(base_decimals: 2)
+    input = BigDecimal('66.60455877')
+    price = ticker.adjusted_price(price: input, method: :ceil)
+
+    assert_equal BigDecimal('66.605'), price
+    assert_operator price, :>=, input
+  end
+
+  test 'adjusted_price handles magnitude rollover at the 5-sig-fig boundary' do
+    ticker = hyperliquid_ticker(base_decimals: 2)
+    price = ticker.adjusted_price(price: BigDecimal('9999.999'), method: :round)
+
+    assert_equal BigDecimal('10000'), price
+  end
+
+  test 'adjusted_price returns zero unchanged' do
+    ticker = hyperliquid_ticker(base_decimals: 2)
+    assert_equal BigDecimal('0'), ticker.adjusted_price(price: BigDecimal('0'))
+  end
+
+  test 'limit_buy sends a tick-size-valid price to the exchange (<=5 sig figs)' do
+    @exchange.set_client
+    client = @exchange.send(:client)
+    ticker = hyperliquid_ticker(base_decimals: 2)
+
+    captured = {}
+    client.define_singleton_method(:order) do |**kwargs|
+      captured.merge!(kwargs)
+      Result::Success.new('status' => 'ok',
+                          'response' => { 'data' => { 'statuses' => [{ 'resting' => { 'oid' => 123 } }] } })
+    end
+
+    @exchange.stubs(:dry_run?).returns(false)
+    result = @exchange.limit_buy(ticker: ticker, amount: BigDecimal('0.15'),
+                                 amount_type: :base, price: BigDecimal('66.60455877'))
+
+    assert result.success?, "expected success, got #{result.inspect}"
+    assert_equal BigDecimal('66.604'), captured[:limit_px].to_d
+    assert_operator significant_figures(captured[:limit_px]), :<=, 5
+  end
+
+  private
+
+  def hyperliquid_ticker(base_decimals:)
+    usdc = create(:asset, external_id: 'usdc', symbol: 'USDC', name: 'USDC')
+    hype = create(:asset, external_id: 'hype', symbol: 'HYPE', name: 'Hype')
+    create(:ticker, exchange: @exchange, base_asset: hype, quote_asset: usdc,
+                    ticker: 'HYPE/USDC', base: 'HYPE', quote: 'USDC',
+                    base_decimals: base_decimals, price_decimals: 5)
+  end
+
+  def significant_figures(value)
+    digits = value.to_d.abs.to_s('F').delete('.').sub(/^0+/, '').sub(/0+$/, '')
+    [digits.length, 1].max
+  end
 end

--- a/test/models/ticker_test.rb
+++ b/test/models/ticker_test.rb
@@ -138,4 +138,16 @@ class TickerTest < ActiveSupport::TestCase
 
     assert_not @ticker.priced?(:last)
   end
+
+  # == #adjusted_price : delegates to the exchange; default = fixed decimal places ==
+
+  test 'adjusted_price floors to price_decimals for a non-Hyperliquid exchange' do
+    @ticker.update!(price_decimals: 2)
+    assert_equal BigDecimal('100.12'), @ticker.adjusted_price(price: BigDecimal('100.12999'))
+  end
+
+  test 'adjusted_price honors the :round method for a non-Hyperliquid exchange' do
+    @ticker.update!(price_decimals: 2)
+    assert_equal BigDecimal('100.13'), @ticker.adjusted_price(price: BigDecimal('100.12999'), method: :round)
+  end
 end


### PR DESCRIPTION
## Problem

> Hyperliquid order failed: Price must be divisible by tick size. asset=10105

Hyperliquid's price rule is **≤5 significant figures** and, for spot, **≤(8 − szDecimals) decimal places**. We formatted prices as **5 decimal places**: `Ticker#adjusted_price` did `price.floor(price_decimals)` with `price_decimals: 5`. For any spot token priced ≥ ~$1 that yields 6–7 significant figures, so **every order was rejected** (e.g. HYPE ~$66 → `66.60455`). Sub-$1 tokens passed by coincidence.

The `hyperliquid-rb` gem only applies the correct 5-sig-fig formula in `market_open`/`market_close`, not the plain `order` path Honeymaker uses — so price formatting is the caller's job.

## Fix

Make price formatting exchange-aware:
- `Ticker#adjusted_price` delegates to `Exchange#adjusted_price` (default behaviour unchanged for all other exchanges).
- `Exchanges::Hyperliquid` overrides it: convert the significant-figure rule into a decimal-place count via `BigDecimal#exponent`, preserving `floor`/`ceil`/`round` direction (a buy limit set below market is never rounded up). Prices ≥$10k clamp to an integer (always valid on Hyperliquid).

This corrects all three price paths (order-setters, real `set_limit_order`, dry-run) at one chokepoint.

## Tests

- Tests written first (red → green): HYPE regression, mid/sub-$1/tiny prices, ≥$10k→integer, `9999.999` boundary rollover, directional `:ceil`/`:round`, end-to-end `limit_buy`, plus a non-Hyperliquid no-regression check.
- Full suite green.

Codex-reviewed (plan + code).