### PR TITLE
Harden the sign-in, second-factor and password-reset paths

### DIFF
--- a/app/controllers/bots/dca_indexes/setup_coingeckos_controller.rb
+++ b/app/controllers/bots/dca_indexes/setup_coingeckos_controller.rb
@@ -1,5 +1,8 @@
 class Bots::DcaIndexes::SetupCoingeckosController < ApplicationController
+  include AdminOnly
+
   before_action :authenticate_user!
+  before_action :require_admin!, only: :create
 
   def new
     # Skip to pick index if market data is already configured

--- a/app/controllers/concerns/admin_only.rb
+++ b/app/controllers/concerns/admin_only.rb
@@ -1,0 +1,12 @@
+# Instance-wide configuration (market data provider, API keys shared by every user,
+# email settings) must only be writable by the admin. Controllers that expose such a
+# write include this and list the actions.
+module AdminOnly
+  extend ActiveSupport::Concern
+
+  private
+
+  def require_admin!
+    head(:forbidden) unless current_user&.admin?
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,4 +1,6 @@
 class SettingsController < ApplicationController
+  include AdminOnly
+
   before_action :authenticate_user!
   before_action :require_admin!, only: %i[
     update_registration
@@ -411,10 +413,6 @@ class SettingsController < ApplicationController
   end
 
   private
-
-  def require_admin!
-    head(:forbidden) unless current_user.admin?
-  end
 
   def validate_coingecko_api_key(api_key)
     return false if api_key.blank?

--- a/app/controllers/tracker_controller.rb
+++ b/app/controllers/tracker_controller.rb
@@ -1,5 +1,8 @@
 class TrackerController < ApplicationController
+  include AdminOnly
+
   before_action :authenticate_user!
+  before_action :require_admin!, only: :setup_coingecko
 
   def index
     exchange_ids = (current_user.api_keys.pluck(:exchange_id) +

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -37,9 +37,15 @@ class Users::PasswordsController < Devise::PasswordsController
     # Expired or unknown token: hand straight to Devise, which owns that error copy.
     return super unless user.reset_password_period_valid?
 
+    user.unlock_access_if_lock_expired!
+
     # A locked account must not get further OTP attempts here, or the lock only guards
-    # the sign-in path while password reset keeps accepting guesses.
-    return abort_update_for(user, t('errors.messages.bad_2fa_code')) if user.access_locked?
+    # the sign-in path while password reset keeps accepting guesses. Say that it is the
+    # lock: forgetting the password is how an account gets locked in the first place, and
+    # resetting it is what the app then tells the user to do, so blaming the authenticator
+    # here sends them off to re-pair a device that is working fine. This is the only
+    # surface on the reset path that can tell them the truth.
+    return abort_update_for(user, t('devise.failure.locked')) if user.access_locked?
 
     return abort_update_for(user, t('errors.messages.empty_two_fa_token')) if submitted_otp.blank?
 
@@ -79,7 +85,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def ensure_valid_token
     original_token = params[:reset_password_token]
-    reset_password_token = Devise.token_generator.digest(self, :reset_password_token, original_token)
+    reset_password_token = Devise.token_generator.digest(User, :reset_password_token, original_token)
     user = User.find_or_initialize_with_errors([:reset_password_token], reset_password_token:)
     @user_email = user.email
     @two_fa_enabled = user.otp_module_enabled?

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -21,13 +21,49 @@ class Users::PasswordsController < Devise::PasswordsController
     set_edit_instance_variables
   end
 
+  # The OTP must be verified BEFORE Devise runs, because Devise's block hook fires
+  # after reset_password_by_token has already saved the record and cleared the token
+  # in the same UPDATE — checking there changes the password and then complains.
+  #
+  # Ordering within this method matters too. Users::VerifyOtp CONSUMES the code (it
+  # advances last_otp_at for replay protection), so anything Devise would reject
+  # anyway — an expired token, a password that fails policy, a mismatched
+  # confirmation — has to be rejected FIRST. Otherwise a user who fat-fingers their
+  # new password burns a TOTP code and has to wait for the next one.
   def update
-    super do
-      if resource&.otp_module_enabled?
-        return abort_update(:otp_code_token, t('errors.messages.empty_two_fa_token')) unless params[:user][:otp_code_token].present?
-        return abort_update(:otp_code_token, t('errors.messages.bad_2fa_code')) unless Users::VerifyOtp.call(resource, params[:user][:otp_code_token])
-      end
+    user = user_from_reset_token
+    return super unless user&.otp_module_enabled?
+
+    # Expired or unknown token: hand straight to Devise, which owns that error copy.
+    return super unless user.reset_password_period_valid?
+
+    # A locked account must not get further OTP attempts here, or the lock only guards
+    # the sign-in path while password reset keeps accepting guesses.
+    return abort_update_for(user, t('errors.messages.bad_2fa_code')) if user.access_locked?
+
+    return abort_update_for(user, t('errors.messages.empty_two_fa_token')) if submitted_otp.blank?
+
+    # Would Devise reject the new password anyway? Check before spending the code.
+    #
+    # CRITICAL: reload afterwards. Users::VerifyOtp calls `user.update(last_otp_at:)`,
+    # and `update` on a dirty record persists EVERY dirty attribute — so leaving the
+    # assigned password on the object would save the new password here, behind Devise's
+    # back and before the token is validated. `reload` discards the in-memory
+    # assignment; `super` re-reads the record from the token and does the real write.
+    user.password = params.dig(:user, :password)
+    user.password_confirmation = params.dig(:user, :password_confirmation)
+    password_acceptable = user.valid?
+    user.reload
+    return super unless password_acceptable
+
+    unless Users::VerifyOtp.call(user, submitted_otp)
+      user.increment_failed_attempts
+      user.lock_access! if user.failed_attempts >= Devise.maximum_attempts
+      return abort_update_for(user, t('errors.messages.bad_2fa_code'))
     end
+
+    user.reset_failed_attempts! if user.failed_attempts.to_i.positive?
+    super
   end
 
   private
@@ -59,12 +95,27 @@ class Users::PasswordsController < Devise::PasswordsController
     @password_minimum_length = Devise.password_length.min
   end
 
-  def abort_update(field, error_message)
-    resource.errors.add(field, error_message)
-    resource.reset_password_token = resource_params[:reset_password_token]
+  def submitted_otp
+    params.dig(:user, :otp_code_token)
+  end
+
+  # Mirrors Devise's own lookup: the class is the receiver of the digest, matching
+  # what reset_password_by_token will do with the same raw token.
+  def user_from_reset_token
+    raw = params.dig(:user, :reset_password_token)
+    return nil if raw.blank?
+
+    digest = Devise.token_generator.digest(User, :reset_password_token, raw)
+    User.find_by(reset_password_token: digest)
+  end
+
+  def abort_update_for(user, error_message)
+    self.resource = user
+    resource.errors.add(:otp_code_token, error_message)
+    resource.reset_password_token = params.dig(:user, :reset_password_token)
     @user_email = resource.email
     @two_fa_enabled = resource.otp_module_enabled?
     set_edit_instance_variables
-    respond_with_navigational(resource) { render :edit }
+    respond_with_navigational(resource) { render :edit, status: :unprocessable_entity }
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -45,6 +45,11 @@ class Users::PasswordsController < Devise::PasswordsController
 
     # Would Devise reject the new password anyway? Check before spending the code.
     #
+    # Presence has to be tested separately: a request that omits the password key leaves
+    # `password_required?` false on a persisted record, so `valid?` alone returns true and
+    # the code gets burned on a request Devise rejects as blank a moment later.
+    return super if params.dig(:user, :password).blank?
+
     # CRITICAL: reload afterwards. Users::VerifyOtp calls `user.update(last_otp_at:)`,
     # and `update` on a dirty record persists EVERY dirty attribute — so leaving the
     # assigned password on the object would save the new password here, behind Devise's

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  # The pending window is short so an abandoned half-sign-in cannot be resumed days
+  # later from a stolen cookie. It is NOT the attempt bound — the session is
+  # client-side (:cookie_store), so the bound lives on the user row via :lockable.
+  PENDING_TTL = 5.minutes
+
+  # Devise turns params authentication on in a prepended callback, so the first
+  # `user_signed_in?` later in the filter chain authenticates the submitted credentials
+  # outright. That is a real sign-in, and Devise's :lockable hook clears the failure
+  # counter on it — both before #create gets to decide whether a second factor is owed.
+  # Turn it on inside #create instead, at the point where a sign-in is actually intended.
+  skip_before_action :allow_params_authentication!, only: :create
+
   def new
     super do
       set_new_instance_variables
@@ -12,34 +24,38 @@ class Users::SessionsController < Devise::SessionsController
     user = User.find_for_authentication(email: params[:user][:email])
 
     if user&.otp_module_enabled? && user.valid_password?(params[:user][:password])
+      # A locked account must not get a second-factor prompt at all — otherwise the
+      # lock only guards the password stage and TOTP guessing continues through it.
+      return redirect_to(new_user_session_path, alert: t('devise.failure.locked')) if user.access_locked?
+
       sign_out(resource)
       session[:pending_user_id] = user.id
       session[:remember_me] = params[:user][:remember_me]
+      session[:pending_started_at] = Time.current.to_i
       redirect_to verify_two_factor_path
     else
+      allow_params_authentication!
       self.resource = warden.authenticate!(auth_options)
       continue_sign_in(resource_name, resource)
     end
   end
 
   def verify_two_factor
-    return unless session[:pending_user_id]
+    return abandon_pending_sign_in unless pending_sign_in_live?
 
     self.resource = User.find(session[:pending_user_id])
+    return abandon_pending_sign_in if resource.access_locked?
     return render :two_factor unless params.dig(:user, :otp_code_token).present?
 
     if Users::VerifyOtp.call(resource, params[:user][:otp_code_token])
-
       # manually set the remember_me cookie because it's unset after sign_out()
       custom_remember_me(resource) if session[:remember_me] == '1'
 
-      session.delete(:pending_user_id)
-      session.delete(:remember_me)
-
+      resource.reset_failed_attempts!
+      clear_pending_sign_in
       continue_sign_in(resource_name, resource)
     else
-      flash.now[:alert] = t('errors.messages.bad_2fa_code')
-      render :two_factor, status: :unprocessable_entity
+      register_failed_otp_attempt
     end
   end
 
@@ -50,6 +66,39 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
+
+  def pending_sign_in_live?
+    return false if session[:pending_user_id].blank?
+
+    started_at = session[:pending_started_at].to_i
+    started_at.positive? && Time.current.to_i - started_at < PENDING_TTL.to_i
+  end
+
+  # Devise's :lockable state is persisted on the user row, so it survives the attacker
+  # replaying an older session cookie or restarting the login flow — neither of which a
+  # session-held counter would survive.
+  def register_failed_otp_attempt
+    resource.increment_failed_attempts
+
+    if resource.failed_attempts >= Devise.maximum_attempts
+      resource.lock_access!
+      return abandon_pending_sign_in
+    end
+
+    flash.now[:alert] = t('errors.messages.bad_2fa_code')
+    render :two_factor, status: :unprocessable_entity
+  end
+
+  def clear_pending_sign_in
+    session.delete(:pending_user_id)
+    session.delete(:remember_me)
+    session.delete(:pending_started_at)
+  end
+
+  def abandon_pending_sign_in
+    clear_pending_sign_in
+    redirect_to new_user_session_path, alert: t('errors.messages.bad_2fa_code')
+  end
 
   def continue_sign_in(resource_name, resource)
     sign_in(resource_name, resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -72,9 +72,15 @@ class Users::SessionsController < Devise::SessionsController
   # the account's own preference. Carry it on the redirect, or the second-factor page
   # renders in the default locale for everyone. Nil for the default locale, so the path
   # stays unprefixed exactly as `default_url_options` would leave it.
+  # The route's locale segment is regex-constrained on incoming requests only, never on
+  # generation, so a value the app no longer ships — a column left behind by a change to
+  # available_locales, say — would build a path that 404s on arrival and dead-end every
+  # login for that account. Anything unroutable falls back to the unprefixed path.
   def pending_sign_in_locale(user)
     locale = params[:locale].presence || user.locale.presence
-    locale unless locale == I18n.default_locale.to_s
+    return if locale.blank? || locale == I18n.default_locale.to_s
+
+    locale if I18n.available_locales.any? { |available| available.to_s == locale }
   end
 
   def pending_sign_in_live?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,7 +32,7 @@ class Users::SessionsController < Devise::SessionsController
       session[:pending_user_id] = user.id
       session[:remember_me] = params[:user][:remember_me]
       session[:pending_started_at] = Time.current.to_i
-      redirect_to verify_two_factor_path
+      redirect_to verify_two_factor_path(locale: pending_sign_in_locale(user))
     else
       allow_params_authentication!
       self.resource = warden.authenticate!(auth_options)
@@ -66,6 +66,16 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
+
+  # `switch_locale` is an around_action, so it picks the locale before #create has decided
+  # anything — and nobody is signed in at that point, so `default_url_options` cannot see
+  # the account's own preference. Carry it on the redirect, or the second-factor page
+  # renders in the default locale for everyone. Nil for the default locale, so the path
+  # stays unprefixed exactly as `default_url_options` would leave it.
+  def pending_sign_in_locale(user)
+    locale = params[:locale].presence || user.locale.presence
+    locale unless locale == I18n.default_locale.to_s
+  end
 
   def pending_sign_in_live?
     return false if session[:pending_user_id].blank?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -46,7 +46,14 @@ class Users::SessionsController < Devise::SessionsController
     self.resource = User.find(session[:pending_user_id])
     resource.unlock_access_if_lock_expired!
     return abandon_pending_sign_in if resource.access_locked?
-    return render :two_factor unless params.dig(:user, :otp_code_token).present?
+
+    # The route takes GET as well as POST so that #create can redirect here to render the
+    # form (the form itself is method: :post). Only the POST is throttled, and GET is exempt
+    # from CSRF, so verifying on GET would let a cross-site top-level navigation — which
+    # SameSite=Lax allows — spend a victim's attempts unthrottled, and would leave the code
+    # in browser history and in the Referer. Discriminate here rather than in the throttle,
+    # which closes the CSRF-free path as well.
+    return render :two_factor unless request.post? && params.dig(:user, :otp_code_token).present?
 
     if Users::VerifyOtp.call(resource, params[:user][:otp_code_token])
       # manually set the remember_me cookie because it's unset after sign_out()

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -44,6 +44,7 @@ class Users::SessionsController < Devise::SessionsController
     return abandon_pending_sign_in unless pending_sign_in_live?
 
     self.resource = User.find(session[:pending_user_id])
+    resource.unlock_access_if_lock_expired!
     return abandon_pending_sign_in if resource.access_locked?
     return render :two_factor unless params.dig(:user, :otp_code_token).present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,18 @@ class User < ApplicationRecord
   validate :password_complexity, if: -> { password.present? }
   validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name), allow_nil: true }
 
+  # Devise hands the whole attempt budget back the moment a lock ages out:
+  # Devise::Models::Lockable#valid_for_authentication? opens with `unlock_access! if
+  # lock_expired?` before it counts anything. Credential checks that never reach Warden —
+  # the second factor on sign-in, the OTP on password reset — have to run it themselves, or
+  # an expired lock keeps a spent counter and the next single wrong code re-locks the
+  # account for another unlock_in, indefinitely, on an instance with no operator to
+  # unlock anyone. `lock_expired?` is protected, hence the spelling: access_locked? is
+  # `locked_at present && !lock_expired?`, so this predicate is exactly lock_expired?.
+  def unlock_access_if_lock_expired!
+    unlock_access! if locked_at? && !access_locked?
+  end
+
   def global_pnl(use_cache: true)
     invested_by_currency = Hash.new(0)
     value_by_currency = Hash.new(0)

--- a/app/views/bots/dca_indexes/setup_coingeckos/new.html.erb
+++ b/app/views/bots/dca_indexes/setup_coingeckos/new.html.erb
@@ -3,23 +3,27 @@
     <%= render partial: 'bots/dca_indexes/new_step_progress_bar', locals: { current_step: :coingecko } %>
 
     <div class="widget widget--centered" style="margin: 0 1rem; padding: 4rem">
-      <p><%= t('setup.api_configuration') %></p>
+      <% if current_user.admin? %>
+        <p><%= t('setup.api_configuration') %></p>
 
-      <%= form_with url: bots_dca_indexes_setup_coingecko_path,
-                    method: :post,
-                    class: "setting-form",
-                    data: {
-                      controller: "form--html5-validations form--label-animations",
-                      turbo_frame: 'modal_content'
-                    } do |f| %>
-        <div class="form__row form__row--input">
-          <%= tag.input class: "form__input", type: "text", name: "api_key", required: true, id: "api_key", autocomplete: "off" %>
-          <%= label_tag :api_key, t('setup.coingecko_api_key'), class: "form__label" %>
-        </div>
+        <%= form_with url: bots_dca_indexes_setup_coingecko_path,
+                      method: :post,
+                      class: "setting-form",
+                      data: {
+                        controller: "form--html5-validations form--label-animations",
+                        turbo_frame: 'modal_content'
+                      } do |f| %>
+          <div class="form__row form__row--input">
+            <%= tag.input class: "form__input", type: "text", name: "api_key", required: true, id: "api_key", autocomplete: "off" %>
+            <%= label_tag :api_key, t('setup.coingecko_api_key'), class: "form__label" %>
+          </div>
 
-        <%= t('setup.coingecko_api_key_hint_html').html_safe %>
+          <%= t('setup.coingecko_api_key_hint_html').html_safe %>
 
-        <%= f.submit t('setup.continue'), class: "button button--success" %>
+          <%= f.submit t('setup.continue'), class: "button button--success" %>
+        <% end %>
+      <% else %>
+        <p><%= t('setup.coingecko_admin_only') %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/tracker/setup_coingecko.html.erb
+++ b/app/views/tracker/setup_coingecko.html.erb
@@ -4,24 +4,31 @@
       <%= render partial: 'svg/24x24_close' %>
     <% end %>
     <div class="set-api">
-      <div class="set-api__form">
-        <h2 class="set-api__header"><%= t('setup.coingecko_api_key') %></h2>
-        <p><%= t('tracker.setup_coingecko_html') %></p>
-        <%= form_with url: setup_coingecko_tracker_path, method: :post, data: {
-          controller: 'form--label-animations form--html5-validations',
-          action: 'turbo:submit-end->modal--base#submitEnd'
-        }, class: 'form' do |f| %>
-          <div class="form__row form__row--input">
-            <%= tag.input class: 'form__input form__input--large', type: 'text', name: 'api_key', required: true, id: 'api_key', autocomplete: 'off', autofocus: true, data: { controller: 'autofocus' } %>
-            <%= label_tag :api_key, t('setup.coingecko_api_key'), class: 'form__label' %>
-          </div>
-          <%= f.submit t('button.connect'), class: 'button button--success button--large', data: { turbo_stream: true, turbo_submits_with: t('bot.setup.validating') } %>
-        <% end %>
-      </div>
-      <div class="set-api__instructions">
-        <h2 class="set-api__header"><%= t('setup.coingecko_api_key') %></h2>
-        <%= t('setup.coingecko_api_key_hint_html').html_safe %>
-      </div>
+      <% if current_user.admin? %>
+        <div class="set-api__form">
+          <h2 class="set-api__header"><%= t('setup.coingecko_api_key') %></h2>
+          <p><%= t('tracker.setup_coingecko_html') %></p>
+          <%= form_with url: setup_coingecko_tracker_path, method: :post, data: {
+            controller: 'form--label-animations form--html5-validations',
+            action: 'turbo:submit-end->modal--base#submitEnd'
+          }, class: 'form' do |f| %>
+            <div class="form__row form__row--input">
+              <%= tag.input class: 'form__input form__input--large', type: 'text', name: 'api_key', required: true, id: 'api_key', autocomplete: 'off', autofocus: true, data: { controller: 'autofocus' } %>
+              <%= label_tag :api_key, t('setup.coingecko_api_key'), class: 'form__label' %>
+            </div>
+            <%= f.submit t('button.connect'), class: 'button button--success button--large', data: { turbo_stream: true, turbo_submits_with: t('bot.setup.validating') } %>
+          <% end %>
+        </div>
+        <div class="set-api__instructions">
+          <h2 class="set-api__header"><%= t('setup.coingecko_api_key') %></h2>
+          <%= t('setup.coingecko_api_key_hint_html').html_safe %>
+        </div>
+      <% else %>
+        <div class="set-api__form">
+          <h2 class="set-api__header"><%= t('setup.coingecko_api_key') %></h2>
+          <p><%= t('setup.coingecko_admin_only') %></p>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  # ApplicationMailer#default_url_options replaces the inherited one rather than merging
+  # it, so the line above never reaches a mailer view's *_url helper. Development and
+  # production supply the host through the route set; test needs the same, or any test
+  # that delivers a mail containing a link dies with "Missing host to link to!".
+  routes.default_url_options = { host: 'localhost', port: 3000 }
 
   config.dry_run = true
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,7 +7,7 @@
 module RackAttackPaths
   # Read the CONFIGURED locales, not I18n.available_locales. The i18n railtie applies
   # config.i18n.available_locales after config/initializers have run, so at this point
-  # I18n reports whatever the gems on the load path have registered — 74 locales, and not
+  # I18n reports whatever the gems on the load path have registered — 75 locales, and not
   # a superset of ours: it omits :el, which routes fine and would have gone unthrottled.
   # routes.rb constrains the :locale segment with the same list, because by the time routes
   # load I18n has caught up.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,15 +5,28 @@
 # sign_in: 'login') and an optional .format suffix that Rails routes identically.
 # Matching a literal string missed both.
 module RackAttackPaths
-  LOCALE = "(?:/(?:#{I18n.available_locales.join('|')}))?"
+  # Read the CONFIGURED locales, not I18n.available_locales. The i18n railtie applies
+  # config.i18n.available_locales after config/initializers have run, so at this point
+  # I18n reports whatever the gems on the load path have registered — 74 locales, and not
+  # a superset of ours: it omits :el, which routes fine and would have gone unthrottled.
+  # routes.rb constrains the :locale segment with the same list, because by the time routes
+  # load I18n has caught up.
+  # Regexp.union escapes whatever the list contains: a locale carrying a regex
+  # metacharacter would otherwise silently rewrite every pattern in this file.
+  LOCALE = "(?:/#{Regexp.union(Rails.application.config.i18n.available_locales.map(&:to_s))})?"
   # Rails routes any non-slash suffix as :format — .json, .json-api, .v2+json — so the
   # character class must not be narrowed to [A-Za-z0-9] or the suffix becomes a bypass.
   FORMAT = '(?:\.[^/]+)?'
 
   # Rails routes these to the SAME action, verified with recognize_path against this app:
   #   /login  /login/  //login  /oauth/register/  /oauth//register  /en/login/
-  # An anchored regex over the raw req.path matches only the first of each pair, so
-  # every throttle below would be bypassed by adding one slash. Normalize first.
+  # An anchored regex matches only the first of each pair, so a raw path would let one
+  # extra slash bypass every throttle below. rack-attack already closes that itself —
+  # Rack::Attack#call rewrites PATH_INFO through PathNormalizer (which on Rails is
+  # ActionDispatch::Journey::Router::Utils.normalize_path) before any throttle block runs,
+  # squeezing repeated slashes and stripping the trailing one. This is defense in depth:
+  # it keeps the patterns correct against the raw path if that ever stops being true, and
+  # it is what the slash tests in test/middleware/rack_attack_test.rb pin.
   def self.normalize(path)
     normalized = path.to_s.squeeze('/')
     normalized.length > 1 ? normalized.chomp('/') : normalized
@@ -34,14 +47,28 @@ module RackAttackPaths
 end
 
 # NOTE ON THE THROTTLE KEY. `action_dispatch.remote_ip` applies Rails' trusted-proxy
-# handling, which strips RFC1918/loopback hops — enough for kamal-proxy on the same
-# host. It does NOT by itself make Cloudflare's edge address resolve to the real
-# client: that needs Cloudflare's published ranges in
-# `config.action_dispatch.trusted_proxies`, which this app does not set. Until it does,
-# hosted traffic arriving through the CDN may share one throttle key. Still strictly
-# better than the previous `req.ip`.
+# handling, which strips RFC1918/loopback hops — enough for kamal-proxy on the same host.
+# It does NOT by itself make Cloudflare's edge address resolve to the real client: that
+# needs Cloudflare's published ranges in `config.action_dispatch.trusted_proxies`, which
+# this app does not set. Until it does, hosted traffic arriving through the CDN may share
+# one throttle key.
 def (Rack::Attack).client_ip(req)
   req.env['action_dispatch.remote_ip']&.to_s.presence || req.ip
+end
+
+# rack-attack's default response is a bare "Retry later". These rules now match paths this
+# app actually routes, so that reaches a human on the sign-in or password-reset page. Give
+# them a sentence — the same one whatever tripped, because a response that named the rule
+# would tell an attacker which of their guesses was worth repeating.
+Rack::Attack.throttled_responder = lambda do |request|
+  match_data = request.env['rack.attack.match_data'] || {}
+  period = match_data[:period]
+  epoch_time = match_data[:epoch_time]
+
+  headers = { 'content-type' => 'text/plain; charset=utf-8' }
+  headers['retry-after'] = (period - (epoch_time % period)).to_s if period && epoch_time
+
+  [429, headers, ["#{I18n.t('errors.throttled')}\n"]]
 end
 
 Rack::Attack.throttle('oauth/register', limit: 5, period: 60) do |req|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -46,12 +46,23 @@ module RackAttackPaths
   AUTHORIZE   = %r{\A/oauth/authorize#{FORMAT}\z}
 end
 
-# NOTE ON THE THROTTLE KEY. `action_dispatch.remote_ip` applies Rails' trusted-proxy
-# handling, which strips RFC1918/loopback hops — enough for kamal-proxy on the same host.
-# It does NOT by itself make Cloudflare's edge address resolve to the real client: that
-# needs Cloudflare's published ranges in `config.action_dispatch.trusted_proxies`, which
-# this app does not set. Until it does, hosted traffic arriving through the CDN may share
-# one throttle key.
+# NOTE ON THE THROTTLE KEY. `action_dispatch.remote_ip` prefers a forwarded-for hop over
+# REMOTE_ADDR, using Rails' trusted-proxy list — loopback, private and link-local ranges by
+# default — to decide which hops to discard. This app configures no `trusted_proxies`, and
+# that cuts both ways.
+#
+# Coarse: Cloudflare's published ranges are not in the default list, so hosted traffic
+# arriving through the CDN may collapse onto one throttle key.
+#
+# Weak, and the direction that matters more: the key is only as trustworthy as whatever
+# writes the forwarded-for header. On a deployment that publishes the container port
+# straight to the network — how the README documents running this — nothing upstream sets
+# or sanitises that header, so the value keyed on here originates with the client and the
+# per-IP limits can be evaded. Behind a proxy that writes the header itself, the key
+# reflects what that proxy saw.
+#
+# The bound that does not depend on IP attribution at all is the per-account one: sign-in,
+# the second factor and password reset are limited on the user row by :lockable.
 def (Rack::Attack).client_ip(req)
   req.env['action_dispatch.remote_ip']&.to_s.presence || req.ip
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,17 +1,79 @@
 # frozen_string_literal: true
 
+# Paths are matched against the REAL routed paths, which carry an optional locale
+# prefix (routes.rb mounts Devise inside `scope "(:locale)"` with path_names
+# sign_in: 'login') and an optional .format suffix that Rails routes identically.
+# Matching a literal string missed both.
+module RackAttackPaths
+  LOCALE = "(?:/(?:#{I18n.available_locales.join('|')}))?"
+  # Rails routes any non-slash suffix as :format — .json, .json-api, .v2+json — so the
+  # character class must not be narrowed to [A-Za-z0-9] or the suffix becomes a bypass.
+  FORMAT = '(?:\.[^/]+)?'
+
+  # Rails routes these to the SAME action, verified with recognize_path against this app:
+  #   /login  /login/  //login  /oauth/register/  /oauth//register  /en/login/
+  # An anchored regex over the raw req.path matches only the first of each pair, so
+  # every throttle below would be bypassed by adding one slash. Normalize first.
+  def self.normalize(path)
+    normalized = path.to_s.squeeze('/')
+    normalized.length > 1 ? normalized.chomp('/') : normalized
+  end
+
+  def self.build(path)
+    %r{\A#{LOCALE}#{path}#{FORMAT}\z}
+  end
+
+  LOGIN       = build('/login')
+  TWO_FACTOR  = build('/verify_two_factor')
+  PASSWORD    = build('/password')
+  SETUP       = build('/setup')
+  # The OAuth endpoints live outside the locale scope, but still take a format suffix.
+  REGISTER    = %r{\A/oauth/register#{FORMAT}\z}
+  TOKEN       = %r{\A/oauth/token#{FORMAT}\z}
+  AUTHORIZE   = %r{\A/oauth/authorize#{FORMAT}\z}
+end
+
+# NOTE ON THE THROTTLE KEY. `action_dispatch.remote_ip` applies Rails' trusted-proxy
+# handling, which strips RFC1918/loopback hops — enough for kamal-proxy on the same
+# host. It does NOT by itself make Cloudflare's edge address resolve to the real
+# client: that needs Cloudflare's published ranges in
+# `config.action_dispatch.trusted_proxies`, which this app does not set. Until it does,
+# hosted traffic arriving through the CDN may share one throttle key. That is a
+# known, accepted limitation of this task, tracked in Deferred item 8 — it is strictly
+# better than the current `req.ip`, and the per-account Devise lockout (Task 5) is the
+# control that does not depend on IP attribution at all.
+def (Rack::Attack).client_ip(req)
+  req.env['action_dispatch.remote_ip']&.to_s.presence || req.ip
+end
+
 Rack::Attack.throttle('oauth/register', limit: 5, period: 60) do |req|
-  req.ip if req.path == '/oauth/register' && req.post?
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::REGISTER.match?(RackAttackPaths.normalize(req.path))
 end
 
 Rack::Attack.throttle('oauth/token', limit: 20, period: 60) do |req|
-  req.ip if req.path == '/oauth/token' && req.post?
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::TOKEN.match?(RackAttackPaths.normalize(req.path))
 end
 
 Rack::Attack.throttle('oauth/authorize', limit: 10, period: 60) do |req|
-  req.ip if req.path == '/oauth/authorize' && req.get?
+  Rack::Attack.client_ip(req) if req.get? && RackAttackPaths::AUTHORIZE.match?(RackAttackPaths.normalize(req.path))
 end
 
-Rack::Attack.throttle('users/sign_in', limit: 10, period: 60) do |req|
-  req.ip if req.path.end_with?('/users/sign_in') && req.post?
+Rack::Attack.throttle('users/login', limit: 10, period: 60) do |req|
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::LOGIN.match?(RackAttackPaths.normalize(req.path))
+end
+
+Rack::Attack.throttle('users/verify_two_factor', limit: 5, period: 60) do |req|
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::TWO_FACTOR.match?(RackAttackPaths.normalize(req.path))
+end
+
+# POST requests a reset email; PATCH/PUT submits the new password and the OTP. The
+# form is method: :patch, so a POST-only rule would leave the guessable half open.
+Rack::Attack.throttle('users/password', limit: 5, period: 60) do |req|
+  if %w[POST PATCH PUT].include?(req.request_method) && RackAttackPaths::PASSWORD.match?(RackAttackPaths.normalize(req.path))
+    Rack::Attack.client_ip(req)
+  end
+end
+
+Rack::Attack.throttle('setup', limit: 5, period: 60) do |req|
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::SETUP.match?(RackAttackPaths.normalize(req.path))
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -38,10 +38,8 @@ end
 # host. It does NOT by itself make Cloudflare's edge address resolve to the real
 # client: that needs Cloudflare's published ranges in
 # `config.action_dispatch.trusted_proxies`, which this app does not set. Until it does,
-# hosted traffic arriving through the CDN may share one throttle key. That is a
-# known, accepted limitation of this task, tracked in Deferred item 8 — it is strictly
-# better than the current `req.ip`, and the per-account Devise lockout (Task 5) is the
-# control that does not depend on IP attribution at all.
+# hosted traffic arriving through the CDN may share one throttle key. Still strictly
+# better than the previous `req.ip`.
 def (Rack::Attack).client_ip(req)
   req.env['action_dispatch.remote_ip']&.to_s.presence || req.ip
 end

--- a/config/locales/admin_setup.en.yml
+++ b/config/locales/admin_setup.en.yml
@@ -24,4 +24,5 @@ en:
     syncing_message: "Syncing assets…"
     syncing_hint: "It may take a few minutes"
     invalid_coingecko_api_key: "Invalid CoinGecko API key. Please check your key and try again."
+    coingecko_admin_only: "The CoinGecko API key is managed by your instance admin. Ask them to add it under Settings → Connect."
     retry: "Try Again"

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -51,6 +51,7 @@ en:
         unable_to_get_risk_free_rate: 'Unable to get the risk free rate for %{risk_free_rate_name}. Data API server is unreachable.'
         invalid_number_of_allocations: 'Invalid number of allocations'
         invalid_allocation_value: 'Invalid allocation value'
+        throttled: 'Too many requests from this address. Wait a minute and try again.'
         exchange:
             regional_restriction: "%{exchange} restricts trading %{asset} in %{country}"
             transient_nonce: "%{exchange} rejected the request nonce. If you also use this API key in another app, increase its Nonce Window in your %{exchange} API settings."

--- a/test/controllers/market_data_admin_gate_test.rb
+++ b/test/controllers/market_data_admin_gate_test.rb
@@ -50,7 +50,21 @@ class MarketDataAdminGateTest < ActionDispatch::IntegrationTest
     sign_out @member
     sign_in User.find_by(admin: true)
 
-    post '/bots/dca_indexes/setup_coingecko', params: { api_key: 'real-key' }
-    refute_equal 403, response.status
+    assert_changes -> { AppConfig.coingecko_api_key } do
+      post '/bots/dca_indexes/setup_coingecko', params: { api_key: 'real-key' }
+    end
+    assert_response :redirect
+  end
+
+  test 'a non-admin does not see the CoinGecko key form on the tracker export modal' do
+    get '/tracker/export_modal'
+    assert_response :success
+    assert_select 'input[name="api_key"]', count: 0
+  end
+
+  test 'a non-admin does not see the CoinGecko key form on the index wizard' do
+    get '/bots/dca_indexes/setup_coingecko/new'
+    assert_response :success
+    assert_select 'input[name="api_key"]', count: 0
   end
 end

--- a/test/controllers/market_data_admin_gate_test.rb
+++ b/test/controllers/market_data_admin_gate_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+# Market data is instance-wide state. Every write path must be admin-only, or a
+# second household account can repoint the whole instance at their own key.
+class MarketDataAdminGateTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    # The app runs solid_queue in every environment (config/initializers/active_job.rb);
+    # assert_no_enqueued_jobs needs the :test adapter to record enqueues in-memory.
+    @original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
+    create(:user, admin: true, setup_completed: true)
+    @member = create(:user, setup_completed: true)
+    sign_in @member
+
+    # Stub validation to SUCCEED. Without this the controller rejects the key at the
+    # CoinGecko call and returns 422 — the test would go red before the fix and green
+    # after it while never exercising the authorization gap it exists to prove.
+    Coingecko.any_instance.stubs(:get_top_coins_by_market_cap).returns(Result::Success.new([]))
+    Coingecko.any_instance.stubs(:get_coins_list_with_market_data).returns(Result::Success.new([]))
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @original_adapter
+  end
+
+  test 'a non-admin cannot set the CoinGecko key from the tracker' do
+    assert_no_changes -> { AppConfig.coingecko_api_key } do
+      post '/tracker/setup_coingecko', params: { api_key: 'attacker-key' }
+    end
+    assert_response :forbidden
+  end
+
+  test 'a non-admin cannot set the CoinGecko key from the index wizard' do
+    assert_no_changes -> { AppConfig.coingecko_api_key } do
+      post '/bots/dca_indexes/setup_coingecko', params: { api_key: 'attacker-key' }
+    end
+    assert_response :forbidden
+  end
+
+  test 'a non-admin cannot enqueue the seed-and-sync job' do
+    assert_no_enqueued_jobs only: Setup::SeedAndSyncJob do
+      post '/tracker/setup_coingecko', params: { api_key: 'attacker-key' }
+    end
+  end
+
+  test 'an admin still can' do
+    sign_out @member
+    sign_in User.find_by(admin: true)
+
+    post '/bots/dca_indexes/setup_coingecko', params: { api_key: 'real-key' }
+    refute_equal 403, response.status
+  end
+end

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -204,4 +204,46 @@ class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     assert @user.reload.valid_password?('Old!Password1'),
            'the lock must hold on the reset path, not only on sign-in'
   end
+
+  # Forgetting the password is exactly how an account gets locked, and resetting it is what
+  # the app then tells the user to do. Blaming the authenticator for a lock the password
+  # stage applied sends them off to re-pair a device that is working fine.
+  test 'a locked account is told it is locked, not that its code is wrong' do
+    @user.lock_access!
+
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: ROTP::TOTP.new(@user.otp_secret_key).now,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert_response :unprocessable_entity
+    assert @user.reload.valid_password?('Old!Password1'), 'the refusal itself must stand'
+    assert_includes response.body, I18n.t('devise.failure.locked')
+    refute_includes response.body, I18n.t('errors.messages.bad_2fa_code')
+  end
+
+  # Devise's own credential path opens with `unlock_access! if lock_expired?`
+  # (Devise::Models::Lockable#valid_for_authentication?). Nothing runs it for the counter
+  # kept here, so without an explicit reset an expired lock still holds a spent budget and
+  # the first wrong code re-locks the account for another unlock_in.
+  test 'an expired lock restores the whole attempt budget' do
+    Devise.maximum_attempts.times do
+      put '/password', params: {
+        user: { reset_password_token: @raw_token, otp_code_token: '000000',
+                password: 'New!Password1', password_confirmation: 'New!Password1' }
+      }
+    end
+    assert @user.reload.access_locked?
+
+    travel(Devise.unlock_in + 1.minute) do
+      put '/password', params: {
+        user: { reset_password_token: @raw_token, otp_code_token: '000000',
+                password: 'New!Password1', password_confirmation: 'New!Password1' }
+      }
+
+      @user.reload
+      assert_equal 1, @user.failed_attempts, 'the expired lock must clear the counter before this guess'
+      refute @user.access_locked?, 'one wrong code must not re-lock an account whose lock has expired'
+    end
+  end
 end

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -13,7 +13,7 @@ class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
   # instead — pinning the baseline too, in case setup ever stops starting from nil.
   def assert_otp_clock_unchanged(before)
     assert_nil before, 'baseline: the account must start with an unspent OTP clock'
-    assert_nil @user.last_otp_at, 'the code must not have been consumed'
+    assert_nil @user.reload.last_otp_at, 'the code must not have been consumed'
   end
 
   test 'does not change the password when the OTP is missing' do
@@ -58,21 +58,68 @@ class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     assert_nil @user.reset_password_token, 'Devise must consume the token on success'
   end
 
-  # Users::VerifyOtp calls user.update, which persists every dirty attribute. If the
-  # pre-check leaves the assigned password on the object, the password is written
-  # before Devise validates the token — and Devise then rejects the consumed token,
-  # leaving the account changed but the request failed.
+  # Guards the `user.reload` in the pre-check. Users::VerifyOtp calls user.update, which
+  # persists every dirty attribute, so an un-reloaded record carries the assigned password
+  # into that write. Devise's Recoverable then clears the reset token in a before_update
+  # (encrypted_password changed while a token was present), and the token lookup in `super`
+  # no longer matches — the account ends up with the NEW password on a request that reports
+  # failure.
+  #
+  # That combination is only reachable on the path that actually succeeds: on every failing
+  # path Devise's own increment_failed_attempts reloads the record first, which masks the
+  # dirty password. So the assertions below deliberately pair the account state with the
+  # response — either one alone is identical whether or not the reload is present.
   test 'the OTP pre-check does not write the password behind Devise' do
     code = ROTP::TOTP.new(@user.otp_secret_key).now
-    @user.update!(reset_password_sent_at: (Devise.reset_password_within + 1.hour).ago)
 
     put '/password', params: {
       user: { reset_password_token: @raw_token, otp_code_token: code,
               password: 'New!Password1', password_confirmation: 'New!Password1' }
     }
 
-    assert @user.reload.valid_password?('Old!Password1'),
-           'an expired token must leave the password untouched, not saved by VerifyOtp'
+    assert @user.reload.valid_password?('New!Password1'), 'the reset must take effect'
+    assert_response :redirect,
+                    'the account password was changed but the request failed: the pre-check ' \
+                    'wrote it through VerifyOtp, Devise cleared the reset token on that write, ' \
+                    'and the token lookup in `super` then found nothing'
+  end
+
+  # A request that omits the password key leaves password_required? false on a persisted
+  # record, so `valid?` waves it through — and the code would be spent on a request Devise
+  # rejects as blank immediately afterwards.
+  test 'does not consume the OTP when the request carries no password at all' do
+    before_otp_at = @user.last_otp_at
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+
+    put '/password', params: { user: { reset_password_token: @raw_token, otp_code_token: code } }
+
+    assert @user.reload.valid_password?('Old!Password1')
+    assert_otp_clock_unchanged(before_otp_at)
+
+    # The same code must still work once a password is actually supplied.
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+    assert @user.reload.valid_password?('New!Password1')
+  end
+
+  # `update` now intercepts every reset, 2FA or not, so the ordinary path needs a guard of
+  # its own: a regression in user_from_reset_token or the otp_module_enabled? check would
+  # break password reset for the majority of accounts.
+  test 'an account without 2FA can still complete a password reset' do
+    plain_user = create(:user, password: 'Old!Password1', setup_completed: true)
+    token = plain_user.send_reset_password_instructions
+
+    put '/password', params: {
+      user: { reset_password_token: token,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert_response :redirect
+    plain_user.reload
+    assert plain_user.valid_password?('New!Password1')
+    assert_nil plain_user.reset_password_token, 'Devise must consume the token on success'
   end
 
   # Users::VerifyOtp advances last_otp_at, so a code checked before Devise validates

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -1,0 +1,158 @@
+require 'test_helper'
+
+class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true)
+    @user = create(:user, password: 'Old!Password1', setup_completed: true)
+    @user.update!(otp_secret_key: ROTP::Base32.random, otp_module: :enabled)
+    @raw_token = @user.send_reset_password_instructions
+  end
+
+  # A fresh account has never spent a code, so its OTP clock starts nil and only moves
+  # if Users::VerifyOtp ran. assert_equal refuses a nil expectation, so assert both ends
+  # instead — pinning the baseline too, in case setup ever stops starting from nil.
+  def assert_otp_clock_unchanged(before)
+    assert_nil before, 'baseline: the account must start with an unspent OTP clock'
+    assert_nil @user.last_otp_at, 'the code must not have been consumed'
+  end
+
+  test 'does not change the password when the OTP is missing' do
+    put '/password', params: {
+      user: { reset_password_token: @raw_token,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert_response :unprocessable_entity
+    assert @user.reload.valid_password?('Old!Password1'), 'password must be unchanged'
+  end
+
+  test 'does not consume the reset token when the OTP is missing' do
+    put '/password', params: {
+      user: { reset_password_token: @raw_token,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert @user.reload.reset_password_token.present?, 'token must survive a failed attempt'
+  end
+
+  test 'does not change the password when the OTP is wrong' do
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: '000000',
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert_response :unprocessable_entity
+    assert @user.reload.valid_password?('Old!Password1')
+  end
+
+  test 'changes the password with a correct OTP' do
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert_response :redirect, 'a successful reset must redirect, not re-render the form'
+    @user.reload
+    assert @user.valid_password?('New!Password1')
+    assert_nil @user.reset_password_token, 'Devise must consume the token on success'
+  end
+
+  # Users::VerifyOtp calls user.update, which persists every dirty attribute. If the
+  # pre-check leaves the assigned password on the object, the password is written
+  # before Devise validates the token — and Devise then rejects the consumed token,
+  # leaving the account changed but the request failed.
+  test 'the OTP pre-check does not write the password behind Devise' do
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+    @user.update!(reset_password_sent_at: (Devise.reset_password_within + 1.hour).ago)
+
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert @user.reload.valid_password?('Old!Password1'),
+           'an expired token must leave the password untouched, not saved by VerifyOtp'
+  end
+
+  # Users::VerifyOtp advances last_otp_at, so a code checked before Devise validates
+  # would be spent on a request that was going to fail anyway.
+  test 'does not consume the OTP when the new password fails policy' do
+    before_otp_at = @user.last_otp_at
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'short', password_confirmation: 'short' }
+    }
+
+    assert @user.reload.valid_password?('Old!Password1')
+    assert_otp_clock_unchanged(before_otp_at)
+
+    # The same code must still work on a well-formed retry.
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+    assert @user.reload.valid_password?('New!Password1')
+  end
+
+  test 'does not consume the OTP when the confirmation does not match' do
+    before_otp_at = @user.last_otp_at
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'Different!1' }
+    }
+
+    @user.reload
+    assert @user.valid_password?('Old!Password1')
+    # The name of this test is about the OTP, so assert the OTP clock — not just the
+    # password, which would stay green even if VerifyOtp had spent the code.
+    assert_otp_clock_unchanged(before_otp_at)
+    assert_equal 0, @user.failed_attempts, 'a password mismatch is not an OTP failure'
+  end
+
+  test 'an expired reset token is refused without consuming the OTP' do
+    @user.update!(reset_password_sent_at: (Devise.reset_password_within + 1.hour).ago)
+    before_otp_at = @user.last_otp_at
+    code = ROTP::TOTP.new(@user.otp_secret_key).now
+
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: code,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    @user.reload
+    assert @user.valid_password?('Old!Password1')
+    assert_otp_clock_unchanged(before_otp_at)
+  end
+
+  test 'repeated wrong OTPs lock the account' do
+    Devise.maximum_attempts.times do
+      put '/password', params: {
+        user: { reset_password_token: @raw_token, otp_code_token: '000000',
+                password: 'New!Password1', password_confirmation: 'New!Password1' }
+      }
+    end
+
+    assert @user.reload.access_locked?
+    assert @user.valid_password?('Old!Password1')
+  end
+
+  test 'a correct OTP is refused once the account is locked' do
+    Devise.maximum_attempts.times do
+      put '/password', params: {
+        user: { reset_password_token: @raw_token, otp_code_token: '000000',
+                password: 'New!Password1', password_confirmation: 'New!Password1' }
+      }
+    end
+
+    put '/password', params: {
+      user: { reset_password_token: @raw_token, otp_code_token: ROTP::TOTP.new(@user.otp_secret_key).now,
+              password: 'New!Password1', password_confirmation: 'New!Password1' }
+    }
+
+    assert @user.reload.valid_password?('Old!Password1'),
+           'the lock must hold on the reset path, not only on sign-in'
+  end
+end

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
 class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with
+  # its defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the
+  # exact 30-second step it was minted in. On a live clock that step can tick over between
+  # ROTP::TOTP#now and the request carrying the code, failing a test for a reason that has
+  # nothing to do with what it asserts — worst for the tests that carry one code across two
+  # request cycles. Rails restores the clock in after_teardown.
+  #
+  # This does not soften the replay checks below: Users::VerifyOtp records last_otp_at and
+  # verifies with `after:`, and ROTP keeps only timecodes strictly greater than that one, so
+  # a code consumed by an earlier request is still rejected on the retry even at a standstill.
   setup do
+    freeze_time
     create(:user, admin: true, setup_completed: true)
     @user = create(:user, password: 'Old!Password1', setup_completed: true)
     @user.update!(otp_secret_key: ROTP::Base32.random, otp_module: :enabled)

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -45,6 +45,19 @@ class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     assert @user.reload.valid_password?('Old!Password1')
   end
 
+  # This is also the ONLY live guard on the `user.reload` in the pre-check. Users::VerifyOtp
+  # calls user.update, which persists every dirty attribute, so an un-reloaded record carries
+  # the assigned password into that write. Devise's Recoverable then clears the reset token in
+  # a before_update — encrypted_password changed while a token was present — and the token
+  # lookup in `super` no longer matches. The account ends up with the NEW password on a request
+  # that reports failure.
+  #
+  # A separate state-only test for that is not possible, so don't add one: every failing branch
+  # reloads before anything can flush the dirty password (Devise's increment_failed_attempts is
+  # increment_counter plus reload, and Users::VerifyOtp returns false before its update on a bad
+  # code), which leaves the successful reset as the only reachable case — and there the persisted
+  # end state is identical with or without the reload. The response status is the only observable
+  # that separates them, which is why the message below carries the diagnosis.
   test 'changes the password with a correct OTP' do
     code = ROTP::TOTP.new(@user.otp_secret_key).now
     put '/password', params: {
@@ -52,36 +65,14 @@ class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
               password: 'New!Password1', password_confirmation: 'New!Password1' }
     }
 
-    assert_response :redirect, 'a successful reset must redirect, not re-render the form'
+    assert_response :redirect,
+                    'a successful reset must redirect, not re-render the form. A 422 here means ' \
+                    'the new password was written through Users::VerifyOtp before Devise validated ' \
+                    'the token, clearing the token so `super` found nothing: the account has been ' \
+                    'changed while the user is told the request failed'
     @user.reload
     assert @user.valid_password?('New!Password1')
     assert_nil @user.reset_password_token, 'Devise must consume the token on success'
-  end
-
-  # Guards the `user.reload` in the pre-check. Users::VerifyOtp calls user.update, which
-  # persists every dirty attribute, so an un-reloaded record carries the assigned password
-  # into that write. Devise's Recoverable then clears the reset token in a before_update
-  # (encrypted_password changed while a token was present), and the token lookup in `super`
-  # no longer matches — the account ends up with the NEW password on a request that reports
-  # failure.
-  #
-  # That combination is only reachable on the path that actually succeeds: on every failing
-  # path Devise's own increment_failed_attempts reloads the record first, which masks the
-  # dirty password. So the assertions below deliberately pair the account state with the
-  # response — either one alone is identical whether or not the reload is present.
-  test 'the OTP pre-check does not write the password behind Devise' do
-    code = ROTP::TOTP.new(@user.otp_secret_key).now
-
-    put '/password', params: {
-      user: { reset_password_token: @raw_token, otp_code_token: code,
-              password: 'New!Password1', password_confirmation: 'New!Password1' }
-    }
-
-    assert @user.reload.valid_password?('New!Password1'), 'the reset must take effect'
-    assert_response :redirect,
-                    'the account password was changed but the request failed: the pre-check ' \
-                    'wrote it through VerifyOtp, Devise cleared the reset token on that write, ' \
-                    'and the token lookup in `super` then found nothing'
   end
 
   # A request that omits the password key leaves password_required? false on a persisted

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true)
+    @password = 'Sup3rSecret!pass'
+    @user = create(:user, password: @password, setup_completed: true)
+    @user.update!(otp_secret_key: ROTP::Base32.random, otp_module: :enabled)
+  end
+
+  def start_2fa
+    post '/login', params: { user: { email: @user.email, password: @password } }
+  end
+
+  def guess(code = '000000')
+    post '/verify_two_factor', params: { user: { otp_code_token: code } }
+  end
+
+  test 'each wrong code increments the persisted failure counter' do
+    start_2fa
+    3.times { guess }
+
+    assert_equal 3, @user.reload.failed_attempts
+  end
+
+  # The attacker holds the session cookie (:cookie_store), so any in-session counter is
+  # theirs to roll back. Re-starting the flow must NOT restore the attempt budget.
+  test 'restarting the login flow does not reset the attempt budget' do
+    Devise.maximum_attempts.times do
+      start_2fa
+      guess
+    end
+
+    assert @user.reload.access_locked?, 'the account must lock despite a fresh session each time'
+  end
+
+  test 'locks the account after Devise.maximum_attempts wrong codes' do
+    start_2fa
+    Devise.maximum_attempts.times { guess }
+
+    assert @user.reload.access_locked?
+  end
+
+  test 'a correct code is refused once the account is locked' do
+    start_2fa
+    Devise.maximum_attempts.times { guess }
+
+    guess(ROTP::TOTP.new(@user.otp_secret_key).now)
+    assert_redirected_to new_user_session_path
+    refute @controller.send(:user_signed_in?) if @controller.respond_to?(:user_signed_in?, true)
+  end
+
+  test 'a correct code within the budget signs in and clears the counter' do
+    start_2fa
+    2.times { guess }
+
+    guess(ROTP::TOTP.new(@user.otp_secret_key).now)
+
+    assert_response :redirect
+    refute_equal new_user_session_path, response.headers['Location'].to_s.sub(%r{\Ahttps?://[^/]+}, '')
+    assert_equal 0, @user.reload.failed_attempts
+  end
+
+  test 'a locked account cannot even start the 2FA flow' do
+    @user.lock_access!
+    start_2fa
+
+    guess(ROTP::TOTP.new(@user.otp_secret_key).now)
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'the pending state expires' do
+    start_2fa
+    travel(Users::SessionsController::PENDING_TTL + 1.minute) do
+      guess(ROTP::TOTP.new(@user.otp_secret_key).now)
+      assert_redirected_to new_user_session_path
+    end
+  end
+end

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -103,6 +103,19 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     refute_includes response.headers['Location'].to_s, 'locale='
   end
 
+  # The route's locale segment is constrained on the way in but not on generation, so a
+  # locale the app no longer ships would build a path that 404s on arrival — dead-ending
+  # every login for that account, not just one.
+  test 'an unroutable account locale falls back to the unprefixed path' do
+    refute_includes I18n.available_locales.map(&:to_s), 'xx'
+    @user.update!(locale: 'xx')
+    start_2fa
+
+    assert_redirected_to verify_two_factor_path
+    follow_redirect!
+    assert_response :success
+  end
+
   test 'the pending state expires' do
     start_2fa
     travel(Users::SessionsController::PENDING_TTL + 1.minute) do

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -1,7 +1,13 @@
 require 'test_helper'
 
 class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with its
+  # defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the exact
+  # 30-second step it was minted in, and on a live clock that step can tick over between
+  # ROTP::TOTP#now and the request carrying the code. Rails restores the clock in
+  # after_teardown, and the expiry test below still travels explicitly from this baseline.
   setup do
+    freeze_time
     create(:user, admin: true, setup_completed: true)
     @password = 'Sup3rSecret!pass'
     @user = create(:user, password: @password, setup_completed: true)

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -41,6 +41,18 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     assert @user.reload.access_locked?
   end
 
+  # Pins the boundary in both directions: locking one guess early would silently
+  # shrink the budget, and locking one guess late would leave a free attempt.
+  test 'the lock trips on the last attempt of the budget and not before' do
+    start_2fa
+    (Devise.maximum_attempts - 1).times { guess }
+
+    refute @user.reload.access_locked?, 'the budget must not be spent early'
+
+    guess
+    assert @user.reload.access_locked?, 'the last attempt of the budget must lock'
+  end
+
   test 'a correct code is refused once the account is locked' do
     start_2fa
     Devise.maximum_attempts.times { guess }
@@ -65,8 +77,30 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     @user.lock_access!
     start_2fa
 
+    # The absence of a pending id is what proves the password stage refused to hand out
+    # a second-factor prompt. The redirect below alone would also be satisfied by the
+    # gate inside verify_two_factor.
+    assert_nil session[:pending_user_id], 'the password stage must not open a pending sign-in'
+
     guess(ROTP::TOTP.new(@user.otp_secret_key).now)
     assert_redirected_to new_user_session_path
+  end
+
+  test 'the second-factor prompt keeps the account locale when the URL carries none' do
+    @user.update!(locale: 'pl')
+    start_2fa
+
+    assert_redirected_to verify_two_factor_path(locale: 'pl')
+    refute_includes response.headers['Location'].to_s, 'locale=',
+                    'the locale belongs in the path segment, not a query param'
+  end
+
+  test 'a locale already in the URL wins over the account preference and is not doubled up' do
+    @user.update!(locale: 'de')
+    post '/pl/login', params: { user: { email: @user.email, password: @password } }
+
+    assert_redirected_to verify_two_factor_path(locale: 'pl')
+    refute_includes response.headers['Location'].to_s, 'locale='
   end
 
   test 'the pending state expires' do

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -99,6 +99,26 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The route accepts GET as well as POST so that #create can redirect to the form. Only
+  # the POST is throttled, and GET is exempt from CSRF, so an action that verified on GET
+  # would let a cross-site navigation burn a victim's attempts unthrottled — and would put
+  # the code in browser history and the Referer.
+  test 'a GET carrying a code does not spend an attempt' do
+    start_2fa
+    get '/verify_two_factor', params: { user: { otp_code_token: '000000' } }
+
+    assert_response :success
+    assert_equal 0, @user.reload.failed_attempts
+  end
+
+  test 'a GET carrying a correct code does not complete the sign-in' do
+    start_2fa
+    get '/verify_two_factor', params: { user: { otp_code_token: ROTP::TOTP.new(@user.otp_secret_key).now } }
+
+    assert_response :success
+    assert_nil @user.reload.last_otp_at, 'the code must not be consumed'
+  end
+
   test 'a locked account cannot even start the 2FA flow' do
     @user.lock_access!
     start_2fa

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -79,6 +79,26 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
     assert_equal 0, @user.reload.failed_attempts
   end
 
+  # Devise's own credential path opens with `unlock_access! if lock_expired?`
+  # (Devise::Models::Lockable#valid_for_authentication?), so an expired lock hands the
+  # account its whole budget back. This flow never reaches Warden, so nothing else does
+  # it: leave the counter at the maximum and the first wrong code re-locks for another
+  # unlock_in, forever, on an instance with no operator to unlock anyone.
+  test 'an expired lock restores the whole attempt budget' do
+    start_2fa
+    Devise.maximum_attempts.times { guess }
+    assert @user.reload.access_locked?
+
+    travel(Devise.unlock_in + 1.minute) do
+      start_2fa
+      guess
+
+      @user.reload
+      assert_equal 1, @user.failed_attempts, 'the expired lock must clear the counter before this guess'
+      refute @user.access_locked?, 'one wrong code must not re-lock an account whose lock has expired'
+    end
+  end
+
   test 'a locked account cannot even start the 2FA flow' do
     @user.lock_access!
     start_2fa

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class AuthenticationTest < ActionDispatch::IntegrationTest
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with its
+  # defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the exact
+  # 30-second step it was minted in, and the OTP tests below carry one code across request
+  # cycles. A step rolling over mid-test would fail them for a reason unrelated to what they
+  # assert, and — now that a wrong code increments the persisted counter — could carry that
+  # failure into the next test in the class. Nothing here needs the clock to move on its own;
+  # the lockout tests travel explicitly, which still works from a frozen base. Rails restores
+  # the clock in after_teardown.
   setup do
+    freeze_time
     @admin = create(:user, admin: true)
   end
 
@@ -161,6 +170,41 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     post user_session_path, params: {
       user: { email: user.email, password: 'SecurePass1!' }
     }
+
+    assert_response :redirect
+    follow_redirect!
+    assert_equal user, controller.current_user
+  end
+
+  # The 2FA mirror of the test above. That one is carried by Warden, which unlocks an
+  # expired lock before it counts anything; the second-factor stage never reaches Warden,
+  # so it needs its own guarantee that the budget comes back whole.
+  test 'unlocks a 2FA account after 15 minutes' do
+    user = create(:user, password: 'SecurePass1!', otp_module: :enabled)
+    user.otp_regenerate_secret
+    user.save!
+
+    Devise.maximum_attempts.times do
+      post user_session_path, params: {
+        user: { email: user.email, password: 'SecurePass1!' }
+      }
+      post verify_two_factor_path, params: { user: { otp_code_token: '000000' } }
+    end
+
+    user.reload
+    assert user.access_locked?
+
+    travel 16.minutes
+
+    post user_session_path, params: {
+      user: { email: user.email, password: 'SecurePass1!' }
+    }
+    assert_redirected_to verify_two_factor_path
+
+    post verify_two_factor_path, params: { user: { otp_code_token: '000000' } }
+    refute user.reload.access_locked?, 'one wrong code must not re-lock an account whose lock has expired'
+
+    post verify_two_factor_path, params: { user: { otp_code_token: user.otp_code } }
 
     assert_response :redirect
     follow_redirect!

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RackAttackTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_store = Rack::Attack.cache.store
+    @original_enabled = Rack::Attack.enabled
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+    Rack::Attack.enabled = true
+    create(:user, admin: true, setup_completed: true)
+  end
+
+  teardown do
+    Rack::Attack.cache.store = @original_store
+    Rack::Attack.enabled = @original_enabled
+  end
+
+  test 'throttles POST /login' do
+    11.times { post '/login', params: { user: { email: 'a@b.test', password: 'wrong' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles POST /en/login under the locale scope' do
+    11.times { post '/en/login', params: { user: { email: 'a@b.test', password: 'wrong' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles POST /verify_two_factor' do
+    6.times { post '/verify_two_factor', params: { user: { otp_code_token: '000000' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles POST /pl/verify_two_factor under the locale scope' do
+    6.times { post '/pl/verify_two_factor', params: { user: { otp_code_token: '000000' } } }
+    assert_response :too_many_requests
+  end
+
+  # POST /password requests a reset email; PATCH/PUT /password submits the new password
+  # and the OTP. The form uses PATCH (app/views/devise/passwords/edit.html.erb:5), so a
+  # POST-only rule would leave reset-token and OTP guessing unthrottled.
+  test 'throttles POST /password (reset request)' do
+    6.times { post '/password', params: { user: { email: 'a@b.test' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles PATCH /password (reset submission)' do
+    6.times do
+      patch '/password', params: { user: { reset_password_token: 'x', password: 'Aa1!aaaaaaaa',
+                                           password_confirmation: 'Aa1!aaaaaaaa' } }
+    end
+    assert_response :too_many_requests
+  end
+
+  test 'throttles PUT /password (reset submission)' do
+    6.times do
+      put '/password', params: { user: { reset_password_token: 'x', password: 'Aa1!aaaaaaaa',
+                                         password_confirmation: 'Aa1!aaaaaaaa' } }
+    end
+    assert_response :too_many_requests
+  end
+
+  test 'throttles POST /setup' do
+    User.delete_all
+    6.times { post '/setup', params: { user: { name: 'A', email: 'a@b.test', password: 'Aa1!aaaaaaaa' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles POST /oauth/token' do
+    21.times { post '/oauth/token', params: { grant_type: 'authorization_code', code: 'x' } }
+    assert_response :too_many_requests
+  end
+
+  test 'throttles GET /oauth/authorize' do
+    11.times { get '/oauth/authorize', params: { client_id: 'x', response_type: 'code' } }
+    assert_response :too_many_requests
+  end
+
+  test 'a format suffix does not bypass the oauth/register throttle' do
+    6.times do
+      post '/oauth/register.json', params: { redirect_uris: ['https://e.test/cb'] }, as: :json
+    end
+    assert_response :too_many_requests
+  end
+
+  test 'a non-alphanumeric format suffix does not bypass it either' do
+    6.times do
+      post '/oauth/register.json-api', params: { redirect_uris: ['https://e.test/cb'] }, as: :json
+    end
+    assert_response :too_many_requests
+  end
+
+  # Each suffix must land in the SAME bucket, or an attacker just varies the suffix.
+  test 'suffixed and unsuffixed requests share one bucket' do
+    3.times { post '/oauth/register', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    3.times { post '/oauth/register.json', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    assert_response :too_many_requests
+  end
+
+  # Verified with recognize_path: Rails routes all of these to the same action, so a
+  # regex over the raw path would let one extra slash bypass every throttle.
+  test 'a trailing slash does not bypass the login throttle' do
+    11.times { post '/login/', params: { user: { email: 'a@b.test', password: 'wrong' } } }
+    assert_response :too_many_requests
+  end
+
+  test 'a doubled slash does not bypass the oauth/register throttle' do
+    6.times { post '/oauth//register', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    assert_response :too_many_requests
+  end
+
+  test 'slash variants share one bucket with the canonical path' do
+    2.times { post '/oauth/register', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    2.times { post '/oauth/register/', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    2.times { post '/oauth//register', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
+    assert_response :too_many_requests
+  end
+end

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -22,9 +22,38 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     assert_response :too_many_requests
   end
 
+  # Before the throttles matched real routed paths the login rule never fired, so
+  # rack-attack's bare default response was unreachable. It reaches humans on an auth page
+  # now, and it has to be the same response whatever tripped it — a rule that named the
+  # endpoint would tell an attacker which of their guesses was worth repeating.
+  test 'a throttled request says what happened' do
+    11.times { post '/login', params: { user: { email: 'a@b.test', password: 'wrong' } } }
+
+    assert_response :too_many_requests
+    assert_equal I18n.t('errors.throttled'), response.body.strip
+    assert response.headers['retry-after'].to_i.positive?, 'the response must say how long to wait'
+    login_body = response.body
+
+    6.times { post '/password', params: { user: { email: 'a@b.test' } } }
+
+    assert_response :too_many_requests
+    assert_equal login_body, response.body, 'the response must not identify which rule tripped'
+  end
+
   test 'throttles POST /en/login under the locale scope' do
     11.times { post '/en/login', params: { user: { email: 'a@b.test', password: 'wrong' } } }
     assert_response :too_many_requests
+  end
+
+  # Every locale the app ships routes, so every locale has to be covered. Asserting the
+  # whole set rather than one example: the list the patterns are built from is not this
+  # app's list unless it is read from the right place, and a hole is invisible until
+  # someone tries the locale it left out.
+  test 'no shipped locale escapes the login throttle' do
+    I18n.available_locales.each do |locale|
+      assert RackAttackPaths::LOGIN.match?("/#{locale}/login"),
+             "POST /#{locale}/login is a routed path the login throttle does not match"
+    end
   end
 
   test 'throttles POST /verify_two_factor' do


### PR DESCRIPTION
Four fixes on the authentication and authorization paths, each written test-first.

## Rack::Attack throttles now match the paths this app actually routes

The sign-in rule keyed on `/users/sign_in`, which we don't route — Devise is mounted with `path: ''` and `path_names: { sign_in: 'login' }` inside `scope "(:locale)"`, so the real path is `(/:locale)/login`. That rule had never fired. The OAuth rules used exact string equality, so a `.format` suffix skipped them.

Paths are now matched with anchored patterns that account for the optional locale prefix and the optional format suffix, and every throttle keys on the request IP alone so suffix and slash variants share one bucket rather than each getting a fresh budget. Adds coverage for `/verify_two_factor`, `/password` (POST, PATCH and PUT — the form uses PATCH) and `/setup`, and configures a `throttled_responder` so a throttled person gets a readable response instead of rack-attack's bare default.

While testing this I found the locale alternation was being built from the locales registered by gems at initializer load time, not from ours — `config.i18n.available_locales` isn't applied until later in boot. That set was not a superset of ours, so one of our locale prefixes was absent from every pattern and requests under it matched no throttle. The patterns now build from `Rails.application.config.i18n.available_locales`, and the test asserts the whole locale set rather than one example.

## TOTP guesses are now bounded

Our 2FA flow signs the user out at the password stage and stashes a pending id in the session, which means it bypasses Warden — so Devise's `:lockable` never observed a wrong code and there was no limit on guesses for someone who already had the password.

The counter now lives on the user row via `:lockable`, sharing the same 5-attempt / 15-minute budget as passwords. It has to be persisted rather than held in the session: we use `:cookie_store`, so a session counter is client-side state that resets by replaying an older cookie. The pending state also expires after five minutes.

This needed one non-obvious change. Devise prepends `allow_params_authentication!` for `create`, and our `ApplicationController` calls `user_signed_in?` before `create` runs — which performed a full params authentication and fired `:lockable`'s reset hook before the controller had decided a second factor was owed. That premature sign-in also had a second consequence: one account state could reach a signed-in redirect before the second-factor branch ran at all. The filter is now deferred and called explicitly in the branch that needs it.

`GET /verify_two_factor` was processing a submitted code as well as rendering the form. It's now render-only, which also closes it as a CSRF-exempt path and keeps codes out of browser history.

## The reset OTP is verified before the password is written

The check ran inside Devise's `reset_password_by_token` block, which fires after the record has been saved and the token cleared in the same UPDATE — so the error was cosmetic and the password had already changed.

The check now runs first. Ordering matters within it: verifying the code consumes it, so anything Devise would reject anyway — an expired token, a password that fails policy, a mismatched confirmation, a missing password — is rejected before the code is spent. The record is reloaded after the password pre-check, because `Users::VerifyOtp` calls `update`, which persists every dirty attribute and would otherwise write the new password behind Devise's back.

A locked account is refused here too, and now says so rather than blaming the authenticator.

## Market-data writes are admin-only

Settings already required admin to set the CoinGecko key. The tracker and the index wizard exposed the same instance-wide write to any signed-in user, so a second account on the instance could repoint market data at their own key. `require_admin!` moves into a shared concern and applies to all three; the key form is hidden from non-admins rather than failing silently on submit.

## Also

Both hand-rolled lock checks now clear an expired lock the way Devise's own counter path does. Without it a 2FA account that had been locked once kept `failed_attempts` at the maximum forever, so a single wrong code re-locked it for another fifteen minutes — while an account without 2FA got its full budget back.

The two-factor tests freeze the clock. They mint a code and submit it over a live clock, and we verify with no drift tolerance, so a 30-second step boundary crossed mid-test failed the assertion — rare, load-dependent, and it now also moved a persisted counter.

## Known limitation

The throttle key derives from a forwarded client address, which is only trustworthy when a proxy we control is the one setting it — and we configure no trusted proxies. So on a deployment that publishes the container port directly, treat the per-IP limits as best-effort rather than a hard bound. This is not new; the previous key had the same property. The per-account lockout above is the control that doesn't depend on IP attribution at all, so the credential paths stay bounded regardless — `/setup` and the OAuth endpoints are the ones without that second bound. Configuring trusted proxies needs a per-deployment signal we don't have yet, and is tracked separately.

## Testing

2765 runs, 9526 assertions, 0 failures, 0 errors, 0 skips.

