### PR TITLE
IBKR: prescriptive portal steps and a way out of a dead activation

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -23,6 +23,13 @@ class ApiKey < ApplicationRecord
   # :pending_activation is IBKR-specific — the consumer key is registered but IBKR hasn't
   # activated it yet (24h–2wk). Appended last so existing integer values are unchanged.
   enum :status, %i[pending_validation correct incorrect pending_activation]
+
+  # IBKR activates a self-service consumer key on its weekend server restart. A registration still
+  # pending after this long has sat through several of those restarts and is never going to
+  # activate — it is invalid, or it was replaced by a later save in IBKR's portal (which keeps only
+  # one registration per login). Past this point the wizard stops promising activation and offers a
+  # way out instead.
+  ACTIVATION_DEADLINE = 14.days
   enum :key_type, %i[trading withdrawal]
 
   scope :for_bot, lambda { |user_id, exchange_id, key_type = 'trading'|
@@ -31,6 +38,13 @@ class ApiKey < ApplicationRecord
 
   def get_validity
     exchange.get_api_key_validity(api_key: self)
+  end
+
+  # Anchored on updated_at, which on a key awaiting IBKR activation moves only when the user
+  # submits credentials: Ibkr::CheckActivationJob writes only on success, and the nightly balance
+  # and transaction syncs both scope to :correct, so nothing else touches the row.
+  def activation_stalled?
+    pending_activation? && updated_at <= ACTIVATION_DEADLINE.ago
   end
 
   def validate_credentials!(params)
@@ -45,7 +59,11 @@ class ApiKey < ApplicationRecord
     result = get_validity
     if result.success? && result.data == :pending_activation
       # IBKR: keys registered, awaiting IBKR activation — persist so the parked bot can start later.
-      update!(status: :pending_activation)
+      # updated_at is bumped explicitly even when nothing else changed: activation_stalled? reads it
+      # as "when the user last submitted credentials", and resubmitting IDENTICAL credentials — the
+      # real fix for a registration redone on a working portal host — dirties nothing, so Active
+      # Record would issue no UPDATE and the already-expired clock would survive the retry.
+      update!(status: :pending_activation, updated_at: Time.current)
     elsif result.success? && result.data
       update!(status: :correct)
     elsif result.success?

--- a/app/models/exchanges/ibkr.rb
+++ b/app/models/exchanges/ibkr.rb
@@ -14,17 +14,26 @@ class Exchanges::Ibkr < Exchange
   FIELD_BID = '84'.freeze
   FIELD_ASK = '86'.freeze
 
-  # First-party OAuth self-service portals. The regional EU hosts (.ie/.lu/.com.hu) reject the
-  # PUT the portal SPA uses to upload the key files (Akamai edge 501 "Unsupported Request";
-  # PUT /ibcust.proxy/v1/ibcust/oauth/consumer_info — verified 2026-07-05 from US + EU IPs), so
-  # consumer registration can never complete there. Only PUT-capable hosts may be linked. The
-  # SPA is byte-identical on every host and entity-agnostic — the account's entity comes from
-  # the login, not the domain — so one European portal plus the US fallback covers everyone.
+  # First-party OAuth self-service portals, listed in RELIABILITY order — deliberately not a
+  # regional choice. The portal SPA uploads the key files with a
+  # PUT /ibcust.proxy/v1/ibcust/oauth/consumer_info, and the Akamai edge fronting IBKR's regional
+  # web hosts (.com, .ie, .lu, .com.hu, .com.au) rejects every PUT with 501 "Unsupported Request":
+  # saving the key NAME works there, uploading the FILES never does, so consumer registration can
+  # never complete (verified from US + EU IPs).
+  #
+  # ndcdyn goes first because it bypasses that CDN edge entirely. IBKR's own login can redirect a
+  # user off www.interactivebrokers.co.uk onto a blocked regional host mid-flow, and the upload
+  # then 501s on a link we called good — which is why the wizard tells users to check the address
+  # bar AFTER logging in rather than to trust the link they clicked.
+  #
+  # The SPA is byte-identical on every host and entity-agnostic — the account's entity comes from
+  # the login, not the domain — so either host serves everyone. `url` is derived from `host` so the
+  # wizard copy, which names the two hosts, cannot drift away from the links themselves.
   OAUTH_PORTAL_PATH = '/oauth/?loginType=1&action=OAUTH&clt=0&RL=1#/configuration'.freeze
   OAUTH_PORTALS = {
-    'europe' => { name: 'IBKR portal (Europe)', url: "https://www.interactivebrokers.co.uk#{OAUTH_PORTAL_PATH}" },
-    'us' => { name: 'IBKR portal (US, fallback)', url: "https://ndcdyn.interactivebrokers.com#{OAUTH_PORTAL_PATH}" }
-  }.freeze
+    'recommended' => { host: 'ndcdyn.interactivebrokers.com' },
+    'alternative' => { host: 'www.interactivebrokers.co.uk' }
+  }.transform_values { |portal| portal.merge(url: "https://#{portal[:host]}#{OAUTH_PORTAL_PATH}").freeze }.freeze
 
   include Exchange::Dryable
 

--- a/app/views/settings/ibkr_connections/_single_key_warning.html.erb
+++ b/app/views/settings/ibkr_connections/_single_key_warning.html.erb
@@ -1,0 +1,4 @@
+<%# IBKR stores one consumer-key registration per login, so re-saving the portal form silently
+    replaces whatever is registered. Shown on the instruction step (so users don't register twice)
+    and in the connected state (where re-saving would break a working connection). %>
+<p class="text-danger"><%= t('settings.ibkr.single_key_warning') %></p>

--- a/app/views/settings/ibkr_connections/_wizard.html.erb
+++ b/app/views/settings/ibkr_connections/_wizard.html.erb
@@ -10,8 +10,22 @@
 
   <% elsif api_key.correct? %>
     <p class="text-success"><%= t('settings.ibkr.connected') %></p>
+    <%= render 'settings/ibkr_connections/single_key_warning' %>
     <%= button_to t('settings.ibkr.disconnect'), settings_ibkr_connect_path,
                   method: :delete, class: 'button button--danger' %>
+
+  <%# A registration IBKR never activated is indistinguishable from a slow one until the wait gets
+      absurd — past ApiKey::ACTIVATION_DEADLINE it is dead, so stop promising activation and make
+      starting over the obvious move. Nothing is auto-deleted; both exits stay the user's call. %>
+  <% elsif api_key.activation_stalled? %>
+    <p class="text-danger">
+      <%= t('settings.ibkr.activation_failed',
+            duration: distance_of_time_in_words(api_key.updated_at, Time.current)) %>
+    </p>
+    <p><%= t('settings.ibkr.activation_failed_fix') %></p>
+    <%= button_to t('settings.ibkr.start_over'), settings_ibkr_connect_path,
+                  method: :delete, class: 'button button--success button--large' %>
+    <%= render 'settings/ibkr_connections/credentials_form' %>
 
   <% elsif api_key.pending_activation? %>
     <p><%= t('settings.ibkr.activation_pending') %></p>
@@ -35,17 +49,29 @@
                     settings_download_ibkr_connection_path(artifact: 'dhparam'), data: { turbo: false }, class: 'button' %>
       </li>
 
+      <%# Every setup failure we have had to unpick happened inside IBKR's portal: a login redirect
+          onto a host whose edge 501s the key-file upload, or a second save wiping the first
+          registration. Hence a prescriptive sequence, with the allowed hosts read straight off
+          OAUTH_PORTALS so the instructions and the links cannot disagree. %>
       <li>
         <p><%= t('settings.ibkr.portal_intro') %></p>
+        <ol>
+          <li><%= t('settings.ibkr.portal_step_private_window') %></li>
+          <li>
+            <%= t('settings.ibkr.portal_step_check_address',
+                  recommended: Exchanges::Ibkr::OAUTH_PORTALS['recommended'][:host],
+                  alternative: Exchanges::Ibkr::OAUTH_PORTALS['alternative'][:host]) %>
+          </li>
+          <li><%= t('settings.ibkr.portal_step_register') %></li>
+        </ol>
         <%= link_to t('settings.ibkr.open_portal'),
-                    Exchanges::Ibkr::OAUTH_PORTALS['europe'][:url],
+                    Exchanges::Ibkr::OAUTH_PORTALS['recommended'][:url],
+                    target: '_blank', rel: 'noopener', class: 'button button--success' %>
+        <%= link_to t('settings.ibkr.open_portal_alternative'),
+                    Exchanges::Ibkr::OAUTH_PORTALS['alternative'][:url],
                     target: '_blank', rel: 'noopener', class: 'button' %>
-        <p>
-          <%= t('settings.ibkr.portal_fallback') %>
-          <%= link_to t('settings.ibkr.open_portal_fallback'),
-                      Exchanges::Ibkr::OAUTH_PORTALS['us'][:url],
-                      target: '_blank', rel: 'noopener' %>
-        </p>
+        <p class="form__info"><%= t('settings.ibkr.portal_error_501') %></p>
+        <%= render 'settings/ibkr_connections/single_key_warning' %>
       </li>
 
       <li>

--- a/app/views/settings/widgets/_ibkr.html.erb
+++ b/app/views/settings/widgets/_ibkr.html.erb
@@ -7,6 +7,10 @@
       <%= t('settings.ibkr.widget_title') %>:
       <% if ibkr_key&.correct? %>
         <span class="text-success">CONNECTED</span>
+      <%# Checked before pending_activation? — past the deadline the wizard has given up on this
+          registration, and a PENDING badge here would contradict it. %>
+      <% elsif ibkr_key&.activation_stalled? %>
+        <span class="text-danger">ACTION NEEDED</span>
       <% elsif ibkr_key&.pending_activation? %>
         <span class="text-warning">PENDING</span>
       <% else %>

--- a/config/locales/ibkr.en.yml
+++ b/config/locales/ibkr.en.yml
@@ -1,3 +1,10 @@
+# Two rules for this file:
+#   1. Anything IBKR itself puts on screen — field labels (Consumer Key), error text, hostnames —
+#      is quoted VERBATIM and must stay verbatim in any future locale. We are telling users what to
+#      look for in IBKR's interface; a translated label is a label they cannot find. Translate the
+#      sentence around it, never the thing being pointed at.
+#   2. Use typographic apostrophes (’) and quotes (“ ”). Straight ones are HTML-escaped to &#39;
+#      / &quot; in the rendered page.
 en:
     settings:
         ibkr:
@@ -7,16 +14,22 @@ en:
             connected: 'Interactive Brokers is connected.'
             disconnect: 'Disconnect'
             activation_pending: 'Credentials submitted — IBKR is activating your consumer key (this can take 24h–2 weeks). Your bot starts automatically once it is active.'
+            activation_failed: 'IBKR has not activated your consumer key in %{duration}. A registration that has waited this long will not activate — it is most likely invalid, or it was replaced when the portal form was saved again.'
+            activation_failed_fix: 'Start over to generate fresh keys and register once more. If you have just re-registered in the portal, re-enter your credentials below instead.'
             start_over: 'Start over'
             generating: 'Generating your secure keys… this can take a moment and will refresh automatically.'
             download_intro: 'Download these three files — you will upload them when you register a consumer at IBKR:'
             signing_key: 'Signing public key'
             encryption_key: 'Encryption public key'
             dh_param: 'Diffie-Hellman params'
-            portal_intro: 'Open the IBKR OAuth self-service portal and register a consumer — pick a consumer key of exactly 9 letters (A–Z):'
+            portal_intro: 'Register your key on IBKR’s OAuth self-service portal — pick a consumer key of exactly 9 letters (A–Z). Follow these three steps in order; this is where almost every failed setup goes wrong:'
+            portal_step_private_window: 'Open the portal in a private/incognito window, and log in to the IBKR account you want to connect — not another account you happen to have.'
+            portal_step_check_address: 'Once you are logged in, look at your browser’s address bar. It has to read %{recommended} or %{alternative}. IBKR sometimes redirects you elsewhere while you log in — if the address is any other interactivebrokers.* domain, close the tab and open the other portal link below. The file upload only works on those two.'
+            portal_step_register: 'Set your Consumer Key, upload the three files you downloaded above, then come back here and paste the credentials IBKR gives you.'
             open_portal: 'Open IBKR portal'
-            portal_fallback: 'If the key upload fails there, use the US portal instead — your account works on both:'
-            open_portal_fallback: 'Open US portal (fallback)'
+            open_portal_alternative: 'Open the other portal'
+            portal_error_501: '“Failed to set Key - failed to put consumer info” (error 501) means you are on an IBKR server that blocks the upload — not that you did anything wrong. Go back and use the other portal link.'
+            single_key_warning: 'IBKR keeps only ONE key registration per login. Saving the portal form again later replaces it and breaks the connection you already have — once you are connected, do not reopen the portal.'
             paste_intro: 'Paste the Consumer Key, Access Token and Access Token Secret IBKR gives you:'
             consumer_key: 'Consumer key'
             consumer_key_hint: 'The 9-letter key (A–Z) you chose and saved in the portal’s Consumer Key box — it stays saved on your IBKR account and is shown at the top of the portal’s Configuration page.'

--- a/test/controllers/settings/ibkr_connections_controller_test.rb
+++ b/test/controllers/settings/ibkr_connections_controller_test.rb
@@ -87,10 +87,95 @@ class Settings::IbkrConnectionsControllerTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', portal[:url]
     end
     assert_select 'select[data-ibkr-connect-target]', count: 0 # entity picker removed
-    # The regional hosts 501 the portal's key-upload PUT — they must never reappear.
-    refute_includes response.body, 'interactivebrokers.ie'
-    refute_includes response.body, 'interactivebrokers.lu'
-    refute_includes response.body, 'interactivebrokers.com.hu'
+    # Every host whose edge 501s the key-upload PUT. The bare IBKR host keeps its `www.` prefix
+    # so the assertion cannot trip over the recommended ndcdyn.interactivebrokers.com.
+    %w[www.interactivebrokers.com interactivebrokers.ie interactivebrokers.lu
+       interactivebrokers.com.hu interactivebrokers.com.au].each do |blocked|
+      refute_includes response.body, blocked, "#{blocked} rejects the key upload — never link it"
+    end
+  end
+
+  # --- step 2: the portal instructions ---------------------------------------------------------
+  # Every failed setup we have had to unpick went wrong inside IBKR's portal, not in our app, so
+  # this step has to be prescriptive rather than descriptive.
+
+  test 'portal step offers both portals with the CDN-bypassing one first' do
+    key_with_artifacts
+    get settings_ibkr_connect_path
+
+    portal_links = css_select('a').filter_map { |a| a['href'] }.select { |href| href.include?('action=OAUTH') }
+    assert_equal [Exchanges::Ibkr::OAUTH_PORTALS['recommended'][:url],
+                  Exchanges::Ibkr::OAUTH_PORTALS['alternative'][:url]],
+                 portal_links,
+                 'the reliable portal must be the first thing the user reaches for'
+  end
+
+  test 'portal step demands a private window and an address-bar check naming both allowed hosts' do
+    key_with_artifacts
+    get settings_ibkr_connect_path
+
+    assert_includes response.body, I18n.t('settings.ibkr.portal_step_private_window')
+    # Hosts come from the constant, so the copy cannot drift away from the links.
+    assert_includes response.body,
+                    I18n.t('settings.ibkr.portal_step_check_address',
+                           recommended: Exchanges::Ibkr::OAUTH_PORTALS['recommended'][:host],
+                           alternative: Exchanges::Ibkr::OAUTH_PORTALS['alternative'][:host])
+    assert_includes response.body, I18n.t('settings.ibkr.portal_step_register')
+  end
+
+  test 'portal step explains the 501 upload failure as a wrong-host problem' do
+    key_with_artifacts
+    get settings_ibkr_connect_path
+
+    assert_includes response.body, I18n.t('settings.ibkr.portal_error_501')
+  end
+
+  test 'portal step warns that IBKR keeps only one key registration per login' do
+    key_with_artifacts
+    get settings_ibkr_connect_path
+
+    assert_includes response.body, I18n.t('settings.ibkr.single_key_warning')
+  end
+
+  test 'the connected state repeats the single-key warning — that is where re-saving bites' do
+    key_with_artifacts.update!(status: :correct)
+    get settings_ibkr_connect_path
+
+    assert_includes response.body, I18n.t('settings.ibkr.connected')
+    assert_includes response.body, I18n.t('settings.ibkr.single_key_warning')
+  end
+
+  # --- the activation wait, and its dead end ---------------------------------------------------
+
+  test 'a fresh pending_activation still shows the activation wait' do
+    key = key_with_artifacts
+    key.update!(status: :pending_activation)
+    key.update_column(:updated_at, 3.days.ago)
+
+    get settings_ibkr_connect_path
+
+    assert_includes response.body, I18n.t('settings.ibkr.activation_pending')
+    refute_includes response.body, I18n.t('settings.ibkr.activation_failed_fix')
+  end
+
+  test 'a pending_activation past the deadline fails out and points at the way forward' do
+    freeze_time do
+      key = key_with_artifacts
+      key.update!(status: :pending_activation)
+      submitted_at = ApiKey::ACTIVATION_DEADLINE.ago - 6.days
+      key.update_column(:updated_at, submitted_at)
+
+      get settings_ibkr_connect_path
+
+      waited = ActionController::Base.helpers.distance_of_time_in_words(submitted_at, Time.current)
+      assert_includes response.body, I18n.t('settings.ibkr.activation_failed', duration: waited)
+      assert_includes response.body, I18n.t('settings.ibkr.activation_failed_fix')
+      refute_includes response.body, I18n.t('settings.ibkr.activation_pending'),
+                      'promising an activation that is never coming is the bug being fixed'
+      # Both exits stay reachable: start over (the fix) and re-enter credentials (the retry).
+      assert_includes response.body, I18n.t('settings.ibkr.start_over')
+      assert_select 'form[action=?]', settings_activate_ibkr_connection_path
+    end
   end
 
   test 'download serves the PUBLIC signing/encryption keys and the dhparam, never the private key' do

--- a/test/integration/settings_ibkr_widget_test.rb
+++ b/test/integration/settings_ibkr_widget_test.rb
@@ -35,4 +35,25 @@ class SettingsIbkrWidgetTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'a[href=?]', settings_ibkr_connect_path
   end
+
+  test 'widget shows PENDING while IBKR is still activating the consumer key' do
+    @user.api_keys.create!(exchange: @ibkr, key_type: :trading, status: :pending_activation)
+
+    get settings_connect_path
+    assert_response :success
+    assert_includes response.body, '>PENDING<'
+    refute_includes response.body, 'ACTION NEEDED'
+  end
+
+  test 'widget flags a registration that never activated, matching the wizard' do
+    key = @user.api_keys.create!(exchange: @ibkr, key_type: :trading, status: :pending_activation)
+    key.update_column(:updated_at, ApiKey::ACTIVATION_DEADLINE.ago - 1.day)
+
+    get settings_connect_path
+    assert_response :success
+    # Leaving this on PENDING would contradict the wizard, which by now says the registration
+    # is dead and the user has to start over.
+    assert_includes response.body, 'ACTION NEEDED'
+    refute_includes response.body, '>PENDING<'
+  end
 end

--- a/test/jobs/ibkr/check_activation_job_test.rb
+++ b/test/jobs/ibkr/check_activation_job_test.rb
@@ -16,12 +16,18 @@ class Ibkr::CheckActivationJobTest < ActiveSupport::TestCase
     assert_predicate @api_key.reload, :correct?
   end
 
-  test 'leaves a still-not-activated key pending' do
+  test 'leaves a still-not-activated key pending, without resetting its clock' do
     Clients::Ibkr.any_instance.stubs(:accounts).returns(Result::Failure.new('not authenticated'))
+    submitted_at = 20.days.ago
+    @api_key.update_column(:updated_at, submitted_at)
 
     Ibkr::CheckActivationJob.new.perform
 
     assert_predicate @api_key.reload, :pending_activation?
+    # The wizard reads updated_at as "when the user last submitted credentials" and fails the
+    # connection out once it is older than ApiKey::ACTIVATION_DEADLINE. A failed poll every 6h
+    # must never touch it, or a dead registration would look fresh forever.
+    assert_in_delta submitted_at, @api_key.updated_at, 1.second
   end
 
   test 'only considers IBKR keys (ignores other exchanges)' do

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -78,4 +78,59 @@ class ApiKeyTest < ActiveSupport::TestCase
 
     api_key.stop_dependent_bots!
   end
+
+  # --- IBKR activation staleness -------------------------------------------------------------
+  # IBKR activates a self-service consumer key on its weekend server restart. A registration still
+  # pending after ACTIVATION_DEADLINE has sat through several restarts and will never activate, so
+  # the wizard has to stop promising an activation that is not coming. Time is frozen throughout:
+  # updated_at is only second-precise, and a boundary assertion against an independently evaluated
+  # Time.current is flaky.
+
+  test 'activation_stalled? only applies to keys actually awaiting IBKR activation' do
+    freeze_time do
+      exchange = create(:binance_exchange) # one exchange, one key per user — both are unique-scoped
+      %i[pending_validation correct incorrect].each do |status|
+        api_key = create(:api_key, exchange: exchange, user: create(:user), status: status)
+        api_key.update_column(:updated_at, 1.year.ago)
+
+        refute_predicate api_key, :activation_stalled?, "#{status} is not an activation wait"
+      end
+    end
+  end
+
+  test 'activation_stalled? flips once the registration waits past the deadline' do
+    freeze_time do
+      api_key = create(:api_key, status: :pending_activation)
+
+      api_key.update_column(:updated_at, ApiKey::ACTIVATION_DEADLINE.ago + 1.day)
+      refute_predicate api_key, :activation_stalled?, 'still inside the activation window'
+
+      api_key.update_column(:updated_at, ApiKey::ACTIVATION_DEADLINE.ago)
+      assert_predicate api_key, :activation_stalled?, 'exactly at the deadline counts as stalled'
+
+      api_key.update_column(:updated_at, ApiKey::ACTIVATION_DEADLINE.ago - 1.day)
+      assert_predicate api_key, :activation_stalled?
+    end
+  end
+
+  test 'resubmitting identical credentials restarts the IBKR activation clock' do
+    freeze_time do
+      api_key = create(:api_key, exchange: create(:ibkr_exchange), status: :pending_activation,
+                                 raw_key: 'CONSUMERAB', raw_secret: 'SECRET789')
+      api_key.update!(access_token: 'TOKEN456')
+      api_key.update_column(:updated_at, 30.days.ago)
+      assert_predicate api_key, :activation_stalled?
+      api_key.exchange.stubs(:get_api_key_validity).returns(Result::Success.new(:pending_activation))
+
+      # Exactly the values the row already holds — the real fix path is re-registering the SAME
+      # consumer key on a working portal host and resubmitting. Nothing is dirty, so without an
+      # explicit timestamp bump Active Record issues no UPDATE and the expired clock survives the
+      # retry, leaving the wizard shouting "failed" at a user who just did the right thing.
+      api_key.validate_credentials!(key: 'CONSUMERAB', secret: 'SECRET789', access_token: 'TOKEN456')
+
+      assert_predicate api_key.reload, :pending_activation?
+      assert_in_delta Time.current, api_key.updated_at, 1.second
+      refute_predicate api_key, :activation_stalled?
+    end
+  end
 end

--- a/test/models/exchanges/ibkr_oauth_portals_test.rb
+++ b/test/models/exchanges/ibkr_oauth_portals_test.rb
@@ -1,29 +1,47 @@
 require 'test_helper'
 
-# §10: the connect wizard links to IBKR's OAuth self-service portal. The regional EU hosts
-# (.ie/.lu/.com.hu) reject the PUT the portal SPA uses to upload the key files (Akamai 501
-# "Unsupported Request"), so consumer registration can never complete there — verified
-# 2026-07-05 from both US and EU vantage points. Only PUT-capable hosts may be linked; the
-# SPA is identical on all hosts and the account's entity comes from the login, not the domain.
+# §10: the connect wizard links to IBKR's OAuth self-service portal. The Akamai edge fronting
+# IBKR's regional web hosts rejects the PUT the portal SPA uses to upload the key files (501
+# "Unsupported Request") — saving the key NAME works there, uploading the FILES never does, so
+# consumer registration can never complete. Only ndcdyn.interactivebrokers.com and
+# www.interactivebrokers.co.uk accept it, and ndcdyn goes first because it bypasses the CDN edge
+# entirely (an IBKR login can redirect a user off the other host mid-flow onto a blocked one).
+# The SPA is identical on every host and the account's entity comes from the login, not the
+# domain — the list is a reliability order, never a regional choice.
 class Exchanges::IbkrOauthPortalsTest < ActiveSupport::TestCase
   EXPECTED_HOSTS = {
-    'europe' => 'www.interactivebrokers.co.uk',
-    'us' => 'ndcdyn.interactivebrokers.com'
+    'recommended' => 'ndcdyn.interactivebrokers.com',
+    'alternative' => 'www.interactivebrokers.co.uk'
   }.freeze
 
-  PUT_BLOCKED_HOSTS = %w[interactivebrokers.ie interactivebrokers.lu interactivebrokers.com.hu].freeze
+  # Hosts whose edge 501s the key-upload PUT. The bare IBKR host carries its `www.` prefix so the
+  # entry cannot accidentally match ndcdyn.interactivebrokers.com.
+  PUT_BLOCKED_HOSTS = %w[
+    www.interactivebrokers.com
+    interactivebrokers.ie
+    interactivebrokers.lu
+    interactivebrokers.com.hu
+    interactivebrokers.com.au
+  ].freeze
 
-  test 'offers exactly the Europe portal plus the US fallback' do
+  test 'offers exactly the two PUT-capable portals' do
     assert_equal EXPECTED_HOSTS.keys.sort, Exchanges::Ibkr::OAUTH_PORTALS.keys.map(&:to_s).sort
   end
 
-  test 'each portal uses a PUT-capable host and lands on the configuration screen' do
-    EXPECTED_HOSTS.each do |key, host|
-      url = Exchanges::Ibkr::OAUTH_PORTALS[key][:url]
+  test 'lists the CDN-bypassing host first — IBKR login can redirect off the other one' do
+    assert_equal EXPECTED_HOSTS.keys, Exchanges::Ibkr::OAUTH_PORTALS.keys.map(&:to_s)
+    assert_equal 'ndcdyn.interactivebrokers.com', Exchanges::Ibkr::OAUTH_PORTALS.values.first[:host]
+  end
 
-      assert_includes url, "https://#{host}/", "#{key} must point at #{host}"
-      assert_includes url, 'action=OAUTH', "#{key} must request the OAuth flow"
-      assert_includes url, '#/configuration', "#{key} must land on the configuration screen"
+  test 'each portal exposes its host and derives its url from it' do
+    EXPECTED_HOSTS.each do |key, host|
+      portal = Exchanges::Ibkr::OAUTH_PORTALS[key]
+
+      assert_equal host, portal[:host], "#{key} must point at #{host}"
+      assert_equal "https://#{host}#{Exchanges::Ibkr::OAUTH_PORTAL_PATH}", portal[:url],
+                   "#{key} url must be derived from its host, so link and instructions cannot drift"
+      assert_includes portal[:url], 'action=OAUTH', "#{key} must request the OAuth flow"
+      assert_includes portal[:url], '#/configuration', "#{key} must land on the configuration screen"
     end
   end
 


### PR DESCRIPTION
Every IBKR setup that has needed hands-on unpicking failed inside IBKR's own portal, not in our app. Two distinct failure modes, both now handled in the connect wizard, plus an exit from registrations IBKR never activates.

## Wrong host

The Akamai edge fronting IBKR's regional web hosts (`.com`, `.ie`, `.lu`, `.com.hu`, `.com.au`) rejects the `PUT /ibcust.proxy/v1/ibcust/oauth/consumer_info` the portal SPA uses to upload the key files with `501 Unsupported Request`. Saving the key **name** works there; uploading the **files** never does — so registration can never complete, and the failure looks like user error.

- `OAUTH_PORTALS` is now keyed by reliability (`recommended` / `alternative`), not region. The SPA is byte-identical on every host and the account's entity comes from the login, so the regional framing was always wrong.
- `ndcdyn.interactivebrokers.com` goes first because it bypasses that CDN edge entirely. IBKR's login can redirect a user off `www.interactivebrokers.co.uk` mid-flow onto a blocked host, which is why the instructions say to check the address bar **after** logging in rather than to trust the link they clicked.
- Each portal `url` is derived from its `host`, so the wizard copy (which names both hosts) cannot drift away from the links themselves.
- The portal step is now a prescriptive 3-step list: private window → address-bar check → register. The 501 error text is quoted verbatim and explained as a wrong-host problem, not a mistake.

## Second registration wipes the first

IBKR keeps exactly one consumer-key registration per login, so re-saving the portal form silently replaces whatever is there. Warned on the instruction step (so users don't register twice) and again in the connected state, where re-saving would break a working connection.

## Dead activations

IBKR activates a self-service consumer key on its weekend server restart. A registration still pending past `ApiKey::ACTIVATION_DEADLINE` (14 days) has sat through several of those and is never going to activate — it is invalid, or it was replaced by a later save.

- `ApiKey#activation_stalled?` gates a new wizard state that stops promising activation and offers both exits: start over, or re-enter credentials after re-registering. Nothing is auto-deleted.
- The settings widget shows `ACTION NEEDED` (checked before `pending_activation?`) so it can't contradict the wizard with a `PENDING` badge.
- The clock is `updated_at`, which on a pending key moves only when the user submits credentials — `Ibkr::CheckActivationJob` writes on success only, and the nightly syncs scope to `:correct`.
- `validate_credentials!` bumps `updated_at` explicitly on the pending-activation branch. Resubmitting **identical** credentials is the real fix path after re-registering on a working host, and it dirties nothing — Active Record would issue no `UPDATE`, leaving the expired clock in place and the wizard shouting "failed" at a user who just did the right thing.

## Tests

Full suite green: 2681 runs, 9318 assertions, 0 failures. Rubocop clean.

New coverage: portal ordering and host/url derivation, the blocked-host denylist (with `www.` prefixes so it can't trip over `ndcdyn`), all three portal instruction steps, the 501 explanation, the single-key warning in both places it appears, fresh-vs-stalled `pending_activation` in wizard and widget, `activation_stalled?` boundaries and status scoping, the identical-credentials clock restart, and a regression guard that a failed activation poll never resets the clock.