### PR TITLE
Harden credential, locale, export and token handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'net-pop', require: false
 gem 'sqlite3', '~> 2.9'
 gem 'puma', '~> 8.0'
 gem 'rack-attack'
-gem 'rack-cors'
 gem 'rails', '~> 8.1.3'
 gem 'rqrcode'
 gem 'solid_queue'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,9 +400,6 @@ GEM
     rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-cors (3.0.0)
-      logger
-      rack (>= 3.0.14)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.2)
@@ -643,7 +640,6 @@ DEPENDENCIES
   pagy (~> 43.5)
   puma (~> 8.0)
   rack-attack
-  rack-cors
   rack-mini-profiler (~> 4.0)
   rails (~> 8.1.3)
   rbnacl
@@ -812,7 +808,6 @@ CHECKSUMS
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
-  rack-cors (3.0.0) sha256=7b95be61db39606906b61b83bd7203fa802b0ceaaad8fcb2fef39e097bf53f68
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463

--- a/app/assets/stylesheets/new/_rules.sass
+++ b/app/assets/stylesheets/new/_rules.sass
@@ -38,6 +38,9 @@
     .sinput,.tag,.sbutton,.ticker
         height: 3rem !important
         line-height: 3rem !important
+    .tag--wrap
+        height: auto !important
+        line-height: 1.4 !important
     .ticker
         min-width: 9rem
     &--active

--- a/app/assets/stylesheets/new/_ticker.sass
+++ b/app/assets/stylesheets/new/_ticker.sass
@@ -92,6 +92,7 @@
     color: var(--stone) !important
     display: flex
     gap: .5rem
+    overflow-wrap: anywhere
     &--address,&--copy
         text-overflow: ellipsis
         overflow: hidden

--- a/app/assets/stylesheets/new/_ticker.sass
+++ b/app/assets/stylesheets/new/_ticker.sass
@@ -92,7 +92,16 @@
     color: var(--stone) !important
     display: flex
     gap: .5rem
-    overflow-wrap: anywhere
+    &--wrap
+        height: auto
+        line-height: 1.4
+        white-space: normal
+        text-overflow: clip
+        overflow: visible
+        overflow-wrap: anywhere
+        text-align: left
+        justify-content: flex-start
+        padding: .75rem 1.5rem
     &--address,&--copy
         text-overflow: ellipsis
         overflow: hidden

--- a/app/controllers/api/api_keys_controller.rb
+++ b/app/controllers/api/api_keys_controller.rb
@@ -2,9 +2,10 @@ module Api
   class ApiKeysController < Api::BaseController
     def create
       keys_params = api_key_params.merge(user: current_user)
-      # prevent JSON parse errors like reading "\n" as "\\n"
-      keys_params[:key] = JSON.parse("{\"content\": \"#{keys_params[:key]}\"}")['content']
-      keys_params[:secret] = JSON.parse("{\"content\": \"#{keys_params[:secret]}\"}")['content']
+      # A pasted Coinbase CDP PEM secret arrives with literal \n sequences instead of real
+      # newlines; unescape them so OpenSSL::PKey::EC can parse the key.
+      keys_params[:key] = keys_params[:key].to_s.gsub('\n', "\n")
+      keys_params[:secret] = keys_params[:secret].to_s.gsub('\n', "\n")
       api_key = current_user.api_keys
                             .find_by(exchange_id: keys_params[:exchange_id], key_type: keys_params[:key_type])
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,8 +14,9 @@ class ApplicationController < ActionController::Base
   end
 
   def switch_locale(&action)
-    locale = params[:locale].presence || current_user.try(:locale) || I18n.default_locale
-    I18n.with_locale(locale, &action)
+    requested = params[:locale].presence || current_user.try(:locale)
+    locale = requested if requested.to_s.in?(I18n.available_locales.map(&:to_s))
+    I18n.with_locale(locale || I18n.default_locale, &action)
   end
 
   private

--- a/app/controllers/settings/ibkr_connections_controller.rb
+++ b/app/controllers/settings/ibkr_connections_controller.rb
@@ -47,18 +47,19 @@ class Settings::IbkrConnectionsController < ApplicationController
     @api_key = current_ibkr_key
     return redirect_to(settings_ibkr_connect_path) if @api_key.nil?
 
-    # Blank/omitted fields must never reach validate_credentials! — assign_credentials nils
-    # absent fields, and any client failure lands in :pending_activation, which users can't
-    # tell apart from a genuine IBKR activation wait. Check by explicit key so an omitted
-    # param is caught, not just a submitted empty string.
+    # Blank/omitted fields must never reach validate_credentials! — a blank key/secret/access_token
+    # is still a present param and gets assigned, and any resulting client failure lands in
+    # :pending_activation, which users can't tell apart from a genuine IBKR activation wait. Check
+    # by explicit key so an omitted param is caught too, not just a submitted empty string.
     creds = activate_params
     if %i[key access_token secret].any? { |field| creds[field].blank? }
       flash[:alert] = t('settings.ibkr.missing_fields')
       return redirect_to(settings_ibkr_connect_path)
     end
 
-    # assign_credentials is destructive (nils absent fields), so re-pass the generated keys to
-    # keep them intact while adding the pasted consumer credentials.
+    # activate_params only permits key/access_token/secret, so assign_credentials would leave the
+    # RSA/DH fields untouched anyway — re-pass them explicitly for clarity, and default ibkr_realm
+    # here since nothing else supplies one on first activation.
     @api_key.validate_credentials!(creds.merge(
                                      rsa_signature_key: @api_key.rsa_signature_key,
                                      rsa_encryption_key: @api_key.rsa_encryption_key,

--- a/app/models/account_transaction.rb
+++ b/app/models/account_transaction.rb
@@ -34,7 +34,7 @@ class AccountTransaction < ApplicationRecord
   end
 
   def self.to_csv(records)
-    CSV.generate do |csv|
+    CsvSafe.generate do |csv|
       csv << csv_headers
       records.order(transacted_at: :asc).each do |record|
         csv << record.to_csv_row

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -32,6 +32,13 @@ class ApiKey < ApplicationRecord
   ACTIVATION_DEADLINE = 14.days
   enum :key_type, %i[trading withdrawal]
 
+  # Fields assign_credentials will touch, checked against both `ActionController::Parameters`
+  # (string-keyed once permitted) and symbol-keyed hashes from direct/test callers.
+  CREDENTIAL_FIELDS = %i[
+    key secret passphrase access_token
+    rsa_signature_key rsa_encryption_key dh_param ibkr_realm
+  ].freeze
+
   scope :for_bot, lambda { |user_id, exchange_id, key_type = 'trading'|
     where(user_id: user_id, exchange_id: exchange_id, key_type: key_type)
   }
@@ -111,18 +118,16 @@ class ApiKey < ApplicationRecord
 
   private
 
-  CREDENTIAL_FIELDS = %i[
-    key secret passphrase access_token
-    rsa_signature_key rsa_encryption_key dh_param ibkr_realm
-  ].freeze
-
   # Assigns only the credential fields actually present in the submitted params. The generic
   # add-api-key forms send key/secret alone; assigning the whole set would NULL the IBKR RSA
   # material and DH param, which IBKR only lets a user register once. An explicitly-supplied
-  # nil still clears the field.
+  # nil still clears the field. Accepts either a symbol or string key for each field so a
+  # string-keyed hash doesn't silently skip every assignment and leave get_validity checking
+  # stale, previously-stored credentials instead of what was just submitted.
   def assign_credentials(params)
     CREDENTIAL_FIELDS.each do |field|
-      self[field] = params[field] if params.key?(field)
+      submitted_key = [field, field.to_s].find { |name| params.key?(name) }
+      self[field] = params[submitted_key] if submitted_key
     end
   end
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -111,19 +111,19 @@ class ApiKey < ApplicationRecord
 
   private
 
-  # Assigns whatever credential params were submitted. Crypto exchanges send key/secret/passphrase;
-  # the IBKR wizard additionally sends the OAuth fields. Uses indifferent `params[...]` (works for
-  # both ActionController::Parameters and plain hashes); absent keys assign nil, which is a no-op
-  # for exchanges that don't use them.
+  CREDENTIAL_FIELDS = %i[
+    key secret passphrase access_token
+    rsa_signature_key rsa_encryption_key dh_param ibkr_realm
+  ].freeze
+
+  # Assigns only the credential fields actually present in the submitted params. The generic
+  # add-api-key forms send key/secret alone; assigning the whole set would NULL the IBKR RSA
+  # material and DH param, which IBKR only lets a user register once. An explicitly-supplied
+  # nil still clears the field.
   def assign_credentials(params)
-    self.key = params[:key]
-    self.secret = params[:secret]
-    self.passphrase = params[:passphrase]
-    self.access_token = params[:access_token]
-    self.rsa_signature_key = params[:rsa_signature_key]
-    self.rsa_encryption_key = params[:rsa_encryption_key]
-    self.dh_param = params[:dh_param]
-    self.ibkr_realm = params[:ibkr_realm]
+    CREDENTIAL_FIELDS.each do |field|
+      self[field] = params[field] if params.key?(field)
+    end
   end
 
   def unique_for_user_exchange_and_key_type

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -89,11 +89,19 @@ class ApiKey < ApplicationRecord
 
   def update_status!(result)
     if result.success?
-      if result.data
-        update!(status: :correct)
-      else
+      case result.data
+      when :pending_activation
+        # This runs on a passive GET re-poll (the wizard/tracker/withdrawal "new" actions check
+        # the key's validity on every page view), not a credential submission — do not bump
+        # updated_at here, or activation_stalled? could never fire: a user revisiting the page
+        # would keep restarting its own deadline. Marking :correct here would also defeat
+        # Bot::ActionJob's guard against trading on a key IBKR has not activated yet.
+        update!(status: :pending_activation)
+      when nil, false
         Rails.logger.warn("[#{exchange.name}] API key validation: incorrect key")
         update!(status: :incorrect)
+      else
+        update!(status: :correct)
       end
     else
       Rails.logger.warn("[#{exchange.name}] API key validation failed: #{result.errors.join(', ')}")

--- a/app/models/bot/exportable.rb
+++ b/app/models/bot/exportable.rb
@@ -68,8 +68,8 @@ module Bot::Exportable
     records = []
 
     rows.each do |row|
-      csv_base = row['Base Asset']&.strip&.upcase
-      csv_quote = row['Quote Asset']&.strip&.upcase
+      csv_base = CsvSafe.unescape(row['Base Asset'])&.strip&.upcase
+      csv_quote = CsvSafe.unescape(row['Quote Asset'])&.strip&.upcase
 
       # Skip rows where currencies don't match
       # For index bots (bot_base_symbols is nil), accept any base asset as long as quote matches
@@ -79,7 +79,7 @@ module Bot::Exportable
         next
       end
 
-      original_order_id = row['Order ID']
+      original_order_id = CsvSafe.unescape(row['Order ID'])
 
       # Generate a unique external_id for the imported transaction
       # This allows importing the same orders to different bots
@@ -92,13 +92,13 @@ module Bot::Exportable
       end
 
       # Only import closed/finalized orders
-      status = row['Status']&.strip&.downcase
+      status = CsvSafe.unescape(row['Status'])&.strip&.downcase
       next unless status == 'closed'
 
       # Parse values
       timestamp = Time.zone.parse(row['Timestamp'])
-      order_type = "#{row['Type'].downcase}_order"
-      side = row['Side'].downcase
+      order_type = "#{CsvSafe.unescape(row['Type']).downcase}_order"
+      side = CsvSafe.unescape(row['Side']).downcase
       amount = row['Amount'].to_d
       value = row['Value'].to_d
       price = row['Price'].to_d

--- a/app/models/bot/exportable.rb
+++ b/app/models/bot/exportable.rb
@@ -36,7 +36,7 @@ module Bot::Exportable
                           :external_status
                         )
 
-    CSV.generate do |csv|
+    CsvSafe.generate do |csv|
       csv << headers
       parsed_csv_values(transactions_data).each { |row| csv << row }
     end

--- a/app/models/bot_signal.rb
+++ b/app/models/bot_signal.rb
@@ -20,7 +20,7 @@ class BotSignal < ApplicationRecord
     return if token.present?
 
     loop do
-      self.token = SecureRandom.urlsafe_base64(4)
+      self.token = SecureRandom.urlsafe_base64(32)
       break unless BotSignal.exists?(token: token)
     end
   end

--- a/app/models/concerns/csv_safe.rb
+++ b/app/models/concerns/csv_safe.rb
@@ -1,0 +1,43 @@
+# Spreadsheet software treats a cell beginning with = + - @ (or a leading control
+# character) as a formula. Exchange-supplied text reaches our exports, so prefix a
+# quote to force it to be read as text. Non-strings are left alone so numeric
+# columns stay numeric.
+module CsvSafe
+  FORMULA_LEADERS = ['=', '+', '-', '@', "\t", "\r", "\n"].freeze
+
+  def self.cell(value)
+    return value unless value.is_a?(String)
+    return value if value.empty?
+
+    FORMULA_LEADERS.any? { |leader| value.start_with?(leader) } ? "'#{value}" : value
+  end
+
+  def self.row(values)
+    Array(values).map { |value| cell(value) }
+  end
+
+  # Drop-in replacement for CSV.generate. Escaping at the WRITER rather than at each
+  # call site matters here: app/models/tax/report.rb alone has ~40 `csv <<` sites, most
+  # of them I18n literals but several carrying exchange-derived asset names and price
+  # warnings. Wrapping each one individually would be forgotten the first time someone
+  # adds a row.
+  def self.generate(&block)
+    CSV.generate do |csv|
+      block.call(Writer.new(csv))
+    end
+  end
+
+  class Writer
+    def initialize(csv)
+      @csv = csv
+    end
+
+    def <<(row)
+      @csv << CsvSafe.row(row)
+      self
+    end
+
+    def method_missing(name, *args, &blk) = @csv.send(name, *args, &blk)
+    def respond_to_missing?(name, include_private = false) = @csv.respond_to?(name, include_private)
+  end
+end

--- a/app/models/concerns/csv_safe.rb
+++ b/app/models/concerns/csv_safe.rb
@@ -22,10 +22,10 @@ module CsvSafe
   # here when the remainder is itself formula-leading -- otherwise a value that legitimately
   # starts with an apostrophe (never touched by cell, since "'" isn't a formula leader) would
   # be corrupted on the way back in. This isn't a perfect inverse: cell("=1+1") and the literal
-  # string "'=1+1" both export as "'=1+1", so that one case stays ambiguous. Every other case
-  # -- an apostrophe followed by a non-formula character, which is the overwhelmingly common
-  # one -- now round-trips correctly, where before this stripped every leading apostrophe
-  # unconditionally.
+  # string "'=1+1" both export as "'=1+1", so a literal apostrophe followed by a formula leader
+  # ('-5, '@G, '+1, '\tx, ' =1+1, ...) stays ambiguous. Every other case -- an apostrophe
+  # followed by a non-formula character, which is the overwhelmingly common one -- now
+  # round-trips correctly, where before this stripped every leading apostrophe unconditionally.
   def self.unescape(value)
     return value unless value.is_a?(String)
     return value unless value.start_with?("'")

--- a/app/models/concerns/csv_safe.rb
+++ b/app/models/concerns/csv_safe.rb
@@ -1,7 +1,7 @@
 # Spreadsheet software treats a cell beginning with = + - @ (or a leading control
-# character) as a formula. Exchange-supplied text reaches our exports, so prefix a
-# quote to force it to be read as text. Non-strings are left alone so numeric
-# columns stay numeric.
+# character) as a formula, including when that character follows leading whitespace.
+# Exchange-supplied text reaches our exports, so prefix a quote to force it to be read
+# as text. Non-strings are left alone so numeric columns stay numeric.
 module CsvSafe
   FORMULA_LEADERS = ['=', '+', '-', '@', "\t", "\r", "\n"].freeze
 
@@ -9,23 +9,39 @@ module CsvSafe
     return value unless value.is_a?(String)
     return value if value.empty?
 
-    FORMULA_LEADERS.any? { |leader| value.start_with?(leader) } ? "'#{value}" : value
+    leading_char?(value) ? "'#{value}" : value
   end
 
   def self.row(values)
     Array(values).map { |value| cell(value) }
   end
 
-  # Drop-in replacement for CSV.generate. Escaping at the WRITER rather than at each
-  # call site matters here: app/models/tax/report.rb alone has ~40 `csv <<` sites, most
-  # of them I18n literals but several carrying exchange-derived asset names and price
-  # warnings. Wrapping each one individually would be forgotten the first time someone
-  # adds a row.
+  # Inverse of cell: strips the single leading quote it adds, so a value round-tripped
+  # through an export and back (e.g. Bot::Exportable#import_orders_csv) matches the
+  # original. Only ever removes one leading apostrophe, matching what cell adds.
+  def self.unescape(value)
+    return value unless value.is_a?(String)
+
+    value.delete_prefix("'")
+  end
+
+  # Minimal wrapper around CSV.generate: takes only a block, escaping every row written
+  # through it. It does not forward writer options (col_sep, force_quotes, etc.) — none
+  # of the three current call sites need them. Escaping at the WRITER rather than at
+  # each call site matters here: app/models/tax/report.rb alone has ~40 `csv <<` sites,
+  # most of them I18n literals but several carrying exchange-derived asset names and
+  # price warnings. Wrapping each one individually would be forgotten the first time
+  # someone adds a row.
   def self.generate(&block)
     CSV.generate do |csv|
       block.call(Writer.new(csv))
     end
   end
+
+  def self.leading_char?(value)
+    FORMULA_LEADERS.any? { |leader| value.start_with?(leader) || value.lstrip.start_with?(leader) }
+  end
+  private_class_method :leading_char?
 
   class Writer
     def initialize(csv)
@@ -37,7 +53,10 @@ module CsvSafe
       self
     end
 
-    def method_missing(name, *args, &blk) = @csv.send(name, *args, &blk)
-    def respond_to_missing?(name, include_private = false) = @csv.respond_to?(name, include_private)
+    # CSV#add_row and CSV#puts are aliases of CSV#<<. Alias them here too instead of
+    # relying on delegation, so every way of writing a row goes through the escape —
+    # a delegated method would write straight to the underlying CSV unescaped.
+    alias add_row <<
+    alias puts <<
   end
 end

--- a/app/models/concerns/csv_safe.rb
+++ b/app/models/concerns/csv_safe.rb
@@ -18,11 +18,20 @@ module CsvSafe
 
   # Inverse of cell: strips the single leading quote it adds, so a value round-tripped
   # through an export and back (e.g. Bot::Exportable#import_orders_csv) matches the
-  # original. Only ever removes one leading apostrophe, matching what cell adds.
+  # original. cell only ever adds that quote ahead of a formula leader, so only strip it
+  # here when the remainder is itself formula-leading -- otherwise a value that legitimately
+  # starts with an apostrophe (never touched by cell, since "'" isn't a formula leader) would
+  # be corrupted on the way back in. This isn't a perfect inverse: cell("=1+1") and the literal
+  # string "'=1+1" both export as "'=1+1", so that one case stays ambiguous. Every other case
+  # -- an apostrophe followed by a non-formula character, which is the overwhelmingly common
+  # one -- now round-trips correctly, where before this stripped every leading apostrophe
+  # unconditionally.
   def self.unescape(value)
     return value unless value.is_a?(String)
+    return value unless value.start_with?("'")
 
-    value.delete_prefix("'")
+    remainder = value.delete_prefix("'")
+    leading_char?(remainder) ? remainder : value
   end
 
   # Minimal wrapper around CSV.generate: takes only a block, escaping every row written

--- a/app/models/tax/report.rb
+++ b/app/models/tax/report.rb
@@ -47,7 +47,7 @@ module Tax
       end
 
       I18n.with_locale(jurisdiction[:locale]) do
-        CSV.generate do |csv|
+        CsvSafe.generate do |csv|
           csv << csv_headers
           if results.empty?
             csv << [I18n.t('tax_report.no_taxable_transactions')]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   validate :validate_email, if: -> { new_record? || email_changed? }
   validate :password_complexity, if: -> { password.present? }
   validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name), allow_nil: true }
+  validates :locale, inclusion: { in: ->(_) { I18n.available_locales.map(&:to_s) } }, allow_blank: true
 
   # Devise hands the whole attempt budget back the moment a lock ages out:
   # Devise::Models::Lockable#valid_for_authentication? opens with `unlock_access! if

--- a/app/views/bots/dca_indexes/pick_indices/new.html.erb
+++ b/app/views/bots/dca_indexes/pick_indices/new.html.erb
@@ -25,7 +25,7 @@
                   data-index-order="<%= idx %>"
                   data-index-name="<%= index.name %>"
                   data-index-description="<%= index.description %>"
-                  onclick="this.form.querySelector('#index_category_id').value='<%= index.external_id %>'; this.form.querySelector('#index_name').value='<%= j(index.name) %>';">
+                  onclick="this.form.querySelector('#index_category_id').value='<%= j(index.external_id) %>'; this.form.querySelector('#index_name').value='<%= j(index.name) %>';">
             <h4><%= index.name %></h4>
             <p><%= truncate(index.description, length: 150) %></p>
             <% if index.top_coins.present? %>

--- a/app/views/bots/signals/_signal_widget.html.erb
+++ b/app/views/bots/signals/_signal_widget.html.erb
@@ -85,7 +85,7 @@
             </div>
             <span data-form--select-toggle-target="section" data-select-toggle-value="percentage" style="<%= 'display:none' unless signal.percentage? %>"><%= t('bot.signal.of_the_balance') %></span>
             <span><%= t('bot.signal.when_triggered') %></span>
-            <span class="tag"><%= request.base_url %><%= signal.webhook_url %></span>
+            <span class="tag tag--wrap"><%= request.base_url %><%= signal.webhook_url %></span>
           </div>
         </div>
       </div>

--- a/app/views/layouts/_language_dropdown.html.erb
+++ b/app/views/layouts/_language_dropdown.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="dropdown-wrapper <%= extra_classes %>" style="font-weight: 600; color: var(--link)">
-  <%= params[:locale]&.to_s&.upcase || 'EN' %>
+  <%= I18n.locale.to_s.upcase %>
   <div class="dropdown">
     <% locale = params[:locale] %>
     <% unless locale.blank? || locale == 'en' %>

--- a/app/views/layouts/_language_dropdown_full.html.erb
+++ b/app/views/layouts/_language_dropdown_full.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="sbutton sbutton--link dropdown-wrapper <%= extra_classes %>">
   <% locale = params[:locale] %>
   <% language_names = { 'en' => 'English', 'de' => 'Deutsch', 'nl' => 'Nederlands', 'fr' => 'Français', 'es' => 'Español', 'pt' => 'Português', 'it' => 'Italiano', 'pl' => 'Polski', 'ru' => 'Русский', 'cs' => 'Čeština', 'sk' => 'Slovenčina', 'da' => 'Dansk', 'sv' => 'Svenska', 'el' => 'Ελληνικά', 'bg' => 'Български' } %>
-  <%= language_names[locale] || 'English' %> <%= render "svg/16x16_down" %>
+  <%= language_names[I18n.locale.to_s] || 'English' %> <%= render "svg/16x16_down" %>
   <div class="dropdown">
     <% unless locale.blank? || locale == 'en' %>
       <%= link_to "🇬🇧 English", locale_switch_path('en'), class: "dropdown__item", data: { turbo: false } %>

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,6 +1,0 @@
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins /localhost:\d{4}/,
-            /127\.0\.0\.1:\d{4}/
-  end
-end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -81,7 +81,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,7 @@ Rails.application.routes.draw do
       get '/', to: redirect { |params, request|
         locale = request.params[:locale].to_s
         locale = nil unless I18n.available_locales.map(&:to_s).include?(locale)
-        locale ? "/#{locale}/settings/connect" : "/settings/connect"
+        locale.presence ? "/#{locale}/settings/connect" : "/settings/connect"
       }
       get :connect
       get :account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,8 @@ Rails.application.routes.draw do
 
     namespace :settings do
       get '/', to: redirect { |params, request|
-        locale = request.params[:locale]
+        locale = request.params[:locale].to_s
+        locale = nil unless I18n.available_locales.map(&:to_s).include?(locale)
         locale ? "/#{locale}/settings/connect" : "/settings/connect"
       }
       get :connect
@@ -161,7 +162,9 @@ Rails.application.routes.draw do
     end
 
     get :dashboard, to: redirect { |params, request|
-      "/#{request.params[:locale] || I18n.default_locale}/bots"
+      locale = request.params[:locale].to_s
+      locale = I18n.default_locale.to_s unless I18n.available_locales.map(&:to_s).include?(locale)
+      "/#{locale}/bots"
     }
 
     namespace :bots do

--- a/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
+++ b/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
@@ -18,10 +18,10 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
     # suppress_messages is ever removed. Neither guard touches ActiveRecord's own adapter
     # logging, though: connection.execute fires the sql.active_record notification regardless,
     # and at :debug (development's default, which a debug build of the desktop app runs under)
-    # that logs the full UPDATE statement, token included. logger.silence raises the effective
-    # level past :debug for the duration, closing that path too.
+    # that logs the full UPDATE statement, token included. without_sql_logging closes that path
+    # too, without making the rotation itself depend on a logger being configured.
     suppress_messages do
-      ActiveRecord::Base.logger&.silence do
+      without_sql_logging do
         used_tokens = Set.new(select_values('SELECT token FROM bot_signals'))
         last_id = 0
 
@@ -50,6 +50,17 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
   end
 
   private
+
+  # ActiveRecord::Base.logger&.silence would make the whole expression nil, block included, when
+  # the logger is nil -- silently skipping the entire rotation instead of running it unlogged.
+  # A self-hosted install with its logger nilled out (a common way to quiet SQL logging) would
+  # have every token untouched forever, since migrations run once. Nil is already leak-free on
+  # its own -- ActiveSupport::LogSubscriber#call only calls through when a logger is present --
+  # so the work only needs to run either way, not be gated on a logger existing.
+  def without_sql_logging(&block)
+    logger = ActiveRecord::Base.logger
+    logger ? logger.silence(&block) : block.call
+  end
 
   # Regenerates on collision rather than trusting 256 bits of entropy blindly: the column
   # carries a unique index, and a duplicate would otherwise abort the migration outright.

--- a/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
+++ b/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
@@ -10,28 +10,35 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
   def up
     rotated = 0
 
-    # Bare quote/execute calls resolve through Migration#method_missing, which logs its
-    # arguments via say_with_time -- including the token itself. suppress_messages keeps every
-    # token, old or new, out of the migration log; only a final count is reported. quote and
-    # execute are also overridden locally below, bypassing method_missing's logging entirely, so
-    # neither can print a token even without suppress_messages.
+    # Two independent logging paths can print a token, and both need closing. Bare quote/execute
+    # calls resolve through Migration#method_missing, which logs its arguments via
+    # say_with_time; suppress_messages keeps that path silent, reporting only a final count.
+    # quote and execute are also overridden locally below, bypassing method_missing's logging
+    # entirely, so neither call site here can reach the verbose migration log even if
+    # suppress_messages is ever removed. Neither guard touches ActiveRecord's own adapter
+    # logging, though: connection.execute fires the sql.active_record notification regardless,
+    # and at :debug (development's default, which a debug build of the desktop app runs under)
+    # that logs the full UPDATE statement, token included. logger.silence raises the effective
+    # level past :debug for the duration, closing that path too.
     suppress_messages do
-      used_tokens = Set.new(select_values('SELECT token FROM bot_signals'))
-      last_id = 0
+      ActiveRecord::Base.logger&.silence do
+        used_tokens = Set.new(select_values('SELECT token FROM bot_signals'))
+        last_id = 0
 
-      loop do
-        ids = select_values(<<~SQL.squish).map(&:to_i)
-          SELECT id FROM bot_signals WHERE id > #{last_id} ORDER BY id LIMIT #{BATCH_SIZE}
-        SQL
-        break if ids.empty?
+        loop do
+          ids = select_values(<<~SQL.squish).map(&:to_i)
+            SELECT id FROM bot_signals WHERE id > #{last_id} ORDER BY id LIMIT #{BATCH_SIZE}
+          SQL
+          break if ids.empty?
 
-        ids.each do |id|
-          token = unused_token(used_tokens)
-          used_tokens << token
-          execute("UPDATE bot_signals SET token = #{quote(token)} WHERE id = #{id}")
-          rotated += 1
+          ids.each do |id|
+            token = unused_token(used_tokens)
+            used_tokens << token
+            execute("UPDATE bot_signals SET token = #{quote(token)} WHERE id = #{id}")
+            rotated += 1
+          end
+          last_id = ids.last
         end
-        last_id = ids.last
       end
     end
 

--- a/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
+++ b/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
@@ -5,14 +5,35 @@
 # Raw SQL throughout, not the BotSignal model: the app models keep changing, and this
 # migration needs to keep running unmodified on every self-hosted install for years.
 class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
-  def up
-    used_tokens = select_values('SELECT token FROM bot_signals')
+  BATCH_SIZE = 1000
 
-    select_values('SELECT id FROM bot_signals').each do |id|
-      token = unused_token(used_tokens)
-      used_tokens << token
-      execute("UPDATE bot_signals SET token = #{quote(token)} WHERE id = #{id.to_i}")
+  def up
+    rotated = 0
+
+    # Bare quote/execute calls resolve through Migration#method_missing, which logs its
+    # arguments via say_with_time -- including the token itself. suppress_messages keeps every
+    # token, old or new, out of the migration log; only a final count is reported.
+    suppress_messages do
+      used_tokens = Set.new(select_values('SELECT token FROM bot_signals'))
+      last_id = 0
+
+      loop do
+        ids = select_values(<<~SQL.squish).map(&:to_i)
+          SELECT id FROM bot_signals WHERE id > #{last_id} ORDER BY id LIMIT #{BATCH_SIZE}
+        SQL
+        break if ids.empty?
+
+        ids.each do |id|
+          token = unused_token(used_tokens)
+          used_tokens << token
+          execute("UPDATE bot_signals SET token = #{quote(token)} WHERE id = #{id}")
+          rotated += 1
+        end
+        last_id = ids.last
+      end
     end
+
+    say "Rotated #{rotated} token(s)"
   end
 
   def down
@@ -28,5 +49,11 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
       token = SecureRandom.urlsafe_base64(32)
       return token unless used_tokens.include?(token)
     end
+  end
+
+  # Defined locally rather than delegated through method_missing, so a call site here can never
+  # end up in the verbose migration log even if suppress_messages is ever removed above.
+  def quote(value)
+    ActiveRecord::Base.connection.quote(value)
   end
 end

--- a/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
+++ b/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
@@ -1,0 +1,32 @@
+# The /hook/:token receiver has no route yet, so nothing breaks by rotating these values in
+# place today. Once it is wired up, the token becomes a trade-triggering credential, and
+# rotating it stops being free.
+#
+# Raw SQL throughout, not the BotSignal model: the app models keep changing, and this
+# migration needs to keep running unmodified on every self-hosted install for years.
+class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
+  def up
+    used_tokens = select_values('SELECT token FROM bot_signals')
+
+    select_values('SELECT id FROM bot_signals').each do |id|
+      token = unused_token(used_tokens)
+      used_tokens << token
+      execute("UPDATE bot_signals SET token = #{quote(token)} WHERE id = #{id.to_i}")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # Regenerates on collision rather than trusting 256 bits of entropy blindly: the column
+  # carries a unique index, and a duplicate would otherwise abort the migration outright.
+  def unused_token(used_tokens)
+    loop do
+      token = SecureRandom.urlsafe_base64(32)
+      return token unless used_tokens.include?(token)
+    end
+  end
+end

--- a/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
+++ b/db/migrate/20260806001012_rotate_bot_signal_tokens.rb
@@ -12,7 +12,9 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
 
     # Bare quote/execute calls resolve through Migration#method_missing, which logs its
     # arguments via say_with_time -- including the token itself. suppress_messages keeps every
-    # token, old or new, out of the migration log; only a final count is reported.
+    # token, old or new, out of the migration log; only a final count is reported. quote and
+    # execute are also overridden locally below, bypassing method_missing's logging entirely, so
+    # neither can print a token even without suppress_messages.
     suppress_messages do
       used_tokens = Set.new(select_values('SELECT token FROM bot_signals'))
       last_id = 0
@@ -51,9 +53,15 @@ class RotateBotSignalTokens < ActiveRecord::Migration[8.1]
     end
   end
 
-  # Defined locally rather than delegated through method_missing, so a call site here can never
-  # end up in the verbose migration log even if suppress_messages is ever removed above.
+  # quote and execute are defined locally rather than delegated through method_missing, so
+  # neither call site here can end up in the verbose migration log even if suppress_messages is
+  # ever removed above -- method_missing (and its say_with_time wrapper) is only reached for
+  # methods the class does not already implement.
   def quote(value)
-    ActiveRecord::Base.connection.quote(value)
+    connection.quote(value)
+  end
+
+  def execute(sql)
+    connection.execute(sql)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_001012) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/controllers/api/api_keys_controller_test.rb
+++ b/test/controllers/api/api_keys_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Api::ApiKeysControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    create(:user, admin: true, setup_completed: true)
+    @user = create(:user, setup_completed: true)
+    sign_in @user
+  end
+
+  test 'stores a secret containing a double quote intact' do
+    secret = 'abc"def'
+    post '/api/api_keys', params: { api_key: { key: 'k', secret: secret,
+                                               exchange_id: create(:exchange).id } }
+
+    assert_response :created
+    assert_equal secret, ApiKey.last.secret
+  end
+
+  test 'unescapes a pasted PEM secret into real newlines' do
+    pem = '-----BEGIN EC PRIVATE KEY-----\nabc123\n-----END EC PRIVATE KEY-----\n'
+    post '/api/api_keys', params: { api_key: { key: 'k', secret: pem,
+                                               exchange_id: create(:exchange).id } }
+
+    assert_response :created
+    assert_equal "-----BEGIN EC PRIVATE KEY-----\nabc123\n-----END EC PRIVATE KEY-----\n",
+                 ApiKey.last.secret
+  end
+end

--- a/test/controllers/bots/dca_indexes/pick_indices_controller_test.rb
+++ b/test/controllers/bots/dca_indexes/pick_indices_controller_test.rb
@@ -66,4 +66,15 @@ class Bots::DcaIndexes::PickIndicesControllerTest < ActionDispatch::IntegrationT
     assert_no_match 'Nasdaq 100', response.body
     assert_match 'Layer 1', response.body
   end
+
+  test 'escapes a quote in the external id used by the tile onclick handler' do
+    Index.create!(external_id: "ev'il", source: Index::SOURCE_COINGECKO,
+                  name: 'Evil Index', weight: 1)
+    MarketDataSettings.stubs(:current_provider).returns(MarketDataSettings::PROVIDER_COINGECKO)
+
+    get new_bots_dca_indexes_pick_index_path
+    assert_response :success
+    assert_match "value='ev\\&#39;il'", response.body
+    assert_no_match "value='ev&#39;il'", response.body
+  end
 end

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -152,9 +152,12 @@ class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
   # The route's locale segment is constrained on the way in but not on generation, so a
   # locale the app no longer ships would build a path that 404s on arrival — dead-ending
   # every login for that account, not just one.
+  # Seeded past the model validation on purpose: the row this guards against is one that
+  # became unroutable without being written, which is what config drift does — drop a locale
+  # from the available list and every row still carrying it is suddenly out of range.
   test 'an unroutable account locale falls back to the unprefixed path' do
     refute_includes I18n.available_locales.map(&:to_s), 'xx'
-    @user.update!(locale: 'xx')
+    @user.update_column(:locale, 'xx')
     start_2fa
 
     assert_redirected_to verify_two_factor_path

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -211,6 +211,26 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_equal user, controller.current_user
   end
 
+  test 'does not disclose that an account is locked' do
+    user = create(:user, password: 'SecurePass1!')
+
+    5.times do
+      post user_session_path, params: {
+        user: { email: user.email, password: 'wrongpassword' }
+      }
+    end
+
+    user.reload
+    assert user.access_locked?
+
+    post user_session_path, params: {
+      user: { email: user.email, password: 'SecurePass1!' }
+    }
+
+    assert_response :unprocessable_content
+    assert_equal 'Invalid email or password.', flash[:alert]
+  end
+
   # == Logout ==
 
   test 'signs out the user' do

--- a/test/integration/locale_param_safety_test.rb
+++ b/test/integration/locale_param_safety_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class LocaleParamSafetyTest < ActionDispatch::IntegrationTest
+  setup { create(:user, admin: true, setup_completed: true) }
+
+  # NOTE: the path must NOT carry a locale segment. `/en/login` sets locale=en as a path
+  # parameter (config/routes.rb:68) and Rails merges path parameters over query
+  # parameters, so `/en/login?locale=zz` reaches the controller as `en` and would pass
+  # before the fix. Only the unprefixed path lets the query param through.
+  test 'an unknown locale falls back rather than raising' do
+    get '/login', params: { locale: 'zz' }
+    assert_response :success
+  end
+
+  test 'a junk locale falls back rather than raising' do
+    get '/login', params: { locale: '../../etc/passwd' }
+    assert_response :success
+  end
+
+  test 'the dashboard redirect cannot be pointed off-site' do
+    get '/dashboard', params: { locale: '/evil.com' }
+
+    assert_response :redirect
+    refute_match %r{\A(https?:)?//evil\.com}, response.headers['Location'].to_s
+  end
+
+  test 'the settings redirect cannot be pointed off-site' do
+    get '/settings', params: { locale: '/evil.com' }
+
+    assert_response :redirect
+    refute_match %r{\A(https?:)?//evil\.com}, response.headers['Location'].to_s
+  end
+end

--- a/test/integration/locale_param_safety_test.rb
+++ b/test/integration/locale_param_safety_test.rb
@@ -22,6 +22,7 @@ class LocaleParamSafetyTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     refute_match %r{\A(https?:)?//evil\.com}, response.headers['Location'].to_s
+    assert_match %r{\Ahttp://www\.example\.com/}, response.headers['Location'].to_s
   end
 
   test 'the settings redirect cannot be pointed off-site' do
@@ -29,5 +30,29 @@ class LocaleParamSafetyTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     refute_match %r{\A(https?:)?//evil\.com}, response.headers['Location'].to_s
+    assert_match %r{\Ahttp://www\.example\.com/}, response.headers['Location'].to_s
+  end
+
+  # Guards against a validator that always fails closed to the default locale (e.g. comparing
+  # a String param against the Symbol keys `I18n.available_locales` returns) — that would still
+  # pass every test above while silently forcing English for every visitor.
+  test 'a legitimate locale is actually honoured, not just accepted' do
+    get '/login', params: { locale: 'pl' }
+
+    assert_response :success
+    assert_includes response.body, 'Witaj ponownie!'
+  end
+
+  # settings#update_locale reads current_user.locale straight into I18n.t after saving it,
+  # bypassing switch_locale's own guard entirely. The fix belongs on the column, not this
+  # call site, so any other future reader of current_user.locale is covered too.
+  test 'an invalid locale submitted through the account form is rejected, not persisted' do
+    user = create(:user, admin: true, setup_completed: true, locale: 'en')
+    sign_in user
+
+    patch settings_update_locale_path, params: { user: { locale: 'zz' } }
+
+    assert_response :success
+    assert_equal 'en', user.reload.locale
   end
 end

--- a/test/migrations/rotate_bot_signal_tokens_test.rb
+++ b/test/migrations/rotate_bot_signal_tokens_test.rb
@@ -4,6 +4,12 @@ require Rails.root.join('db/migrate/20260806001012_rotate_bot_signal_tokens.rb')
 # The migration handles a secret column, so its two logging surfaces both need coverage: the
 # migration log (Migration#say/say_with_time) and ActiveRecord's own adapter-level SQL log,
 # which are silenced by two independent mechanisms and can regress independently.
+#
+# Two tests below reassign ActiveRecord::Base.logger, a global class_attribute, for the
+# duration of a migration run. That's only safe because this suite parallelizes across
+# processes (test_helper.rb's `parallelize(workers: :number_of_processors)`), each with its own
+# process-wide state; it would race under `parallelize(with: :threads)`, where every thread
+# shares one process's class_attribute.
 class RotateBotSignalTokensTest < ActiveSupport::TestCase
   test 'rotates every token to a new, distinct 43-character value' do
     bot = create(:signal_bot)
@@ -30,6 +36,19 @@ class RotateBotSignalTokensTest < ActiveSupport::TestCase
 
     refute_includes log, signal.reload.token
     refute_match(/UPDATE bot_signals SET token/, log)
+  end
+
+  test 'still rotates the token when ActiveRecord::Base.logger is nil' do
+    signal = create(:bot_signal)
+    original_token = signal.token
+    original_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = nil
+
+    migrate!
+
+    assert_not_equal original_token, signal.reload.token
+  ensure
+    ActiveRecord::Base.logger = original_logger
   end
 
   private

--- a/test/migrations/rotate_bot_signal_tokens_test.rb
+++ b/test/migrations/rotate_bot_signal_tokens_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260806001012_rotate_bot_signal_tokens.rb')
+
+# The migration handles a secret column, so its two logging surfaces both need coverage: the
+# migration log (Migration#say/say_with_time) and ActiveRecord's own adapter-level SQL log,
+# which are silenced by two independent mechanisms and can regress independently.
+class RotateBotSignalTokensTest < ActiveSupport::TestCase
+  test 'rotates every token to a new, distinct 43-character value' do
+    bot = create(:signal_bot)
+    first = create(:bot_signal, bot: bot)
+    second = create(:bot_signal, bot: bot)
+    original_tokens = [first.token, second.token]
+
+    migrate!
+
+    new_tokens = [first.reload.token, second.reload.token]
+    assert_equal 2, new_tokens.uniq.size
+    new_tokens.each { |token| assert_equal 43, token.length }
+    assert_empty original_tokens & new_tokens
+  end
+
+  test 'the migration is irreversible' do
+    assert_raises(ActiveRecord::IrreversibleMigration) { RotateBotSignalTokens.new.down }
+  end
+
+  test 'does not leak a token through ActiveRecord SQL logging at debug level' do
+    signal = create(:bot_signal)
+
+    log = capture_ar_debug_log { migrate! }
+
+    refute_includes log, signal.reload.token
+    refute_match(/UPDATE bot_signals SET token/, log)
+  end
+
+  private
+
+  def migrate!
+    RotateBotSignalTokens.new.tap { |m| m.verbose = false }.up
+  end
+
+  # ActiveRecord::LogSubscriber#logger always reads ActiveRecord::Base.logger fresh (it is a
+  # class_attribute, not memoized), so swapping it here is enough to intercept every SQL log
+  # line the adapter emits for the duration of the block, independent of Rails.logger and of
+  # whatever level the suite's own logger runs at. ActiveSupport::Logger, not plain ::Logger --
+  # every Rails environment logger is one (it's what Rails.logger is built from), and only
+  # ActiveSupport::Logger carries the #silence the fix depends on.
+  def capture_ar_debug_log
+    buffer = StringIO.new
+    debug_logger = ActiveSupport::Logger.new(buffer)
+    debug_logger.level = Logger::DEBUG
+    original_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = debug_logger
+
+    yield
+
+    buffer.string
+  ensure
+    ActiveRecord::Base.logger = original_logger
+  end
+end

--- a/test/models/account_transaction_export_test.rb
+++ b/test/models/account_transaction_export_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class AccountTransactionExportTest < ActiveSupport::TestCase
+  test 'a hostile exchange description cannot become a spreadsheet formula' do
+    tx = create(:account_transaction, description: '=1+1')
+
+    csv = AccountTransaction.to_csv(AccountTransaction.where(id: tx.id))
+
+    refute_includes csv, ',=1+1'
+    assert_includes csv, ",'=1+1"
+  end
+end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -178,6 +178,7 @@ class ApiKeyTest < ActiveSupport::TestCase
     key.send(:assign_credentials, { key: 'new-key', secret: 'new-secret' })
 
     assert_equal 'new-key', key.key
+    assert_equal 'new-secret', key.secret
     assert_equal 'SIGKEY', key.rsa_signature_key, 'omitted fields must be untouched'
     assert_equal 'DHPARAM', key.dh_param
   end
@@ -189,5 +190,16 @@ class ApiKeyTest < ActiveSupport::TestCase
     key.send(:assign_credentials, { key: 'k', passphrase: nil })
 
     assert_nil key.passphrase
+  end
+
+  test 'a string-keyed hash still assigns submitted fields and preserves omitted ones' do
+    key = create(:api_key)
+    key.update_columns(rsa_signature_key: 'SIGKEY')
+
+    key.send(:assign_credentials, { 'key' => 'new-key', 'secret' => 'new-secret' })
+
+    assert_equal 'new-key', key.key, 'a submitted string-keyed field must be assigned'
+    assert_equal 'new-secret', key.secret
+    assert_equal 'SIGKEY', key.rsa_signature_key, 'omitted fields must be untouched'
   end
 end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -133,4 +133,39 @@ class ApiKeyTest < ActiveSupport::TestCase
       refute_predicate api_key, :activation_stalled?
     end
   end
+
+  test 'update_status! keeps a pending IBKR key pending' do
+    key = create(:api_key, status: :pending_activation)
+
+    key.update_status!(Result::Success.new(:pending_activation))
+
+    assert key.reload.pending_activation?, 'a pending key must not be marked correct'
+  end
+
+  test 'update_status! does not restart the IBKR activation deadline on a passive re-poll' do
+    key = create(:api_key, status: :pending_activation)
+    key.update_column(:updated_at, 30.days.ago)
+
+    key.update_status!(Result::Success.new(:pending_activation))
+
+    key.reload
+    assert key.pending_activation?
+    assert key.activation_stalled?, 'a passive re-poll must not restart the IBKR activation deadline'
+  end
+
+  test 'update_status! still marks a genuinely valid key correct' do
+    key = create(:api_key, status: :pending_validation)
+
+    key.update_status!(Result::Success.new(true))
+
+    assert key.reload.correct?
+  end
+
+  test 'update_status! marks an invalid key incorrect' do
+    key = create(:api_key, status: :pending_validation)
+
+    key.update_status!(Result::Success.new(false))
+
+    assert key.reload.incorrect?
+  end
 end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -168,4 +168,26 @@ class ApiKeyTest < ActiveSupport::TestCase
 
     assert key.reload.incorrect?
   end
+
+  # --- assign_credentials must not wipe fields the submitter never sent -------------------------
+
+  test 'submitting only key and secret does not wipe stored IBKR material' do
+    key = create(:api_key)
+    key.update_columns(rsa_signature_key: 'SIGKEY', dh_param: 'DHPARAM')
+
+    key.send(:assign_credentials, { key: 'new-key', secret: 'new-secret' })
+
+    assert_equal 'new-key', key.key
+    assert_equal 'SIGKEY', key.rsa_signature_key, 'omitted fields must be untouched'
+    assert_equal 'DHPARAM', key.dh_param
+  end
+
+  test 'an explicitly nil field is still cleared' do
+    key = create(:api_key)
+    key.update_columns(passphrase: 'OLD')
+
+    key.send(:assign_credentials, { key: 'k', passphrase: nil })
+
+    assert_nil key.passphrase
+  end
 end

--- a/test/models/bot/exportable_test.rb
+++ b/test/models/bot/exportable_test.rb
@@ -275,6 +275,30 @@ class Bot::ExportableTest < ActiveSupport::TestCase
     assert_equal 'USD', imported.quote
   end
 
+  test 'export then import preserves an asset symbol beginning with a formula leader' do
+    hostile_asset = create(:asset, symbol: '@G', external_id: 'graphite-network')
+    hostile_bot = create(:dca_single_asset, exchange: @bot.exchange, base_asset: hostile_asset,
+                                            quote_asset: @bot.quote_asset)
+
+    create(:transaction, bot: hostile_bot,
+                         external_id: 'original-1', order_type: :market_order, side: :buy,
+                         amount: 0.001, amount_exec: 0.001,
+                         quote_amount: 50, quote_amount_exec: 50,
+                         price: 50_000, base: hostile_asset.symbol, quote: hostile_bot.quote_asset.symbol,
+                         external_status: :closed, status: :submitted)
+
+    csv_content = hostile_bot.reload.orders_csv
+    other_bot = create(:dca_single_asset, user: hostile_bot.user, exchange: hostile_bot.exchange,
+                                          base_asset: hostile_bot.base_asset, quote_asset: hostile_bot.quote_asset)
+    file = StringIO.new(csv_content)
+
+    result = other_bot.import_orders_csv(file)
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+    assert_equal '@G', other_bot.transactions.last.base
+  end
+
   # == Dual asset bot ==
 
   test 'import accepts both base assets for dual asset bot' do

--- a/test/models/bot/exportable_test.rb
+++ b/test/models/bot/exportable_test.rb
@@ -299,6 +299,23 @@ class Bot::ExportableTest < ActiveSupport::TestCase
     assert_equal '@G', other_bot.transactions.last.base
   end
 
+  test 'import treats a literal leading apostrophe as significant, not a collision with the bare id' do
+    csv = generate_csv([
+                         ['2025-01-15 12:00:00', "'abc", 'Market', 'Buy', '0.001', '50', '50000',
+                          'BTC', 'USD', 'closed'],
+                         ['2025-01-15 12:00:00', 'abc', 'Market', 'Buy', '0.001', '50', '50000',
+                          'BTC', 'USD', 'closed']
+                       ])
+
+    result = @bot.import_orders_csv(csv)
+
+    assert result[:success]
+    assert_equal 2, result[:imported_count]
+    assert_equal result[:imported_count], @bot.transactions.count
+    assert_equal ["imported_#{@bot.id}_'abc", "imported_#{@bot.id}_abc"].sort,
+                 @bot.transactions.pluck(:external_id).sort
+  end
+
   # == Dual asset bot ==
 
   test 'import accepts both base assets for dual asset bot' do

--- a/test/models/bot_signal_test.rb
+++ b/test/models/bot_signal_test.rb
@@ -11,7 +11,19 @@ class BotSignalTest < ActiveSupport::TestCase
     assert_nil signal.token
     signal.save!
     assert_not_nil signal.token
-    assert_equal 6, signal.token.length # urlsafe_base64(4) produces 6 chars
+    assert_equal 43, signal.token.length # urlsafe_base64(32) produces 43 chars
+  end
+
+  test 'mints a high-entropy token' do
+    signal = create(:bot_signal, bot: @bot)
+
+    assert signal.token.length >= 43,
+           "expected >= 256 bits of token, got #{signal.token.length} chars"
+  end
+
+  test 'tokens are unique' do
+    tokens = Array.new(20) { create(:bot_signal, bot: @bot).token }
+    assert_equal 20, tokens.uniq.length
   end
 
   test 'does not overwrite existing token on create' do

--- a/test/models/concerns/csv_safe_test.rb
+++ b/test/models/concerns/csv_safe_test.rb
@@ -61,4 +61,16 @@ class CsvSafeTest < ActiveSupport::TestCase
   test 'unescape passes non-strings through' do
     assert_nil CsvSafe.unescape(nil)
   end
+
+  test 'a literal leading apostrophe round-trips through cell and unescape intact' do
+    assert_equal "'abc", CsvSafe.unescape(CsvSafe.cell("'abc"))
+  end
+
+  test 'unescape leaves a literal leading apostrophe alone when nothing formula-leading follows' do
+    assert_equal "'abc", CsvSafe.unescape("'abc")
+  end
+
+  test 'a formula-leading value still round-trips through cell and unescape intact' do
+    assert_equal '=1+1', CsvSafe.unescape(CsvSafe.cell('=1+1'))
+  end
 end

--- a/test/models/concerns/csv_safe_test.rb
+++ b/test/models/concerns/csv_safe_test.rb
@@ -10,7 +10,11 @@ class CsvSafeTest < ActiveSupport::TestCase
   end
 
   test 'neutralises leading control characters' do
-    assert_equal "'\tx", CsvSafe.cell("\tx")
+    ["\t", "\r", "\n"].each { |c| assert_equal "'#{c}x", CsvSafe.cell("#{c}x") }
+  end
+
+  test 'neutralises a formula leader hidden behind leading whitespace' do
+    assert_equal "' =1+1", CsvSafe.cell(' =1+1')
   end
 
   test 'leaves ordinary text alone' do
@@ -34,5 +38,27 @@ class CsvSafeTest < ActiveSupport::TestCase
 
     assert_includes csv, "'=cmd|calc"
     refute_includes csv, "\n=cmd|calc"
+  end
+
+  test 'add_row and puts escape exactly like << instead of bypassing it' do
+    csv = CsvSafe.generate do |out|
+      out.add_row(['=evil'])
+      out.puts(['=evil2'])
+    end
+
+    assert_includes csv, "'=evil\n"
+    assert_includes csv, "'=evil2\n"
+  end
+
+  test 'unescape reverses a single leading quote' do
+    assert_equal '=1+1', CsvSafe.unescape("'=1+1")
+  end
+
+  test 'unescape leaves a value with no escape prefix alone' do
+    assert_equal 'BTC', CsvSafe.unescape('BTC')
+  end
+
+  test 'unescape passes non-strings through' do
+    assert_nil CsvSafe.unescape(nil)
   end
 end

--- a/test/models/concerns/csv_safe_test.rb
+++ b/test/models/concerns/csv_safe_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class CsvSafeTest < ActiveSupport::TestCase
+  test 'neutralises a leading equals' do
+    assert_equal "'=1+1", CsvSafe.cell('=1+1')
+  end
+
+  test 'neutralises the other formula leaders' do
+    %w[+ - @].each { |c| assert_equal "'#{c}x", CsvSafe.cell("#{c}x") }
+  end
+
+  test 'neutralises leading control characters' do
+    assert_equal "'\tx", CsvSafe.cell("\tx")
+  end
+
+  test 'leaves ordinary text alone' do
+    assert_equal 'BTC', CsvSafe.cell('BTC')
+  end
+
+  test 'leaves a negative number alone' do
+    assert_equal(-1.5, CsvSafe.cell(-1.5))
+  end
+
+  test 'passes nil through' do
+    assert_nil CsvSafe.cell(nil)
+  end
+
+  test 'generate escapes every row pushed through the writer' do
+    csv = CsvSafe.generate do |out|
+      out << ['header']
+      out << ['=cmd|calc']
+      out << []
+    end
+
+    assert_includes csv, "'=cmd|calc"
+    refute_includes csv, "\n=cmd|calc"
+  end
+end

--- a/test/models/tax/report_csv_safety_test.rb
+++ b/test/models/tax/report_csv_safety_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+# End-to-end coverage for Tax::Report#to_csv itself, as opposed to the individual
+# calculation methods exercised elsewhere in test/models/tax/. Every account
+# transaction here quotes directly in the report's own currency, so PriceService
+# resolves fiat values from quote_amount without ever calling out for a market price —
+# no VCR/webmock scaffolding needed.
+class Tax::ReportCsvSafetyTest < ActiveSupport::TestCase
+  test 'an asset symbol beginning with a formula leader comes out escaped in a real report' do
+    user = create(:user)
+    api_key = create(:api_key, user: user)
+
+    create(:account_transaction, user: user, api_key: api_key, exchange: api_key.exchange,
+                                 entry_type: :buy, base_currency: '=1+1', base_amount: 1,
+                                 quote_currency: 'USD', quote_amount: 100,
+                                 transacted_at: Time.utc(2026, 1, 1))
+    create(:account_transaction, user: user, api_key: api_key, exchange: api_key.exchange,
+                                 entry_type: :sell, base_currency: '=1+1', base_amount: 1,
+                                 quote_currency: 'USD', quote_amount: 150,
+                                 transacted_at: Time.utc(2026, 6, 1))
+
+    report = Tax::Report.new(country: 'US', year: 2026, transactions: AccountTransaction.for_user(user))
+    csv = report.to_csv
+
+    refute_includes csv, ',=1+1'
+    assert_includes csv, ",'=1+1"
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  test 'a junk locale is rejected and not persisted' do
+    user = create(:user, locale: 'en')
+
+    refute user.update(locale: 'zz')
+    assert_includes user.errors[:locale], 'is not included in the list'
+    assert_equal 'en', user.reload.locale
+  end
+
+  test 'a real locale is accepted' do
+    user = create(:user)
+
+    assert user.update(locale: 'pl')
+    assert_equal 'pl', user.reload.locale
+  end
+
+  test 'no locale preference is valid' do
+    user = build(:user, locale: nil)
+    assert_predicate user, :valid?
+
+    user.locale = ''
+    assert_predicate user, :valid?
+  end
+end


### PR DESCRIPTION
Six independent hardening changes to models, controllers and exports, plus one data migration. Continues the work from #170 and #171; this branch is cut from `main` and does not depend on #171 landing first — but see the merge-order note below.

## What's in here

**Keep a pending IBKR key pending.** `ApiKey#update_status!` treated the `:pending_activation` sentinel as truthy and flipped the key to `:correct`, disabling the guard that stops a bot calling IBKR before activation. `validate_credentials!` already handled the sentinel correctly — the two methods disagreed. Note it deliberately does *not* stamp `updated_at`: `update_status!` is reached from the wizard's GET `new` on every page view, so bumping the clock there would restart the 14-day window on a passive poll and `activation_stalled?` could never fire.

**Assign only the credential fields that were submitted.** `assign_credentials` wrote every field unconditionally, so the generic add-api-key forms — which send key/secret alone — NULLed the stored IBKR RSA keys and DH params. IBKR only lets you register that material once. Accepts symbol or string keys, since a symbol-keyed lookup silently matches nothing against a string-keyed hash and would have skipped every field without raising.

These two belong together and shouldn't be split: keeping a key pending means the wizard stops short-circuiting to the next step, so users land on the credential form more often — which is exactly the path that used to wipe the RSA material.

**Validate the locale param.** An unrecognised locale raised, giving an unauthenticated way to flood the error log, and the two routing-level redirects interpolated the raw param straight into a `Location` header. Falls back to the default in both places, and adds a model-level inclusion validation on `User#locale` so the settings writer can't persist an out-of-range value either. Devise's own writes to the user row all bypass validations (`save(validate: false)` / `increment_counter`), so lockout and sign-in are unaffected.

**Escape formula leaders in CSV exports.** Exchange-supplied text reaches the transaction, tax and bot-order exports unescaped, so a description beginning with `=` or `@` executes when the file is opened in a spreadsheet. Escaping happens at the writer rather than per call site — `tax/report.rb` alone has ~40 row writes. The bot-order export round-trips back through its own importer, so there's a matching `unescape` on the read side.

**Widen signal webhook tokens to 256 bits.** They were 32 bits, and the URL is already shown to users as the address to paste into a signal provider. The receiving route isn't implemented yet, so rotating the existing rows costs nothing today and stops being free later. The migration keeps tokens out of both the migration log and ActiveRecord's SQL log, and doesn't make the rotation itself conditional on a logger being configured.

**Four small cleanups.** Remove the unused CORS middleware and `rack-cors` (the initializer declared no `resource`, so it emitted no headers); enable Devise paranoid mode; escape the index id in the picker's inline handler alongside the name, which was already escaped; and stop round-tripping API credentials through hand-built JSON — a credential containing `"` raised, and one containing `", "x":"` was silently truncated. The `\n` unescape that endpoint relies on for pasted PEM secrets is preserved.

## Merge order

Land #171 before or alongside this. Paranoid mode makes Devise compute a bcrypt dummy hash on every login POST for an unknown email — that's its timing-attack defence, and it's the intended behaviour — but the throttle that should bound it doesn't currently match the real login path. #171 is what fixes that.

## Testing

2758 runs / 9493 assertions / 0 failures, up from 2713 on `main`; the delta is added tests only, with no existing test deleted or weakened. The migration was exercised on disposable database copies: empty table, non-contiguous ids, apostrophe-bearing tokens, 2500 rows, forced collision, and `down` raising as designed.

## Known follow-ups

- The add-api-key controllers still permit the full credential set, so an explicitly-empty `rsa_signature_key` is "present" and still overwrites. Reaching it needs an authenticated request against your own key, so it's self-harm only — narrowing those permits is the real close-out.
- The IBKR fix is forward-only: a key the old code already flipped to `:correct` isn't re-evaluated by anything. It self-heals once IBKR activates the key.
- The compact language dropdown picks its link list from the raw request param rather than the resolved locale, so a user whose stored preference differs from the URL sees the wrong options. Pre-existing.
