### PR TITLE
Fix Hyperliquid limit orders mis-sizing quote amounts

### DIFF
--- a/app/models/exchanges/hyperliquid.rb
+++ b/app/models/exchanges/hyperliquid.rb
@@ -353,11 +353,17 @@ class Exchanges::Hyperliquid < Exchange
   def set_limit_order(ticker:, amount:, amount_type:, side:, price:)
     amount = ticker.adjusted_amount(amount:, amount_type:)
     price = ticker.adjusted_price(price:)
+    return Result::Failure.new('Hyperliquid order failed: limit price must be positive') unless price.positive?
+
+    # Hyperliquid's order API takes size in BASE units, so a quote amount must be
+    # converted at the limit price (mirrors Exchanges::Alpaca#set_limit_order).
+    size = amount_type == :quote ? (amount.to_d / price.to_d) : amount.to_d
+    size = ticker.adjusted_amount(amount: size, amount_type: :base)
 
     result = client.order(
       coin: ticker.ticker,
       is_buy: side == :buy,
-      size: amount.to_d,
+      size: size.to_d,
       limit_px: price.to_d
     )
     return result if result.failure?

--- a/test/models/exchanges/hyperliquid_test.rb
+++ b/test/models/exchanges/hyperliquid_test.rb
@@ -290,7 +290,81 @@ class Exchanges::HyperliquidTest < ActiveSupport::TestCase
     assert_operator significant_figures(captured[:limit_px]), :<=, 5
   end
 
+  # == set_limit_order: amount_type conversion (Hyperliquid's order API takes size in base units) ==
+
+  test 'limit_buy converts a quote amount to base size before ordering' do
+    @exchange.set_client
+    client = @exchange.send(:client)
+    ticker = hyperliquid_ticker(base_decimals: 4)
+
+    captured = capture_order(client)
+    @exchange.stubs(:dry_run?).returns(false)
+
+    # Buy 10 USDC worth at a 50 limit => 0.2 HYPE of size, not 10.
+    result = @exchange.limit_buy(ticker: ticker, amount: BigDecimal('10'),
+                                 amount_type: :quote, price: BigDecimal('50'))
+
+    assert result.success?, "expected success, got #{result.inspect}"
+    assert_equal BigDecimal('0.2'), captured[:size].to_d
+    assert_equal BigDecimal('50'), captured[:limit_px].to_d
+  end
+
+  test 'limit_sell converts a quote amount to base size before ordering' do
+    @exchange.set_client
+    client = @exchange.send(:client)
+    ticker = hyperliquid_ticker(base_decimals: 4)
+
+    captured = capture_order(client)
+    @exchange.stubs(:dry_run?).returns(false)
+
+    result = @exchange.limit_sell(ticker: ticker, amount: BigDecimal('10'),
+                                  amount_type: :quote, price: BigDecimal('50'))
+
+    assert result.success?, "expected success, got #{result.inspect}"
+    assert_equal BigDecimal('0.2'), captured[:size].to_d
+  end
+
+  test 'limit_buy sends a base amount as size unchanged' do
+    @exchange.set_client
+    client = @exchange.send(:client)
+    ticker = hyperliquid_ticker(base_decimals: 4)
+
+    captured = capture_order(client)
+    @exchange.stubs(:dry_run?).returns(false)
+
+    result = @exchange.limit_buy(ticker: ticker, amount: BigDecimal('0.15'),
+                                 amount_type: :base, price: BigDecimal('50'))
+
+    assert result.success?, "expected success, got #{result.inspect}"
+    assert_equal BigDecimal('0.15'), captured[:size].to_d
+  end
+
+  test 'set_limit_order fails gracefully when the adjusted price is not positive' do
+    @exchange.set_client
+    client = @exchange.send(:client)
+    ticker = hyperliquid_ticker(base_decimals: 4)
+
+    client.define_singleton_method(:order) { |**_kwargs| raise 'order should not be called' }
+    @exchange.stubs(:dry_run?).returns(false)
+
+    result = @exchange.limit_buy(ticker: ticker, amount: BigDecimal('10'),
+                                 amount_type: :quote, price: BigDecimal('0'))
+
+    assert result.failure?
+    assert_match(/price/i, result.errors.join)
+  end
+
   private
+
+  def capture_order(client)
+    captured = {}
+    client.define_singleton_method(:order) do |**kwargs|
+      captured.merge!(kwargs)
+      Result::Success.new('status' => 'ok',
+                          'response' => { 'data' => { 'statuses' => [{ 'resting' => { 'oid' => 123 } }] } })
+    end
+    captured
+  end
 
   def hyperliquid_ticker(base_decimals:)
     usdc = create(:asset, external_id: 'usdc', symbol: 'USDC', name: 'USDC')


### PR DESCRIPTION
Stacked on #161 (review/merge that first; this PR auto-retargets to `main` once #161 merges).

## Problem

`Exchanges::Hyperliquid#set_limit_order` sent `amount` as the order `size` (base units) **regardless of `amount_type`**. Hyperliquid's order API only takes size in base units.

- **Bot orders are unaffected** — `minimum_amount_logic == :base`, so the order-setter converts the user's quote budget to base before ordering.
- The **direct REST/MCP** `limit_buy` defaults to `amount_type: :quote` (`bot_api/orders/limit_buy.rb:41`), so a quote amount was mis-sent as a base size.

Same class as the tracked Bitget/Kucoin/Bybit quote-as-base bug.

## Fix

Convert quote→base at the limit price before ordering, mirroring `Exchanges::Alpaca#set_limit_order`. Also guard a non-positive adjusted price (explicit zero, or a tiny price that floors to zero under tick-size rules) so a quote order returns a `Result::Failure` instead of raising `ZeroDivisionError`.

## Tests

Tests written first (red → green): quote→base for buy and sell, base amount unchanged (no regression), and graceful failure on a non-positive price. Full suite green.

Codex-reviewed (the zero-price guard was added in response to a Codex finding).
