### PR TITLE
Take the transport, throttle and policy settings from the deployment itself

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -32,6 +32,23 @@ HOME_PAGE_URL=http://localhost:3737
 # FORCE_SSL=true raises them to https as well.
 # FORCE_SSL=true
 
+# Whether a reverse proxy sits in front of this container. It decides where the rate limits
+# protecting the authentication endpoints read the caller's address from: the forwarded-for
+# header when a proxy is declared, otherwise the address the connection was accepted from.
+# Set it to match the deployment, because both mistakes cost something. Left unset behind a
+# proxy, every request appears to come from the proxy's own address, so the whole deployment
+# shares one budget of a few attempts per minute and ordinary sign-ins start being refused —
+# the symptom is "too many requests" on the sign-in page while barely anyone is using the
+# instance. Set where no proxy exists, the header is whatever the caller chose to send, and
+# the limits stop bounding anything.
+#
+# Inferred from an https:// APP_ROOT_URL or from FORCE_SSL=true, so a proxy that terminates
+# TLS needs nothing set here. Set it explicitly for a proxy that speaks plain http to this
+# container. Note that docker compose reads APP_ROOT_URL from your shell or from its own
+# .env file, not from this one, so a value set here does not feed that inference — behind a
+# plain-http proxy this variable is the setting that works.
+# BEHIND_PROXY=true
+
 # =============================================================================
 # DATABASE (SQLite - stored in /app/storage)
 # =============================================================================

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -25,9 +25,10 @@ HOME_PAGE_URL=http://localhost:3737
 # Comma-separated allowed hosts (optional, allows all if not set)
 # ALLOWED_HOSTS=example.com,www.example.com
 
-# Force SSL: HSTS, secure cookies, and no plain-http requests. Inferred from an https://
-# APP_ROOT_URL, so set this only to override — FORCE_SSL=false keeps an https root URL on
-# plain http, FORCE_SSL=true turns it on for a root URL that is not https.
+# Force SSL: HSTS, secure cookies, and every request treated as https. Inferred from an
+# https:// APP_ROOT_URL, so set this only to override the inference — FORCE_SSL=false to
+# serve an https:// APP_ROOT_URL over plain http, FORCE_SSL=true for a root URL that is
+# not https. Generated links (email, assets) follow APP_ROOT_URL either way.
 # FORCE_SSL=true
 
 # =============================================================================

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -28,7 +28,8 @@ HOME_PAGE_URL=http://localhost:3737
 # Force SSL: HSTS, secure cookies, and every request treated as https. Inferred from an
 # https:// APP_ROOT_URL, so set this only to override the inference — FORCE_SSL=false to
 # serve an https:// APP_ROOT_URL over plain http, FORCE_SSL=true for a root URL that is
-# not https. Generated links (email, assets) follow APP_ROOT_URL either way.
+# not https. Generated links (email, assets) follow APP_ROOT_URL, except that
+# FORCE_SSL=true raises them to https as well.
 # FORCE_SSL=true
 
 # =============================================================================

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -25,7 +25,9 @@ HOME_PAGE_URL=http://localhost:3737
 # Comma-separated allowed hosts (optional, allows all if not set)
 # ALLOWED_HOSTS=example.com,www.example.com
 
-# Force SSL (set to true for HTTPS)
+# Force SSL: HSTS, secure cookies, and no plain-http requests. Inferred from an https://
+# APP_ROOT_URL, so set this only to override — FORCE_SSL=false keeps an https root URL on
+# plain http, FORCE_SSL=true turns it on for a root URL that is not https.
 # FORCE_SSL=true
 
 # =============================================================================

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-# Browsers POST Content-Security-Policy violations here as application/csp-report. It takes
-# no session and no CSRF token, because a browser sends neither with a report — so anyone at
-# all can reach it, and everything it writes is text a stranger chose. All it does is log a
-# fixed set of fields, each of them bounded and neutralised first.
+# Browsers POST Content-Security-Policy violations here as application/csp-report. A browser
+# sends a report on its own, carrying neither session nor CSRF token — so anyone at all can
+# reach it, and everything it writes is text a stranger chose. All it does is log a fixed set
+# of fields, each of them bounded and neutralised first.
 #
-# ActionController::Base rather than ApplicationController is required, not just tidy:
-# ApplicationController's redirect_to_setup_if_needed would 302 every report to /setup until
-# an admin exists, and switch_locale would touch the database once per report.
-# HealthCheckController and Oauth::DynamicRegistrationController inherit it for the same
-# reason.
-class CspReportsController < ActionController::Base
-  skip_forgery_protection
-
+# ActionController::API is what that shape asks for, and both halves of the choice matter.
+# Not ApplicationController: redirect_to_setup_if_needed would 302 every report to /setup
+# until an admin exists, and switch_locale would touch the database once per report. Not
+# ActionController::Base either: Base carries request forgery protection, cookies, sessions,
+# flash and view rendering, and this action reads the raw body, writes one line and returns
+# 204 — it touches none of them. Forgery protection is the one that would have had to be
+# turned back off by hand, since a report arrives with no token and a token check would 422
+# every real one; under API the module is not there to disable. Api::V1::BaseController
+# inherits API already.
+class CspReportsController < ActionController::API
   # Read cap on the request body. Anything larger is refused and said so, rather than read
   # to the cap and left to fail as truncated JSON — real reports do exceed this (long
   # blocked-uris, deep source-file paths), and those are the interesting ones, so they must

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -18,9 +18,12 @@ class CspReportsController < ActionController::Base
   # blocked-uris, deep source-file paths), and those are the interesting ones, so they must
   # not disappear without a trace.
   MAX_BODY = 4_000
-  # Per-value cap, applied before the values are joined, so one field cannot spend the whole
-  # line and push the rest out. The line is bounded by construction: a fixed set of nine
-  # field names, each value at most this long.
+  # Per-value cap in BYTES, applied before the values are joined, so one field cannot spend
+  # the whole line and push the rest out. Bytes rather than characters because that is the
+  # unit the log is measured and rotated in, and the two are not interchangeable here: a
+  # four-byte codepoint is one character, so a character cap over these nine fields would
+  # admit four times the line it appears to promise. The line is bounded by construction —
+  # a fixed set of nine field names, each value at most this many bytes.
   MAX_FIELD = 256
 
   # Never log the whole report body. Per the CSP reporting algorithm the browser strips the
@@ -43,10 +46,11 @@ class CspReportsController < ActionController::Base
     report = parsed_report
     return head :no_content if report.blank?
 
-    fields = SAFE_FIELDS.index_with { |field| report[field] }
-                        .merge(URI_FIELDS.index_with { |field| strip_query(report[field]) })
+    fields = SAFE_FIELDS.index_with { |field| text(report[field]) }
+                        .merge(URI_FIELDS.index_with { |field| strip_query(text(report[field])) })
                         .compact_blank
                         .transform_values { |value| sanitize(value) }
+    return head :no_content if fields.empty?
 
     Rails.logger.warn("[csp-violation] #{fields.map { |name, value| "#{name}=#{value}" }.join(' ')}")
     head :no_content
@@ -74,6 +78,18 @@ class CspReportsController < ActionController::Base
     nil
   end
 
+  # JSON.parse returns Strings tagged UTF-8 whose bytes need not BE valid UTF-8: a lone
+  # surrogate escape (\uD800) is legal JSON carried in a pure-ASCII body, and a raw \xFF
+  # byte in the body is accepted too. Every blank? and every regex below raises
+  # ArgumentError on such a String, which from an unauthenticated endpoint is a way to put
+  # a real backtrace into the log on demand — the same log this class is careful about, and
+  # the inverse of the neutralising in sanitize. So nothing inspects a value before this
+  # has run. Only a String can carry the bad bytes; containers reach the log through
+  # inspect, which escapes them.
+  def text(value)
+    value.is_a?(String) ? value.scrub('?') : value
+  end
+
   # Keep scheme, host and path; drop the query and fragment entirely.
   def strip_query(value)
     return nil if value.blank?
@@ -91,8 +107,14 @@ class CspReportsController < ActionController::Base
   # one being written.
   def sanitize(value)
     value.to_s
+         # Defense in depth, in the same idiom as RackAttackPaths.normalize: text() already
+         # covers every String, and a value that is still a container here reaches the log
+         # through inspect, which escapes invalid bytes — so no input reaches this scrub
+         # needing it today. It is here because that is a property of inspect rather than of
+         # this class, and because the gsubs below are what raise when it stops being true.
+         .scrub('?')
          .gsub(/[[:cntrl:]]+/, ' ')
          .gsub(CONSTANT_SHAPE, &:downcase)
-         .truncate(MAX_FIELD)
+         .truncate_bytes(MAX_FIELD)
   end
 end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -21,8 +21,9 @@ class CspReportsController < ActionController::Base
   # Per-value cap in BYTES, applied before the values are joined, so one field cannot spend
   # the whole line and push the rest out. Bytes rather than characters because that is the
   # unit the log is measured and rotated in, and the two are not interchangeable here: a
-  # four-byte codepoint is one character, so a character cap over these nine fields would
-  # admit four times the line it appears to promise. The line is bounded by construction —
+  # four-byte codepoint is one character, so a character cap reads as a far smaller line
+  # than it admits — in practice as much as the MAX_BODY read cap leaves room for, measured
+  # at about 4 KB against the 2.4 KB this one gives. The line is bounded by construction —
   # a fixed set of nine field names, each value at most this many bytes.
   MAX_FIELD = 256
 
@@ -104,7 +105,12 @@ class CspReportsController < ActionController::Base
 
   # Control characters go first: the log is read line by line, so a lone CR in a report
   # would be enough to make one logged violation look like two lines, or to overwrite the
-  # one being written.
+  # one being written, and an ESC sequence can rewrite the line of whoever is reading it in
+  # a terminal. Unicode format characters (category Cf) go with them: they cannot forge or
+  # split a line, but U+202E reverses the display of everything after it, which is the same
+  # harm one category across. The cost is that an emoji ZWJ sequence loses its joiners and
+  # renders as its separate parts; ordinary URIs, non-ASCII paths and percent-encoding are
+  # untouched, which is what these values actually contain.
   def sanitize(value)
     value.to_s
          # Defense in depth, in the same idiom as RackAttackPaths.normalize: text() already
@@ -113,7 +119,7 @@ class CspReportsController < ActionController::Base
          # needing it today. It is here because that is a property of inspect rather than of
          # this class, and because the gsubs below are what raise when it stops being true.
          .scrub('?')
-         .gsub(/[[:cntrl:]]+/, ' ')
+         .gsub(/[[:cntrl:]\p{Cf}]+/, ' ')
          .gsub(CONSTANT_SHAPE, &:downcase)
          .truncate_bytes(MAX_FIELD)
   end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Browsers POST Content-Security-Policy violations here as application/csp-report. It takes
+# no session and no CSRF token, because a browser sends neither with a report — so anyone at
+# all can reach it, and everything it writes is text a stranger chose. All it does is log a
+# fixed set of fields, each of them bounded and neutralised first.
+#
+# ActionController::Base rather than ApplicationController is required, not just tidy:
+# ApplicationController's redirect_to_setup_if_needed would 302 every report to /setup until
+# an admin exists, and switch_locale would touch the database once per report.
+# HealthCheckController and Oauth::DynamicRegistrationController inherit it for the same
+# reason.
+class CspReportsController < ActionController::Base
+  skip_forgery_protection
+
+  # Read cap on the request body. Anything larger is refused and said so, rather than read
+  # to the cap and left to fail as truncated JSON — real reports do exceed this (long
+  # blocked-uris, deep source-file paths), and those are the interesting ones, so they must
+  # not disappear without a trace.
+  MAX_BODY = 4_000
+  # Per-value cap, applied before the values are joined, so one field cannot spend the whole
+  # line and push the rest out. The line is bounded by construction: a fixed set of nine
+  # field names, each value at most this long.
+  MAX_FIELD = 256
+
+  # Never log the whole report body. Per the CSP reporting algorithm the browser strips the
+  # fragment and any credentials from these URLs but KEEPS THE QUERY STRING — and Devise's
+  # reset link is /password/edit?reset_password_token=…, so a violation fired on that page
+  # would otherwise write a live password-reset token into the log.
+  URI_FIELDS = %w[document-uri blocked-uri source-file referrer].freeze
+  SAFE_FIELDS = %w[violated-directive effective-directive disposition status-code line-number].freeze
+
+  # A Rails log is read — by a person skimming `docker logs` and by log scanners alike — as
+  # a stream of lines in which an uppercase-initial, optionally scope-resolved token names
+  # an exception class. Every value logged below is chosen by whoever POSTed the report, so
+  # one shaped like `Foo::BarError` would let an unauthenticated caller invent faults in
+  # someone else's alerting. Downcasing that shape keeps the text readable while removing
+  # its ability to read as a Ruby constant. It does not make the value trustworthy — nothing
+  # here can — it makes it unable to impersonate one.
+  CONSTANT_SHAPE = /[A-Z][A-Za-z0-9_]*(?:::[A-Za-z0-9_]+)*/
+
+  def create
+    report = parsed_report
+    return head :no_content if report.blank?
+
+    fields = SAFE_FIELDS.index_with { |field| report[field] }
+                        .merge(URI_FIELDS.index_with { |field| strip_query(report[field]) })
+                        .compact_blank
+                        .transform_values { |value| sanitize(value) }
+
+    Rails.logger.warn("[csp-violation] #{fields.map { |name, value| "#{name}=#{value}" }.join(' ')}")
+    head :no_content
+  end
+
+  private
+
+  # Valid JSON is not necessarily a report: `null`, `[]` and {"csp-report": []} all parse
+  # fine and would then blow up on Hash access.
+  def parsed_report
+    raw = request.body.read(MAX_BODY + 1).to_s
+    return log_discarded("body over #{MAX_BODY} bytes") if raw.bytesize > MAX_BODY
+
+    body = JSON.parse(raw)
+    return nil unless body.is_a?(Hash)
+
+    report = body['csp-report']
+    report.is_a?(Hash) ? report : nil
+  rescue JSON::ParserError
+    nil
+  end
+
+  def log_discarded(reason)
+    Rails.logger.warn("[csp-violation] discarded: #{reason}")
+    nil
+  end
+
+  # Keep scheme, host and path; drop the query and fragment entirely.
+  def strip_query(value)
+    return nil if value.blank?
+
+    uri = URI.parse(value.to_s)
+    uri.query = nil
+    uri.fragment = nil
+    uri.to_s
+  rescue URI::Error
+    '[unparseable]'
+  end
+
+  # Control characters go first: the log is read line by line, so a lone CR in a report
+  # would be enough to make one logged violation look like two lines, or to overwrite the
+  # one being written.
+  def sanitize(value)
+    value.to_s
+         .gsub(/[[:cntrl:]]+/, ' ')
+         .gsub(CONSTANT_SHAPE, &:downcase)
+         .truncate(MAX_FIELD)
+  end
+end

--- a/app/services/users/verify_otp.rb
+++ b/app/services/users/verify_otp.rb
@@ -10,15 +10,19 @@ module Users
       #
       # Replay protection is unchanged: `after:` keeps only steps strictly later than the one
       # last consumed, so a spent code stays spent. What does change is that a step ahead of the
-      # current one can be consumed, which spends the current one along with it. rotp records the
-      # last candidate that matched, so that is usually the submitted code's own step — a fast
-      # device's — but on the roughly one-in-a-million occasion that two adjacent steps render the
-      # same digits, an ordinary current code records the later of the two.
+      # current one can be consumed, taking the steps in between with it. rotp records the last
+      # candidate that matched, which is usually the submitted code's own step — a fast device's,
+      # say — but when two of the three candidate steps render the same digits, on the order of one
+      # submission in a million, the later of them is recorded instead. A correct clock can trigger
+      # that, and a slow device can end up two steps past the code it actually sent.
       #
-      # The cost is bounded either way: at most one interval passes between spending a step and
-      # the next accepted code, and that code is accepted the second it appears. Outside the
-      # collision case, spending a step ahead takes an attempt that would have been refused
-      # outright before.
+      # None of it can wedge an account, and that is the property worth holding on to: what gets
+      # recorded is never more than one step past the step real time was in, and a device inside
+      # the tolerated skew always shows a code within one step of real time, so the clock alone
+      # clears it — no operator, no reset. How long that takes is deliberately not written down
+      # here. Every attempt to put a number on it has been wrong: it turns on the direction of the
+      # skew and on which of the candidate steps collided, and a freshly displayed code is not
+      # automatically an acceptable one.
       drift = totp.interval
       last_otp_at = totp.verify(code, after: user.last_otp_at, drift_behind: drift, drift_ahead: drift)
       return false if last_otp_at.nil?

--- a/app/services/users/verify_otp.rb
+++ b/app/services/users/verify_otp.rb
@@ -2,7 +2,19 @@ module Users
   class VerifyOtp < BaseService
     def call(user, code)
       totp = ROTP::TOTP.new(user.otp_secret_key)
-      last_otp_at = totp.verify(code, after: user.last_otp_at)
+      # Tolerate one step of clock skew either side of now, so a device whose clock is off by
+      # up to half a minute can still sign in. rotp's drift is in SECONDS, not steps, and it is
+      # applied to the timestamp before that is floored into a step — so the value has to be a
+      # whole interval. A smaller number widens the window during only part of each step, and a
+      # larger one reaches two steps away near a step boundary.
+      #
+      # Replay protection is unchanged: `after:` keeps only steps strictly later than the one
+      # last consumed, so a spent code stays spent. Note that this makes an accepted ahead code
+      # spend the current step AND the next one, since it is the code's own step that is
+      # recorded. A device fast enough to show that code only shows it during the current step,
+      # so the user still waits exactly one code rotation, as they would with no drift at all.
+      drift = totp.interval
+      last_otp_at = totp.verify(code, after: user.last_otp_at, drift_behind: drift, drift_ahead: drift)
       return false if last_otp_at.nil?
 
       user.update(last_otp_at: Time.at(last_otp_at))

--- a/app/services/users/verify_otp.rb
+++ b/app/services/users/verify_otp.rb
@@ -11,8 +11,10 @@ module Users
       # Replay protection is unchanged: `after:` keeps only steps strictly later than the one
       # last consumed, so a spent code stays spent. Note that this makes an accepted ahead code
       # spend the current step AND the next one, since it is the code's own step that is
-      # recorded. A device fast enough to show that code only shows it during the current step,
-      # so the user still waits exactly one code rotation, as they would with no drift at all.
+      # recorded. The device that produced it runs fast, so it keeps showing the spent code into
+      # part of the following step, where it is refused; the next code it shows is accepted the
+      # moment it appears, one rotation after the code was spent. Only an attempt that would
+      # have been refused outright before can spend a step this way.
       drift = totp.interval
       last_otp_at = totp.verify(code, after: user.last_otp_at, drift_behind: drift, drift_ahead: drift)
       return false if last_otp_at.nil?

--- a/app/services/users/verify_otp.rb
+++ b/app/services/users/verify_otp.rb
@@ -9,12 +9,16 @@ module Users
       # larger one reaches two steps away near a step boundary.
       #
       # Replay protection is unchanged: `after:` keeps only steps strictly later than the one
-      # last consumed, so a spent code stays spent. Note that this makes an accepted ahead code
-      # spend the current step AND the next one, since it is the code's own step that is
-      # recorded. The device that produced it runs fast, so it keeps showing the spent code into
-      # part of the following step, where it is refused; the next code it shows is accepted the
-      # moment it appears, one rotation after the code was spent. Only an attempt that would
-      # have been refused outright before can spend a step this way.
+      # last consumed, so a spent code stays spent. What does change is that a step ahead of the
+      # current one can be consumed, which spends the current one along with it. rotp records the
+      # last candidate that matched, so that is usually the submitted code's own step — a fast
+      # device's — but on the roughly one-in-a-million occasion that two adjacent steps render the
+      # same digits, an ordinary current code records the later of the two.
+      #
+      # The cost is bounded either way: at most one interval passes between spending a step and
+      # the next accepted code, and that code is accepted the second it appears. Outside the
+      # collision case, spending a step ahead takes an attempt that would have been refused
+      # outright before.
       drift = totp.interval
       last_otp_at = totp.verify(code, after: user.last_otp_at, drift_behind: drift, drift_ahead: drift)
       return false if last_otp_at.nil?

--- a/app/services/users/verify_otp.rb
+++ b/app/services/users/verify_otp.rb
@@ -11,18 +11,23 @@ module Users
       # Replay protection is unchanged: `after:` keeps only steps strictly later than the one
       # last consumed, so a spent code stays spent. What does change is that a step ahead of the
       # current one can be consumed, taking the steps in between with it. rotp records the last
-      # candidate that matched, which is usually the submitted code's own step — a fast device's,
-      # say — but when two of the three candidate steps render the same digits, on the order of one
-      # submission in a million, the later of them is recorded instead. A correct clock can trigger
-      # that, and a slow device can end up two steps past the code it actually sent.
+      # candidate that matched, which is usually the submitted code's own step; when that step is
+      # ahead of real time the sender is a fast device, and with no drift its code would simply
+      # have been refused — the widening turned a refusal into a sign-in, which is the point of
+      # it. The exception is a collision, on the order of one submission in a million: when the
+      # submitted code's step is one of two candidates rendering the same digits, the later of
+      # them is recorded. It has to be the submitted step that collides — two other candidates
+      # matching each other changes nothing. A correct clock can trigger it, and a slow device
+      # can land two steps past the code it actually sent.
       #
-      # None of it can wedge an account, and that is the property worth holding on to: what gets
-      # recorded is never more than one step past the step real time was in, and a device inside
-      # the tolerated skew always shows a code within one step of real time, so the clock alone
-      # clears it — no operator, no reset. How long that takes is deliberately not written down
-      # here. Every attempt to put a number on it has been wrong: it turns on the direction of the
-      # skew and on which of the candidate steps collided, and a freshly displayed code is not
-      # automatically an acceptable one.
+      # None of it can wedge an account. Two facts bound the wait, both readable off the call
+      # below: the recorded step is never more than one past the step real time was in, because
+      # the candidate list stops there; and a device inside the tolerated skew never shows a code
+      # more than one step from real time, so its own code is always a candidate. Once real time
+      # is two steps past the record, that code sorts later than the record and is accepted — so
+      # the third step after the spend, at the worst, whatever the digits collide with. The clock
+      # alone clears it: no operator, no reset. That is arithmetic on the two facts rather than a
+      # promise; note also that a freshly displayed code is not automatically an acceptable one.
       drift = totp.interval
       last_otp_at = totp.verify(code, after: user.last_otp_at, drift_behind: drift, drift_ahead: drift)
       return false if last_otp_at.nil?

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,9 +37,27 @@ module Deltabadger
     config.time_zone = 'UTC'
     config.active_record.default_timezone = :utc
 
+    # Deployments that terminate TLS in front of the app do not necessarily pass FORCE_SSL,
+    # so the configured root URL is the signal: if the app is reached over https then https
+    # is what it must insist on. A plain-http self-hosted or LAN install keeps its plain
+    # http. FORCE_SSL stays as an explicit override and is cast the way every other boolean
+    # env var in Rails is, so '1' and 'on' mean on rather than "not the string 'true'".
+    def self.force_ssl_from_env(env = ENV)
+      explicit = ActiveModel::Type::Boolean.new.cast(env['FORCE_SSL'])
+      return explicit unless explicit.nil?
+
+      env['APP_ROOT_URL'].to_s.start_with?('https://')
+    end
+
     #cookie
 
-    config.session_store :cookie_store, key: '_deltabadger_session', expire_after: 30.days
+    # secure and same_site both restate what the stack derives on its own today — the
+    # middleware sets secure whenever force_ssl is on, and SameSite=Lax is the default.
+    # Stating them at the declaration keeps the cookie's intent readable and pins it if
+    # either default moves. secure comes from the same signal as force_ssl so that a
+    # plain-http install is not handed a cookie its browser will refuse to send back.
+    config.session_store :cookie_store, key: '_deltabadger_session', expire_after: 30.days,
+                                        secure: force_ssl_from_env, same_site: :lax
 
     config.action_mcp.name = "Deltabadger"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,11 +40,19 @@ module Deltabadger
     # Deployments that terminate TLS in front of the app do not necessarily pass FORCE_SSL,
     # so the configured root URL is the signal: if the app is reached over https then https
     # is what it must insist on. A plain-http self-hosted or LAN install keeps its plain
-    # http. FORCE_SSL stays as an explicit override and is cast the way every other boolean
-    # env var in Rails is, so '1' and 'on' mean on rather than "not the string 'true'".
+    # http, and FORCE_SSL overrides the inference in either direction.
+    #
+    # The spellings are listed out rather than run through ActiveModel::Type::Boolean
+    # because that cast has no verdict for an unrecognised value: its false list is closed,
+    # so 'no' — and every typo — comes back true. On this setting an unrecognised value
+    # must never be able to mean on. Turning SSL on for a plain-http install points every
+    # redirect and every generated URL at a host with no TLS listener, which is a site the
+    # browser cannot reach at all. Anything unrecognised falls through to the root URL,
+    # which is the branch that is secure by default without guessing.
     def self.force_ssl_from_env(env = ENV)
-      explicit = ActiveModel::Type::Boolean.new.cast(env['FORCE_SSL'])
-      return explicit unless explicit.nil?
+      explicit = env['FORCE_SSL'].to_s.strip.downcase
+      return true if %w[1 t true y yes on].include?(explicit)
+      return false if %w[0 f false n no off].include?(explicit)
 
       env['APP_ROOT_URL'].to_s.start_with?('https://')
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,24 +37,51 @@ module Deltabadger
     config.time_zone = 'UTC'
     config.active_record.default_timezone = :utc
 
+    # ENV carries a setting as free text, so a resolver has to rule on what a spelling meant.
+    # The spellings are listed out rather than run through ActiveModel::Type::Boolean
+    # because that cast has no verdict for an unrecognised value: its false list is closed,
+    # so 'no' — and every typo — comes back true. Neither setting below may have an
+    # unrecognised value mean on, so nothing is guessed here: anything unrecognised returns
+    # nil and the caller falls through to what it can infer about the deployment. One list,
+    # so the two resolvers cannot drift into disagreeing about what an operator wrote.
+    def self.env_boolean(value)
+      case value.to_s.strip.downcase
+      when '1', 't', 'true', 'y', 'yes', 'on' then true
+      when '0', 'f', 'false', 'n', 'no', 'off' then false
+      end
+    end
+
     # Deployments that terminate TLS in front of the app do not necessarily pass FORCE_SSL,
     # so the configured root URL is the signal: if the app is reached over https then https
     # is what it must insist on. A plain-http self-hosted or LAN install keeps its plain
     # http, and FORCE_SSL overrides the inference in either direction.
     #
-    # The spellings are listed out rather than run through ActiveModel::Type::Boolean
-    # because that cast has no verdict for an unrecognised value: its false list is closed,
-    # so 'no' — and every typo — comes back true. On this setting an unrecognised value
-    # must never be able to mean on. Turning SSL on for a plain-http install points every
-    # redirect and every generated URL at a host with no TLS listener, which is a site the
-    # browser cannot reach at all. Anything unrecognised falls through to the root URL,
-    # which is the branch that is secure by default without guessing.
+    # Turning SSL on for a plain-http install points every redirect and every generated URL
+    # at a host with no TLS listener, which is a site the browser cannot reach at all — so
+    # anything unrecognised falls through to the root URL, which is the branch that is
+    # secure by default without guessing.
     def self.force_ssl_from_env(env = ENV)
-      explicit = env['FORCE_SSL'].to_s.strip.downcase
-      return true if %w[1 t true y yes on].include?(explicit)
-      return false if %w[0 f false n no off].include?(explicit)
+      explicit = env_boolean(env['FORCE_SSL'])
+      return explicit unless explicit.nil?
 
       env['APP_ROOT_URL'].to_s.start_with?('https://')
+    end
+
+    # Whether something in front of this deployment writes the forwarded-for header, and so
+    # whether that header describes the caller or is only what the caller typed. The
+    # rack-attack throttle key turns on the answer.
+    #
+    # That is the same fact about the deployment force_ssl reads, so it reads the same
+    # signals: nothing here binds Puma to TLS, so an https root URL — or an explicit
+    # FORCE_SSL — means TLS terminates in front, and whatever terminates it is what writes
+    # the header. README's deployment advice is to put nginx or Traefik there for exactly
+    # that reason. BEHIND_PROXY is for the installs where the two facts come apart: true for
+    # a proxy that terminates plain http, false for one that serves TLS from Ruby itself.
+    def self.behind_proxy_from_env(env = ENV)
+      explicit = env_boolean(env['BEHIND_PROXY'])
+      return explicit unless explicit.nil?
+
+      force_ssl_from_env(env)
     end
 
     #cookie

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,10 +40,11 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure
   # cookies. Derived from the configured root URL, so a plain-http self-hosted deployment
-  # is untouched, and FORCE_SSL overrides that inference in either direction. It overrides
-  # the transport only: the mailer, route and asset URLs further down still follow
-  # APP_ROOT_URL, since those describe how the app is reached rather than how this process
-  # is spoken to.
+  # is untouched, and FORCE_SSL overrides that inference in either direction. It reaches
+  # further than the transport: the mailer, route and asset URLs below take their protocol
+  # from APP_ROOT_URL, and FORCE_SSL=true raises that to https as well — so a plain-http
+  # install told to force SSL also emits https links. It is only ever raised, never
+  # lowered: an https APP_ROOT_URL keeps https links whatever FORCE_SSL says.
   #
   # assume_ssl has to move with it. TLS is terminated by the proxy in front of the app, so
   # the two liveness probes reach the app over plain http with no X-Forwarded-Proto: the

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,10 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure
   # cookies. Derived from the configured root URL, so a plain-http self-hosted deployment
-  # is untouched and FORCE_SSL=false remains the escape hatch.
+  # is untouched, and FORCE_SSL overrides that inference in either direction. It overrides
+  # the transport only: the mailer, route and asset URLs further down still follow
+  # APP_ROOT_URL, since those describe how the app is reached rather than how this process
+  # is spoken to.
   #
   # assume_ssl has to move with it. TLS is terminated by the proxy in front of the app, so
   # the two liveness probes reach the app over plain http with no X-Forwarded-Proto: the

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,9 +38,20 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # For self-hosted deployments, SSL can be disabled by not setting FORCE_SSL=true
-  config.force_ssl = ENV['FORCE_SSL'] == 'true'
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure
+  # cookies. Derived from the configured root URL, so a plain-http self-hosted deployment
+  # is untouched and FORCE_SSL=false remains the escape hatch.
+  #
+  # assume_ssl has to move with it. TLS is terminated by the proxy in front of the app, so
+  # the two liveness probes reach the app over plain http with no X-Forwarded-Proto: the
+  # container's own HEALTHCHECK (curl http://localhost:3000/up) and the routing proxy's
+  # /health-check probe. force_ssl on its own answers both with a 301 — which `curl -fsS`
+  # reports as success, so the container looks healthy while the proxy refuses to route to
+  # it. Treating the connection as already-secure applies HSTS and the secure cookie flag
+  # without ever redirecting, and the http-to-https redirect already happens at the proxy.
+  ssl_enabled = Deltabadger::Application.force_ssl_from_env
+  config.assume_ssl = ssl_enabled
+  config.force_ssl = ssl_enabled
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -88,10 +99,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Determine protocol from APP_ROOT_URL or use FORCE_SSL setting
+  # Determine protocol from APP_ROOT_URL, or from the same SSL signal as above so that a
+  # FORCE_SSL of any spelling still produces https links.
   app_root_url = ENV.fetch('APP_ROOT_URL', 'http://localhost:3000')
   default_protocol = app_root_url.start_with?('https://') ? 'https' : 'http'
-  default_protocol = 'https' if ENV['FORCE_SSL'] == 'true'
+  default_protocol = 'https' if ssl_enabled
 
   # Extract host from URL (remove protocol)
   app_host = app_root_url.gsub(/^https?:\/\//, '').gsub(/\/.*$/, '')

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,71 @@
-# Be sure to restart your server when you modify this file.
+# frozen_string_literal: true
 
-# Define an application-wide content security policy.
+# Be sure to restart your server when you modify this file.
+#
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
+#
+# THIS POLICY DOES NOT YET DEFEND AGAINST INJECTED SCRIPT. It ships report-only, and
+# script-src still carries 'unsafe-inline' to keep the app's inline event handlers and
+# inline <script> blocks working. That combination reports; it enforces nothing. It is here
+# to measure real traffic and size the work, and it becomes protection only once the inline
+# handlers have moved into the bundle, 'unsafe-inline' is gone from script-src, and
+# CSP_ENFORCE=true is set.
+#
+# Do NOT restore config.content_security_policy_nonce_generator, which the commented-out
+# default this replaced carried two lines below the policy. A nonce-source or hash-source
+# anywhere in a source list makes browsers ignore 'unsafe-inline' (CSP3, "does element match
+# source list for type and source": allow-all-inline returns "Does Not Allow" when a nonce
+# or hash is present), so adding one would break every inline handler, every inline <script>
+# and every style="" attribute in the app at once, plus the <style> Turbo injects for its
+# progress bar on each navigation. Enabling the policy does make csp_meta_tag start
+# rendering in the three layouts; with no generator it renders an empty tag, which Turbo
+# reads as "no nonce" and ignores.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src     :self
+    policy.font_src        :self, :data
+    policy.img_src         :self, :data, :https
+    policy.object_src      :none
+    policy.base_uri        :self
+    policy.frame_ancestors :none
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+    # form-action is a navigation directive: it is absent from CSP3's "get fetch directive
+    # fallback list", so it inherits nothing from default-src and form submissions are
+    # otherwise unrestricted. No view in this app posts to an external host. With
+    # 'unsafe-inline' conceded on script-src, this is one of the few directives here that
+    # still closes something — an injected <form action="https://evil/">.
+    policy.form_action     :self
+
+    policy.script_src      :self, :unsafe_inline
+    policy.style_src       :self, :unsafe_inline
+
+    # No wss: or ws: on purpose. 'self' already matches wss:// from an https page and ws://
+    # from an http page on the same host and port (CSP3, "does url match expression in
+    # origin with redirect count", step 4.2), so ActionCable's /cable is covered in every
+    # deployment shape this app has. A bare `wss:` is a scheme-source and carries no host
+    # constraint: it would permit a WebSocket to any host on the internet, on the one
+    # directive that bounds where a page can send data. `ws:` is worse — its scheme-part
+    # also matches http and https. If a browser turns out not to implement that 'self'
+    # rule, report-only is what will show it, and the fix is the specific origin.
+    #
+    # ipc: and http://ipc.localhost are Tauri v2's IPC transports. This header governs the
+    # desktop webview too: src-tauri/tauri.conf.json sets "csp": null, so Tauri injects no
+    # policy of its own, and src-tauri/src/lib.rs loads the Rails app itself at
+    # http://127.0.0.1:PORT. Without these, every invoke() — opening an external link, the
+    # CSV export save dialog, dragging the titlebar — is reported, and breaks outright once
+    # the policy is enforced. `ipc:` is a scheme-source with no host constraint, which is
+    # tolerable only because it is a webview-internal custom protocol rather than a way
+    # onto the network; http://ipc.localhost is bound to that host.
+    policy.connect_src     :self, 'ipc:', 'http://ipc.localhost'
+
+    # Relative on purpose: hosted installs each live on their own subdomain, so a report
+    # goes to the origin the page came from. The CSP grammar takes a uri-reference here.
+    policy.report_uri      '/csp-report'
+  end
+
+  # frame-src is deliberately absent. The app embeds no iframes, so it would guard nothing
+  # today, and leaving default-src to catch a future embed is what surfaces one in the
+  # reports rather than letting it through unnoticed.
+  config.content_security_policy_report_only = ENV['CSP_ENFORCE'] != 'true'
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,6 +44,10 @@ module RackAttackPaths
   REGISTER    = %r{\A/oauth/register#{FORMAT}\z}
   TOKEN       = %r{\A/oauth/token#{FORMAT}\z}
   AUTHORIZE   = %r{\A/oauth/authorize#{FORMAT}\z}
+  # The CSP report endpoint is outside the locale scope for the same reason, and takes a
+  # format suffix like everything else. Built here rather than as a literal string so
+  # /csp-report.json lands in the same bucket instead of becoming a free bypass.
+  CSP_REPORT  = %r{\A/csp-report#{FORMAT}\z}
 end
 
 # NOTE ON THE THROTTLE KEY. The key is REMOTE_ADDR — the address the connection was
@@ -126,4 +130,13 @@ end
 
 Rack::Attack.throttle('setup', limit: 5, period: 60) do |req|
   Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::SETUP.match?(RackAttackPaths.normalize(req.path))
+end
+
+# The CSP report endpoint takes an unauthenticated POST and writes a line to the log, so
+# without a bound it is a way to fill the disk and drown everything else in it. What this
+# limit does not do is bound the fleet: behind a CDN the key names the edge that relayed
+# the request, so hosted containers can share one budget of 30 and lose reports to it.
+# Losing reports is the acceptable failure here, and enforcement does not depend on them.
+Rack::Attack.throttle('csp-report', limit: 30, period: 60) do |req|
+  Rack::Attack.client_ip(req) if req.post? && RackAttackPaths::CSP_REPORT.match?(RackAttackPaths.normalize(req.path))
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -46,25 +46,39 @@ module RackAttackPaths
   AUTHORIZE   = %r{\A/oauth/authorize#{FORMAT}\z}
 end
 
-# NOTE ON THE THROTTLE KEY. `action_dispatch.remote_ip` prefers a forwarded-for hop over
-# REMOTE_ADDR, using Rails' trusted-proxy list — loopback, private and link-local ranges by
-# default — to decide which hops to discard. This app configures no `trusted_proxies`, and
-# that cuts both ways.
+# NOTE ON THE THROTTLE KEY. The key is REMOTE_ADDR — the address the connection was
+# accepted from — unless the deployment declares that something in front of it writes the
+# forwarded-for header, in which case that header is what tells callers apart and is read
+# instead. Which of the two applies is Deltabadger::Application.behind_proxy_from_env.
 #
-# Coarse: Cloudflare's published ranges are not in the default list, so hosted traffic
-# arriving through the CDN may collapse onto one throttle key.
+# The choice has to be made here rather than by configuring trusted proxies, because
+# ActionDispatch::RemoteIp has no way to express "ignore the header". calculate_ip ends on
 #
-# Weak, and the direction that matters more: the key is only as trustworthy as whatever
-# writes the forwarded-for header. On a deployment that publishes the container port
-# straight to the network — how the README documents running this — nothing upstream sets
-# or sanitises that header, so the value keyed on here originates with the client and the
-# per-IP limits can be evaded. Behind a proxy that writes the header itself, the key
-# reflects what that proxy saw.
+#   filter_proxies(ips + [remote_addr]).first || ips.last || remote_addr
+#
+# and the trusted list only decides which hops that first call rejects, never whether the
+# header is read. A forwarded address the list does not cover survives the filter and is
+# returned by `.first`, so whatever that list holds, a caller supplies a value outside it
+# and is keyed on its own input. Widening the list does not help: once it also covers
+# REMOTE_ADDR the array empties and `ips.last` hands the forwarded address back regardless.
+# RemoteIp's own header comment says as much — without a proxy the remedy is to drop or
+# ignore these headers before it runs, not to tune the list. Forwarded-for is also not the
+# only header calculate_ip consults, and reading REMOTE_ADDR closes them together rather
+# than one at a time. req.ip is not a usable fallback either: it parses the same headers,
+# less strictly, and will hand back a value that is not an address at all.
+#
+# What that buys is a key the request itself cannot restate. What it does not buy is a key
+# per person: where a proxy is declared the key is only as good as that proxy, and behind a
+# CDN it names the edge that relayed the request rather than whoever sent it. If REMOTE_ADDR
+# is somehow absent the key is a shared constant rather than nil, because a throttle block
+# returning nil makes rack-attack skip the rule outright, so it has to fail closed.
 #
 # The bound that does not depend on IP attribution at all is the per-account one: sign-in,
 # the second factor and password reset are limited on the user row by :lockable.
 def (Rack::Attack).client_ip(req)
-  req.env['action_dispatch.remote_ip']&.to_s.presence || req.ip
+  return req.env['REMOTE_ADDR'].presence || 'unattributed' unless Deltabadger::Application.behind_proxy_from_env
+
+  req.env['action_dispatch.remote_ip']&.to_s.presence || req.env['REMOTE_ADDR'].presence || 'unattributed'
 end
 
 # rack-attack's default response is a bare "Retry later". These rules now match paths this

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,5 +249,9 @@ Rails.application.routes.draw do
   get '/sitemap', to: 'sitemap#index', defaults: {format: 'xml'}
   get '/health-check', to: 'health_check#index', as: :health_check
 
+  # Outside the locale scope: a browser posts a CSP violation report to the report-uri
+  # verbatim, with no session and no locale of its own.
+  post '/csp-report', to: 'csp_reports#create'
+
   # get '*path', to: redirect("/#{I18n.default_locale}")
 end

--- a/test/config/proxy_configuration_test.rb
+++ b/test/config/proxy_configuration_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+# The rack-attack throttles key on a forwarded-for header only where something in front of
+# the app writes one. Where nothing does, that header is caller-supplied and keying on it
+# lets a caller pick a fresh bucket per request, which bounds nothing at all. This resolver
+# is what tells the two cases apart, so the direction it errs in matters: an install wrongly
+# read as proxied is back to an unbounded limit, while one wrongly read as direct keys on
+# REMOTE_ADDR and is merely coarse.
+class ProxyConfigurationTest < ActiveSupport::TestCase
+  def behind_proxy_for(env)
+    Deltabadger::Application.behind_proxy_from_env(env)
+  end
+
+  test 'declared by an explicit BEHIND_PROXY' do
+    assert behind_proxy_for('BEHIND_PROXY' => 'true', 'APP_ROOT_URL' => 'http://localhost:3737')
+  end
+
+  test 'declared when the configured root URL is https' do
+    assert behind_proxy_for('APP_ROOT_URL' => 'https://alice.deltabadger.com')
+  end
+
+  # This is the shipped self-hosted default: docker-compose publishes the container port
+  # straight to the network with APP_ROOT_URL=http://localhost:3737 and nothing in front.
+  test 'not declared for a plain-http self-hosted install' do
+    refute behind_proxy_for('APP_ROOT_URL' => 'http://192.168.1.10:3737')
+  end
+
+  test 'not declared when nothing is configured' do
+    refute behind_proxy_for({})
+  end
+
+  test 'an explicit BEHIND_PROXY=false wins over an https root URL' do
+    refute behind_proxy_for('BEHIND_PROXY' => 'false', 'APP_ROOT_URL' => 'https://x.test')
+  end
+
+  # FORCE_SSL is the documented knob for a root URL that is not https (.env.docker.example),
+  # which describes an operator who put a TLS proxy in front and left APP_ROOT_URL alone.
+  # Nothing in this repo binds Puma to TLS, so SSL forced on top of a plain-http root URL
+  # means the TLS is somebody else's and that somebody is in the request path.
+  test 'declared by an explicit FORCE_SSL over a plain-http root URL' do
+    assert behind_proxy_for('FORCE_SSL' => 'true', 'APP_ROOT_URL' => 'http://localhost:3737')
+  end
+
+  test 'an explicit BEHIND_PROXY wins over FORCE_SSL' do
+    refute behind_proxy_for('BEHIND_PROXY' => 'no', 'FORCE_SSL' => 'true', 'APP_ROOT_URL' => 'https://x.test')
+    assert behind_proxy_for('BEHIND_PROXY' => 'yes', 'FORCE_SSL' => 'false', 'APP_ROOT_URL' => 'http://x.test')
+  end
+
+  # Same list as FORCE_SSL, because the two settings are read by one another's helper and an
+  # operator has no reason to expect them to accept different words.
+  test 'an explicit BEHIND_PROXY accepts the usual spellings of on' do
+    %w[true True TRUE 1 t y yes YES on ON].each do |value|
+      assert behind_proxy_for('BEHIND_PROXY' => value, 'APP_ROOT_URL' => 'http://localhost:3737'),
+             "BEHIND_PROXY=#{value} must declare a proxy"
+    end
+  end
+
+  test 'an explicit BEHIND_PROXY accepts the usual spellings of off' do
+    %w[false False FALSE 0 f n no NO off OFF].each do |value|
+      refute behind_proxy_for('BEHIND_PROXY' => value, 'APP_ROOT_URL' => 'https://x.test'),
+             "BEHIND_PROXY=#{value} must not declare a proxy"
+    end
+  end
+
+  # An unrecognised value carries no intent to honour. Reading it as on is the direction that
+  # costs something: it would hand the throttle key back to the caller on an install that
+  # wrote a typo, so it falls through to what the deployment says about itself instead.
+  test 'an unrecognised BEHIND_PROXY falls through to the deployment signals' do
+    ['maybe', 'oui', '2', '-1', '', '   '].each do |value|
+      assert behind_proxy_for('BEHIND_PROXY' => value, 'APP_ROOT_URL' => 'https://x.test'),
+             "BEHIND_PROXY=#{value.inspect} must not override an https root URL"
+      refute behind_proxy_for('BEHIND_PROXY' => value, 'APP_ROOT_URL' => 'http://x.test'),
+             "BEHIND_PROXY=#{value.inspect} must not override a plain-http root URL"
+    end
+  end
+
+  test 'the local environment resolves to no declared proxy' do
+    refute Deltabadger::Application.behind_proxy_from_env,
+           'a local run has nothing in front of it — check APP_ROOT_URL/FORCE_SSL/BEHIND_PROXY in .env'
+  end
+end

--- a/test/config/ssl_configuration_test.rb
+++ b/test/config/ssl_configuration_test.rb
@@ -34,22 +34,49 @@ class SslConfigurationTest < ActiveSupport::TestCase
   # 'true' reads every other spelling as "explicitly off" and silently downgrades an https
   # deployment — the exact opposite of what was asked for.
   test 'an explicit FORCE_SSL accepts the usual spellings of on' do
-    %w[true TRUE 1 yes on t].each do |value|
+    %w[true True TRUE 1 t y yes YES on ON].each do |value|
       assert force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'http://localhost:3000'),
              "FORCE_SSL=#{value} must enable SSL"
     end
   end
 
   test 'an explicit FORCE_SSL accepts the usual spellings of off' do
-    %w[false FALSE 0 off f].each do |value|
+    %w[false False FALSE 0 f n no NO off OFF].each do |value|
       refute force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'https://x.test'),
              "FORCE_SSL=#{value} must disable SSL"
     end
   end
 
+  # 'no' is the one that bites. It is missing from Rails' boolean FALSE_VALUES, so a cast
+  # reads it as on — and on a plain-http install that is not a degraded site but a dead
+  # one: with the connection assumed secure, every redirect and every *_url helper points
+  # at https on a host with no TLS listener, so the browser cannot connect at all.
+  test 'an explicit FORCE_SSL=no keeps a plain-http install on plain http' do
+    %w[no No NO n].each do |value|
+      refute force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'http://192.168.1.10:3737'),
+             "FORCE_SSL=#{value} must not turn SSL on"
+    end
+  end
+
+  # An unrecognised value carries no intent to honour, so it must not decide either way.
+  # It falls through to the root URL — the secure-by-default branch. Reading it as false
+  # would be the mirror image of the bug above.
+  test 'an unrecognised FORCE_SSL falls through to the root URL' do
+    %w[maybe oui 2 -1].each do |value|
+      assert force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'https://x.test'),
+             "FORCE_SSL=#{value} must not override an https root URL"
+      refute force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'http://x.test'),
+             "FORCE_SSL=#{value} must not override a plain-http root URL"
+    end
+  end
+
   test 'a blank FORCE_SSL falls through to the root URL' do
-    assert force_ssl_for('FORCE_SSL' => '', 'APP_ROOT_URL' => 'https://x.test')
-    refute force_ssl_for('FORCE_SSL' => '', 'APP_ROOT_URL' => 'http://x.test')
+    ['', '   '].each do |value|
+      assert force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'https://x.test'),
+             "FORCE_SSL=#{value.inspect} must not override an https root URL"
+      refute force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'http://x.test'),
+             "FORCE_SSL=#{value.inspect} must not override a plain-http root URL"
+    end
   end
 
   # Rack::Test will not replay a Secure cookie over http, so an https root URL in a local

--- a/test/config/ssl_configuration_test.rb
+++ b/test/config/ssl_configuration_test.rb
@@ -1,0 +1,149 @@
+require 'test_helper'
+require 'tmpdir'
+
+# SSL used to hang off FORCE_SSL alone. Nothing in the shipped deployment tooling sets it,
+# so https deployments ran with no HSTS and no Secure flag on a 30-day session cookie.
+# It is now derived from the configured root URL, with FORCE_SSL kept as an explicit
+# override in both directions.
+class SslConfigurationTest < ActiveSupport::TestCase
+  def force_ssl_for(env)
+    Deltabadger::Application.force_ssl_from_env(env)
+  end
+
+  test 'enabled by an explicit FORCE_SSL' do
+    assert force_ssl_for('FORCE_SSL' => 'true', 'APP_ROOT_URL' => 'http://localhost:3000')
+  end
+
+  test 'enabled when the configured root URL is https' do
+    assert force_ssl_for('APP_ROOT_URL' => 'https://alice.deltabadger.com')
+  end
+
+  test 'disabled for a plain-http self-hosted install' do
+    refute force_ssl_for('APP_ROOT_URL' => 'http://192.168.1.10:3737')
+  end
+
+  test 'disabled when nothing is configured' do
+    refute force_ssl_for({})
+  end
+
+  test 'an explicit FORCE_SSL=false wins over an https root URL' do
+    refute force_ssl_for('FORCE_SSL' => 'false', 'APP_ROOT_URL' => 'https://x.test')
+  end
+
+  # An operator who writes FORCE_SSL=1 means "on". Comparing against the literal string
+  # 'true' reads every other spelling as "explicitly off" and silently downgrades an https
+  # deployment — the exact opposite of what was asked for.
+  test 'an explicit FORCE_SSL accepts the usual spellings of on' do
+    %w[true TRUE 1 yes on t].each do |value|
+      assert force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'http://localhost:3000'),
+             "FORCE_SSL=#{value} must enable SSL"
+    end
+  end
+
+  test 'an explicit FORCE_SSL accepts the usual spellings of off' do
+    %w[false FALSE 0 off f].each do |value|
+      refute force_ssl_for('FORCE_SSL' => value, 'APP_ROOT_URL' => 'https://x.test'),
+             "FORCE_SSL=#{value} must disable SSL"
+    end
+  end
+
+  test 'a blank FORCE_SSL falls through to the root URL' do
+    assert force_ssl_for('FORCE_SSL' => '', 'APP_ROOT_URL' => 'https://x.test')
+    refute force_ssl_for('FORCE_SSL' => '', 'APP_ROOT_URL' => 'http://x.test')
+  end
+
+  # Rack::Test will not replay a Secure cookie over http, so an https root URL in a local
+  # .env turns into a pile of unexplained session failures elsewhere in the suite. Fail
+  # here instead, where the cause is named.
+  test 'the local environment resolves to plain http' do
+    refute Deltabadger::Application.force_ssl_from_env,
+           'a local run must not force SSL — check APP_ROOT_URL/FORCE_SSL in .env'
+  end
+
+  # The resolver passing says nothing about whether production consumes it: the resolver,
+  # the production.rb assignment and the cookie options are three separate edits. Boot a
+  # real production environment and read the end state.
+  test 'a production boot with an https root URL forces SSL and secures the cookie' do
+    config = boot_production('APP_ROOT_URL' => 'https://x.test')
+
+    assert config['force_ssl'], 'production with an https APP_ROOT_URL must force SSL'
+    assert config['secure'], 'the session cookie must carry Secure'
+    # secure is set by the middleware stack on its own whenever force_ssl is on, so it
+    # cannot show whether the cookie options were written. same_site can: left alone it
+    # is a per-request Proc, which serialises to {}.
+    assert_equal 'lax', config['same_site'],
+                 'the cookie options must be written explicitly, not left to the default'
+  end
+
+  # force_ssl answers any request it believes is plaintext with a 301, and both health
+  # endpoints are exactly that — the container's own HEALTHCHECK curl and the routing
+  # proxy's probe reach the app over plain http with no forwarded-proto header. Neither
+  # notices: `curl -fsS` exits 0 on a 301, so the container reports healthy while the
+  # proxy refuses to route to it. assume_ssl is what keeps them at 200.
+  test 'a production boot leaves the health endpoints unredirected' do
+    config = boot_production('APP_ROOT_URL' => 'https://x.test')
+
+    assert_equal 200, config['up_status'],
+                 '/up must answer a plain-http probe with 200, not a redirect'
+    assert_equal 200, config['health_check_status'],
+                 '/health-check must answer a plain-http probe with 200, not a redirect'
+    assert config['assume_ssl'], 'assume_ssl must be enabled alongside force_ssl'
+  end
+
+  # A plain-http self-hosted install must be untouched — a Secure cookie over http locks
+  # the owner out of their own instance.
+  test 'a production boot with a plain-http root URL leaves the connection alone' do
+    config = boot_production('APP_ROOT_URL' => 'http://192.168.1.10:3737')
+
+    refute config['force_ssl']
+    refute config['assume_ssl']
+    refute config['secure']
+  end
+
+  private
+
+  def boot_production(env)
+    script = <<~'RUBY'
+      require ENV.fetch('BOOT_FILE')
+      require 'rack/mock'
+
+      app = Rails.application
+      options = app.config.session_options
+      status = ->(path) { app.call(Rack::MockRequest.env_for("http://x.test#{path}")).first }
+
+      puts "SSL_CONFIG_JSON#{{
+        force_ssl: app.config.force_ssl,
+        assume_ssl: app.config.assume_ssl,
+        secure: options[:secure],
+        same_site: options[:same_site],
+        up_status: status.call('/up'),
+        health_check_status: status.call('/health-check')
+      }.to_json}"
+    RUBY
+
+    output = Dir.mktmpdir do |dir|
+      IO.popen(
+        boot_env(dir).merge(env), ['ruby', '-e', script],
+        chdir: Rails.root.to_s, err: %i[child out], &:read
+      )
+    end
+
+    json = output[/^SSL_CONFIG_JSON(.*)$/, 1]
+    assert json, "the production boot reported no configuration:\n#{output}"
+    JSON.parse(json)
+  end
+
+  # A nil value is how IO.popen unsets an inherited variable: SECRET_KEY_BASE_DUMMY is
+  # consulted ahead of SECRET_KEY_BASE, so an inherited one would win over the real key.
+  def boot_env(dir)
+    { 'RAILS_ENV' => 'production',
+      'BOOT_FILE' => Rails.root.join('config/environment').to_s,
+      'RAILS_LOG_TO_STDOUT' => 'true',
+      'SECRET_KEY_BASE' => SecureRandom.hex(64),
+      'SECRET_KEY_BASE_DUMMY' => nil,
+      'DATABASE_PATH' => File.join(dir, 'production.sqlite3'),
+      'QUEUE_DATABASE_PATH' => File.join(dir, 'production_queue.sqlite3'),
+      'CACHE_DATABASE_PATH' => File.join(dir, 'production_cache.sqlite3'),
+      'CABLE_DATABASE_PATH' => File.join(dir, 'production_cable.sqlite3') }
+  end
+end

--- a/test/config/ssl_configuration_test.rb
+++ b/test/config/ssl_configuration_test.rb
@@ -162,12 +162,20 @@ class SslConfigurationTest < ActiveSupport::TestCase
 
   # A nil value is how IO.popen unsets an inherited variable: SECRET_KEY_BASE_DUMMY is
   # consulted ahead of SECRET_KEY_BASE, so an inherited one would win over the real key.
+  #
+  # FORCE_SSL and BEHIND_PROXY are unset for the same reason and a sharper one: they are the
+  # two variables these tests exist to measure, and they are also the two this repo now tells
+  # operators to export. A developer with either set in their shell would otherwise have it
+  # inherited by the boot below and watch tests fail over their own environment rather than
+  # over the code. Same intent as the deletions at the top of test_helper.rb.
   def boot_env(dir)
     { 'RAILS_ENV' => 'production',
       'BOOT_FILE' => Rails.root.join('config/environment').to_s,
       'RAILS_LOG_TO_STDOUT' => 'true',
       'SECRET_KEY_BASE' => SecureRandom.hex(64),
       'SECRET_KEY_BASE_DUMMY' => nil,
+      'FORCE_SSL' => nil,
+      'BEHIND_PROXY' => nil,
       'DATABASE_PATH' => File.join(dir, 'production.sqlite3'),
       'QUEUE_DATABASE_PATH' => File.join(dir, 'production_queue.sqlite3'),
       'CACHE_DATABASE_PATH' => File.join(dir, 'production_cache.sqlite3'),

--- a/test/controllers/csp_reports_controller_test.rb
+++ b/test/controllers/csp_reports_controller_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CspReportsControllerTest < ActionDispatch::IntegrationTest
+  def report(body)
+    post_body(body.to_json)
+  end
+
+  def post_body(raw)
+    post '/csp-report', params: raw, headers: { 'CONTENT_TYPE' => 'application/csp-report' }
+  end
+
+  # Capture what actually reached the logger. Mocha replaces the singleton method on the
+  # very object the controller calls; the block always matches, so nothing is filtered out
+  # on the way in and the assertions can do the filtering instead.
+  def violations
+    lines = []
+    Rails.logger.stubs(:warn).with { |message| lines << message.to_s }
+    yield
+    lines.grep(/\[csp-violation\]/)
+  end
+
+  # allow_forgery_protection is false in the test environment, so a test that only posts a
+  # report and checks the status stays green with skip_forgery_protection deleted — and a
+  # browser sends no CSRF token with a violation report, so in production that deletion
+  # would 422 every one of them. Turning protection back on for the duration is what makes
+  # this cover the production path. The log assertion is the second half: a controller that
+  # did nothing but `head :no_content` would satisfy the status on its own.
+  test 'accepts a report with no session and no CSRF token, and logs it' do
+    ActionController::Base.allow_forgery_protection = true
+
+    lines = violations do
+      report('csp-report' => { 'blocked-uri' => 'inline', 'violated-directive' => 'script-src' })
+    end
+
+    assert_response :no_content
+    assert_equal ['[csp-violation] violated-directive=script-src blocked-uri=inline'], lines
+  ensure
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  # Per the CSP reporting algorithm the browser strips the fragment and any credentials
+  # from these URLs but keeps the query string, and Devise's reset link is
+  # /password/edit?reset_password_token=… — so a violation fired on that page would write a
+  # live password-reset token into the log.
+  test 'never logs a password-reset token from document-uri' do
+    lines = violations do
+      report('csp-report' => {
+               'document-uri' => 'https://x.test/password/edit?reset_password_token=SEKRIT',
+               'violated-directive' => 'script-src'
+             })
+    end
+
+    assert_equal 1, lines.size
+    refute_includes lines.first, 'SEKRIT'
+  end
+
+  test 'keeps the path so the report is still useful' do
+    lines = violations do
+      report('csp-report' => { 'document-uri' => 'https://x.test/password/edit?reset_password_token=SEKRIT' })
+    end
+
+    assert_includes lines.first, '/password/edit'
+  end
+
+  # The endpoint is unauthenticated, so every value in the line below is text a stranger
+  # chose. A lone CR is enough to make one logged report look like two log lines.
+  test 'collapses control characters so a report cannot forge a log line' do
+    lines = violations { report('csp-report' => { 'violated-directive' => "script-src\r\ninjected" }) }
+
+    assert_equal 1, lines.size
+    refute_match(/[[:cntrl:]]/, lines.first)
+  end
+
+  # The inverse of forging a line: poisoning the one that is written. A Rails log is read —
+  # by a person skimming `docker logs` and by log scanners alike — as a stream in which an
+  # uppercase-initial, optionally scope-resolved token names an exception class. Left
+  # as-is, an unauthenticated caller could plant exceptions that never happened into
+  # somebody's alerting, which is worse than noise: it is noise that looks like a fault.
+  test 'a report cannot make the log line read as a Ruby exception' do
+    lines = violations do
+      report('csp-report' => {
+               'blocked-uri' => 'https://evil.test/ActiveRecord::StatementInvalid',
+               'violated-directive' => 'Net::ReadTimeout',
+               'effective-directive' => 'SomeUnscopedError here'
+             })
+    end
+
+    line = lines.first
+    refute_match(/[A-Z][A-Za-z0-9_]*::/, line, 'a scope-resolved constant survived')
+    refute_match(/[A-Z][A-Za-z]*(?:Error|Exception)/, line, 'an exception-shaped token survived')
+    assert_includes line, 'statementinvalid', 'the value still has to be readable'
+  end
+
+  test 'one field cannot spend the whole log line' do
+    lines = violations do
+      report('csp-report' => { 'blocked-uri' => "https://evil.test/#{'a' * 3_000}",
+                               'violated-directive' => 'script-src' })
+    end
+
+    blocked = lines.first[/blocked-uri=(\S*)/, 1]
+    assert_operator blocked.length, :<=, CspReportsController::MAX_FIELD
+    assert_includes lines.first, 'violated-directive=script-src',
+                    'a long field must not push the other fields out'
+  end
+
+  # Both halves matter. Valid JSON is not necessarily a report — `null`, `[]` and
+  # {"csp-report": []} all parse and would then blow up on Hash access — but a controller
+  # that did nothing at all would also return 204 to every one of these, so the discards
+  # only mean something standing next to a well-formed report that does get written.
+  test 'a malformed or wrongly-shaped body is discarded quietly, but a real one is not' do
+    ['not json', '', 'null', '[]', '"a string"', '{"csp-report":[]}', '{"csp-report":null}'].each do |body|
+      lines = violations { post_body(body) }
+
+      assert_response :no_content, "#{body.inspect} should be discarded quietly"
+      assert_empty lines, "#{body.inspect} should not reach the log"
+    end
+
+    lines = violations { report('csp-report' => { 'blocked-uri' => 'inline' }) }
+    assert_equal ['[csp-violation] blocked-uri=inline'], lines
+  end
+
+  # MAX_BODY is a read cap, so an oversized report truncates mid-JSON, fails to parse and
+  # is dropped — and the biggest reports are the interesting ones. Dropping them is
+  # defensible; dropping them with nothing written at all, in an endpoint whose entire job
+  # is telemetry, is not.
+  test 'an oversized report is refused visibly rather than dropped in silence' do
+    padding = 'a' * (CspReportsController::MAX_BODY + 1_000)
+    lines = violations { report('csp-report' => { 'blocked-uri' => padding }) }
+
+    assert_response :no_content
+    assert_equal 1, lines.size
+    assert_match(/discarded/, lines.first)
+  end
+end

--- a/test/controllers/csp_reports_controller_test.rb
+++ b/test/controllers/csp_reports_controller_test.rb
@@ -181,15 +181,36 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
     assert_includes lines.first, 'wiped', 'the value still has to be readable'
   end
 
-  # A character cap is not a byte cap: one four-byte codepoint is a single character, so
-  # nine fields capped by character reach four times the byte budget the cap reads as. The
-  # cap is on bytes, and truncation has to land on a character boundary rather than
-  # splitting one and producing the invalid encoding the test above is about.
+  # A character cap is not a byte cap: one four-byte codepoint is a single character, so a
+  # character cap admits a bigger line than it reads as — bounded in practice by the
+  # MAX_BODY read cap rather than by itself, measured at about 4 KB against the 2.4 KB the
+  # byte cap gives. The cap is on bytes, and truncation has to land on a character boundary
+  # rather than splitting one and producing the invalid encoding the tests above are about.
   test 'the line is bounded in bytes, not just in characters' do
     lines = violations { report('csp-report' => { 'violated-directive' => '𝔘' * 800 }) }
 
     directive = lines.first[/violated-directive=(\S*)/, 1]
     assert_operator directive.bytesize, :<=, CspReportsController::MAX_FIELD
     assert directive.valid_encoding?, 'truncation must not split a multi-byte character'
+  end
+
+  # One Unicode category across from the control characters above, and [[:cntrl:]] matches
+  # none of it: U+202E reverses the display of everything after it, so a value carrying one
+  # rewrites how the rest of the line reads to whoever is looking at the log in a terminal.
+  # It cannot forge or split a line the way a CR can, which is why it is a smaller problem
+  # than that one and a real one anyway. Built from codepoints deliberately: a literal RLO
+  # committed into this file would reverse the source that follows it, here and in review.
+  test 'unicode format characters are stripped as well' do
+    lines = violations do
+      rlo = 0x202E.chr(Encoding::UTF_8) # right-to-left override
+      zwj = 0x200D.chr(Encoding::UTF_8) # zero-width joiner
+      bom = 0xFEFF.chr(Encoding::UTF_8)
+
+      report('csp-report' => { 'violated-directive' => "script-src #{rlo}reversed#{zwj}#{bom}" })
+    end
+
+    assert_equal 1, lines.size
+    refute_match(/\p{Cf}/, lines.first)
+    assert_includes lines.first, 'reversed', 'the value still has to be readable'
   end
 end

--- a/test/controllers/csp_reports_controller_test.rb
+++ b/test/controllers/csp_reports_controller_test.rb
@@ -21,12 +21,14 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
     lines.grep(/\[csp-violation\]/)
   end
 
-  # allow_forgery_protection is false in the test environment, so a test that only posts a
-  # report and checks the status stays green with skip_forgery_protection deleted — and a
-  # browser sends no CSRF token with a violation report, so in production that deletion
-  # would 422 every one of them. Turning protection back on for the duration is what makes
-  # this cover the production path. The log assertion is the second half: a controller that
-  # did nothing but `head :no_content` would satisfy the status on its own.
+  # A browser sends no CSRF token with a violation report, so any token check here would 422
+  # every real one. allow_forgery_protection is false in the test environment, which would
+  # hide a controller that had grown one — so it is turned back on for the duration, and the
+  # 204 below is the production path rather than a test-environment courtesy. The controller
+  # inherits ActionController::API, which carries no forgery protection for that switch to
+  # reach; the switch stays because the property has to hold whatever the base class is. The
+  # log assertion is the second half: a controller that did nothing but `head :no_content`
+  # would satisfy the status on its own.
   test 'accepts a report with no session and no CSRF token, and logs it' do
     ActionController::Base.allow_forgery_protection = true
 

--- a/test/controllers/csp_reports_controller_test.rb
+++ b/test/controllers/csp_reports_controller_test.rb
@@ -133,4 +133,63 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, lines.size
     assert_match(/discarded/, lines.first)
   end
+
+  # JSON.parse hands back a String tagged UTF-8 whose bytes need not be valid UTF-8: a lone
+  # surrogate escape is legal JSON, and the body carrying one is pure ASCII, so nothing
+  # upstream rejects it. Every blank? and every regex the controller runs then raises
+  # ArgumentError. That is worse here than ordinary fragility — it is the inverse of the
+  # neutralising above: a caller who cannot forge an exception through the sanitised path
+  # would instead raise a real one, and each 500 writes a backtrace into the very log this
+  # controller exists to keep tidy. Every logged field is probed, plus a key that is not
+  # one, because any of them can carry it.
+  test 'a field whose bytes are not valid UTF-8 does not raise' do
+    logged = CspReportsController::SAFE_FIELDS + CspReportsController::URI_FIELDS
+
+    (logged + ['not-a-field']).each do |field|
+      lines = violations { post_body(%({"csp-report":{"#{field}":"x\\ud800y"}})) }
+
+      assert_response :no_content, "an invalid byte sequence in #{field} must not raise"
+      assert_equal(logged.include?(field) ? 1 : 0, lines.size,
+                   "#{field} produced the wrong number of log lines")
+      refute_match(/[[:cntrl:]]/, lines.first.to_s)
+    end
+  end
+
+  # The other way in. A raw invalid byte in the body is not rejected either: JSON.parse
+  # accepts it and hands back the same invalid-encoding String.
+  test 'a raw invalid byte in the request body does not raise' do
+    lines = violations do
+      post_body(%({"csp-report":{"blocked-uri":"x\xFFy","violated-directive":"script-src"}}).b)
+    end
+
+    assert_response :no_content
+    assert_equal 1, lines.size
+    assert_includes lines.first, 'violated-directive=script-src'
+  end
+
+  # CR and LF are themselves control characters, so a test that injects only those and then
+  # asserts no control character survived is equally satisfied by a scrub that knows about
+  # nothing else. NUL, ESC, BEL and DEL are what tell the two apart — and an ESC sequence
+  # in a logged value can rewrite the line of whoever is reading the log in a terminal.
+  test 'control characters beyond CR and LF are stripped too' do
+    lines = violations do
+      report('csp-report' => { 'violated-directive' => "script-src \e[2Kwiped" })
+    end
+
+    assert_equal 1, lines.size
+    refute_match(/[[:cntrl:]]/, lines.first)
+    assert_includes lines.first, 'wiped', 'the value still has to be readable'
+  end
+
+  # A character cap is not a byte cap: one four-byte codepoint is a single character, so
+  # nine fields capped by character reach four times the byte budget the cap reads as. The
+  # cap is on bytes, and truncation has to land on a character boundary rather than
+  # splitting one and producing the invalid encoding the test above is about.
+  test 'the line is bounded in bytes, not just in characters' do
+    lines = violations { report('csp-report' => { 'violated-directive' => '𝔘' * 800 }) }
+
+    directive = lines.first[/violated-directive=(\S*)/, 1]
+    assert_operator directive.bytesize, :<=, CspReportsController::MAX_FIELD
+    assert directive.valid_encoding?, 'truncation must not split a multi-byte character'
+  end
 end

--- a/test/controllers/users/passwords_controller_two_factor_test.rb
+++ b/test/controllers/users/passwords_controller_two_factor_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class Users::PasswordsControllerTwoFactorTest < ActionDispatch::IntegrationTest
-  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with
-  # its defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the
-  # exact 30-second step it was minted in. On a live clock that step can tick over between
-  # ROTP::TOTP#now and the request carrying the code, failing a test for a reason that has
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with one
+  # step of drift either side, so a code survives one 30-second rollover between ROTP::TOTP#now
+  # and the request carrying it, and is refused once a second rollover passes. On a live clock
+  # nothing bounds how many a slow run crosses, which would fail a test for a reason that has
   # nothing to do with what it asserts — worst for the tests that carry one code across two
   # request cycles. Rails restores the clock in after_teardown.
   #

--- a/test/controllers/users/sessions_controller_two_factor_test.rb
+++ b/test/controllers/users/sessions_controller_two_factor_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
 
 class Users::SessionsControllerTwoFactorTest < ActionDispatch::IntegrationTest
-  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with its
-  # defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the exact
-  # 30-second step it was minted in, and on a live clock that step can tick over between
-  # ROTP::TOTP#now and the request carrying the code. Rails restores the clock in
-  # after_teardown, and the expiry test below still travels explicitly from this baseline.
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with one
+  # step of drift either side, so a code survives one 30-second rollover between ROTP::TOTP#now
+  # and the request carrying it — but not two, and on a live clock nothing bounds how many a
+  # slow run crosses. Rails restores the clock in after_teardown, and the expiry test below
+  # still travels explicitly from this baseline.
   setup do
     freeze_time
     create(:user, admin: true, setup_completed: true)

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -5,9 +5,11 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
   # step of drift either side, so a code survives one 30-second rollover but not two, and the
   # OTP tests below carry one code across request cycles. Enough rollovers mid-test would fail
   # them for a reason unrelated to what they assert, and — now that a wrong code increments the
-  # persisted counter — could carry that failure into the next test in the class. Nothing here
-  # needs the clock to move on its own; the lockout tests travel explicitly, which still works
-  # from a frozen base. Rails restores the clock in after_teardown.
+  # persisted counter — would spend an attempt from the budget the lockout tests are counting.
+  # It goes no further than the test it happens in: use_transactional_tests rolls the counter
+  # back and each test builds its own user. Nothing here needs the clock to move on its own;
+  # the lockout tests travel explicitly, which still works from a frozen base. Rails restores
+  # the clock in after_teardown.
   setup do
     freeze_time
     @admin = create(:user, admin: true)

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -1,14 +1,13 @@
 require 'test_helper'
 
 class AuthenticationTest < ActionDispatch::IntegrationTest
-  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with its
-  # defaults (drift_ahead: 0, drift_behind: 0), so a code is only accepted inside the exact
-  # 30-second step it was minted in, and the OTP tests below carry one code across request
-  # cycles. A step rolling over mid-test would fail them for a reason unrelated to what they
-  # assert, and — now that a wrong code increments the persisted counter — could carry that
-  # failure into the next test in the class. Nothing here needs the clock to move on its own;
-  # the lockout tests travel explicitly, which still works from a frozen base. Rails restores
-  # the clock in after_teardown.
+  # The clock is frozen for the whole class. Users::VerifyOtp verifies through ROTP with one
+  # step of drift either side, so a code survives one 30-second rollover but not two, and the
+  # OTP tests below carry one code across request cycles. Enough rollovers mid-test would fail
+  # them for a reason unrelated to what they assert, and — now that a wrong code increments the
+  # persisted counter — could carry that failure into the next test in the class. Nothing here
+  # needs the clock to move on its own; the lockout tests travel explicitly, which still works
+  # from a frozen base. Rails restores the clock in after_teardown.
   setup do
     freeze_time
     @admin = create(:user, admin: true)

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  # The whole header, in order. Pinning the string rather than a few substrings is the
+  # point: a directive that quietly widens (a bare scheme-source added to connect-src, say)
+  # still passes every "assert_includes" written against it.
+  EXPECTED = "default-src 'self'; font-src 'self' data:; img-src 'self' data: https:; " \
+             "object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; " \
+             "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; " \
+             "connect-src 'self' ipc: http://ipc.localhost; report-uri /csp-report"
+
+  setup { @admin = create(:user, admin: true, setup_completed: true) }
+
+  # Report-only is the shipped disposition and this test says so on purpose: with
+  # script-src carrying 'unsafe-inline' the policy reports, it does not defend.
+  test 'emits a report-only policy on an unauthenticated page' do
+    get '/en/login'
+
+    assert_response :success
+    assert_nil response.headers['Content-Security-Policy'],
+               'nothing is enforced yet; the header must be the report-only one'
+    assert_equal EXPECTED, response.headers['Content-Security-Policy-Report-Only']
+  end
+
+  # Stands in for the manual click-through. The header comes from middleware, so what is
+  # worth pinning is that it survives on the pages people actually sit on, including one
+  # rendered by a controller that does not inherit ApplicationController (/up).
+  test 'every representative page carries the same policy' do
+    sign_in @admin
+
+    ['/en/bots', '/en/tracker', '/en/settings/connect', '/health-check', '/up'].each do |path|
+      get path
+
+      assert_response :success, "#{path} did not render"
+      assert_equal EXPECTED, response.headers['Content-Security-Policy-Report-Only'],
+                   "#{path} carried no policy, or a different one"
+    end
+  end
+
+  # A nonce-source or hash-source anywhere in a source list makes browsers ignore
+  # 'unsafe-inline' (CSP3 "does element match source list", allow-all-inline), which would
+  # take out every inline handler, inline <script> block and style="" attribute at once.
+  # The commented-out initializer this replaces shipped the two nonce lines a keystroke
+  # away, so the absence is pinned rather than assumed. csp_meta_tag renders now that a
+  # policy exists; it must render empty.
+  test 'no nonce is generated, so unsafe-inline keeps working' do
+    get '/en/login'
+
+    assert_response :success
+    assert_nil Rails.application.config.content_security_policy_nonce_generator
+    refute_includes response.headers['Content-Security-Policy-Report-Only'], 'nonce-'
+    assert_select 'meta[name=?]', 'csp-nonce' do |tags|
+      assert tags.all? { |tag| tag['content'].blank? },
+             'a rendered nonce would make browsers ignore unsafe-inline'
+    end
+  end
+
+  # 'self' already matches wss:// from an https page and ws:// from an http page on the
+  # same host and port (CSP3 "does url match expression in origin", step 4.2), so
+  # ActionCable's /cable needs nothing extra in any deployment. A bare wss: is a
+  # scheme-source with no host constraint — it would permit a WebSocket to any host, on the
+  # one directive that bounds where a page can send data. ws: is worse still: its
+  # scheme-part matches http and https too.
+  test 'connect-src does not permit a websocket to an arbitrary host' do
+    get '/en/login'
+    connect = response.headers['Content-Security-Policy-Report-Only'][/connect-src [^;]+/]
+
+    assert_equal "connect-src 'self' ipc: http://ipc.localhost", connect
+    refute_match(/\bwss?:/, connect, 'a bare websocket scheme-source has no host constraint')
+  end
+
+  # form-action is a navigation directive and inherits nothing: it is absent from CSP3's
+  # "get fetch directive fallback list", so default-src does not cover it. Without it an
+  # injected <form action="https://evil/"> can still post a page's fields off-origin, which
+  # is precisely the hole 'unsafe-inline' on script-src leaves open.
+  test 'form-action is set, since it does not fall back to default-src' do
+    get '/en/login'
+
+    assert_includes response.headers['Content-Security-Policy-Report-Only'], "form-action 'self'"
+  end
+end

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -212,7 +212,22 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     assert Rack::Attack.client_ip(request).present?, 'a missing REMOTE_ADDR must not switch the rule off'
   end
 
+  # /csp-report takes an unauthenticated POST and writes a line to the log, so it is a
+  # log-flooding vector. The 3 + 28 split is what proves both spellings land in ONE bucket:
+  # against a limit of 30 neither half reaches the limit alone, so a rule matching only the
+  # bare path or only the suffixed one would leave this green at 204.
+  test 'throttles the CSP report endpoint, format suffix included' do
+    3.times { post_csp_report('/csp-report') }
+    28.times { post_csp_report('/csp-report.json') }
+
+    assert_response :too_many_requests
+  end
+
   private
+
+  def post_csp_report(path)
+    post path, params: '{}', headers: { 'CONTENT_TYPE' => 'application/csp-report' }
+  end
 
   # Stub rather than set BEHIND_PROXY: ENV is process-wide and shared with every other test
   # in this process, and mocha restores this in teardown whichever way the test exits.

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -4,6 +4,15 @@ require 'test_helper'
 
 class RackAttackTest < ActionDispatch::IntegrationTest
   setup do
+    # Every test below spends its requests against one throttle counter, and rack-attack
+    # counts into a window aligned to the wall clock rather than to the first request:
+    # Rack::Attack::Cache#key_and_expiry keys each counter on (Time.now.to_i / period), and
+    # all seven rules use period: 60. A test whose requests straddle a minute boundary is
+    # therefore counted as two short runs, neither of which reaches the limit, and it fails
+    # having done nothing wrong. Freezing the clock mid-window puts every request in one
+    # bucket. It is the window these tests need pinned, not one they are measuring — none of
+    # them asserts anything about a counter expiring — so this changes no assertion.
+    travel_to Time.at(((Time.now.to_i / 60) * 60) + 30)
     @original_store = Rack::Attack.cache.store
     @original_enabled = Rack::Attack.enabled
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -145,4 +145,73 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     2.times { post '/oauth//register', params: { redirect_uris: ['https://e.test/cb'] }, as: :json }
     assert_response :too_many_requests
   end
+
+  # The throttle key used to be action_dispatch.remote_ip unconditionally, which prefers a
+  # forwarded-for hop over REMOTE_ADDR. On a deployment with nothing in front of it that hop
+  # is written by the caller, so the caller chooses its own bucket and the per-IP limit
+  # bounds nothing. Keyed on REMOTE_ADDR the bucket is whatever the TCP connection came
+  # from, which the caller cannot restate.
+  test 'a rotating forwarded-for header does not mint a fresh bucket per request' do
+    declare_proxy(false)
+    11.times { |i| post_login('REMOTE_ADDR' => '198.18.0.5', 'HTTP_X_FORWARDED_FOR' => "203.0.113.#{i + 1}") }
+
+    assert_response :too_many_requests, 'the limit must hold however the forwarded header varies'
+  end
+
+  # Client-Ip reaches calculate_ip by the same route as X-Forwarded-For, so a fix that only
+  # closed the better-known header would leave an identical second way in.
+  test 'a rotating client-ip header does not mint a fresh bucket per request' do
+    declare_proxy(false)
+    11.times { |i| post_login('REMOTE_ADDR' => '198.18.0.5', 'HTTP_CLIENT_IP' => "203.0.113.#{i + 1}") }
+
+    assert_response :too_many_requests, 'the limit must hold however the client-ip header varies'
+  end
+
+  # The other direction: keying on REMOTE_ADDR must not collapse everyone into one bucket,
+  # or the limit becomes a way for one caller to lock out the rest.
+  test 'distinct REMOTE_ADDRs keep independent budgets' do
+    declare_proxy(false)
+    11.times { post_login('REMOTE_ADDR' => '198.18.0.5') }
+    assert_response :too_many_requests
+
+    post_login('REMOTE_ADDR' => '198.18.0.6')
+    refute_equal 429, response.status, 'a second address must not inherit the first address budget'
+  end
+
+  # Behind a proxy that writes the header, the header is the only thing that distinguishes
+  # callers — REMOTE_ADDR is the proxy for all of them. This pins that the declared branch
+  # still reads it, so hosted and reverse-proxied installs keep per-caller buckets.
+  test 'a declared proxy still keys on the forwarded header' do
+    declare_proxy(true)
+    11.times { post_login('REMOTE_ADDR' => '172.16.0.2', 'HTTP_X_FORWARDED_FOR' => '203.0.113.1') }
+    assert_response :too_many_requests
+
+    post_login('REMOTE_ADDR' => '172.16.0.2', 'HTTP_X_FORWARDED_FOR' => '203.0.113.2')
+    refute_equal 429, response.status, 'a second forwarded caller must not inherit the first budget'
+  end
+
+  # Rack::Attack::Throttle#matched_by? opens with `return false unless discriminator`, so a
+  # nil key does not mean "one shared bucket", it means the rule does not run at all. An
+  # environment with no REMOTE_ADDR must therefore still produce a key.
+  test 'the throttle key is never nil' do
+    request = Rack::Attack::Request.new({})
+
+    declare_proxy(false)
+    assert Rack::Attack.client_ip(request).present?, 'a missing REMOTE_ADDR must not switch the rule off'
+
+    declare_proxy(true)
+    assert Rack::Attack.client_ip(request).present?, 'a missing REMOTE_ADDR must not switch the rule off'
+  end
+
+  private
+
+  # Stub rather than set BEHIND_PROXY: ENV is process-wide and shared with every other test
+  # in this process, and mocha restores this in teardown whichever way the test exits.
+  def declare_proxy(declared)
+    Deltabadger::Application.stubs(:behind_proxy_from_env).returns(declared)
+  end
+
+  def post_login(headers)
+    post '/login', params: { user: { email: 'a@b.test', password: 'wrong' } }, headers: headers
+  end
 end

--- a/test/middleware/rack_attack_test.rb
+++ b/test/middleware/rack_attack_test.rb
@@ -7,7 +7,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     # Every test below spends its requests against one throttle counter, and rack-attack
     # counts into a window aligned to the wall clock rather than to the first request:
     # Rack::Attack::Cache#key_and_expiry keys each counter on (Time.now.to_i / period), and
-    # all seven rules use period: 60. A test whose requests straddle a minute boundary is
+    # all eight rules use period: 60. A test whose requests straddle a minute boundary is
     # therefore counted as two short runs, neither of which reaches the limit, and it fails
     # having done nothing wrong. Freezing the clock mid-window puts every request in one
     # bucket. It is the window these tests need pinned, not one they are measuring — none of

--- a/test/services/users/verify_otp_test.rb
+++ b/test/services/users/verify_otp_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+class Users::VerifyOtpTest < ActiveSupport::TestCase
+  # Codes are minted at an offset and submitted "now" rather than travelling the verifier,
+  # so the only variable under test is the age of the code — travelling would also move the
+  # `after:` baseline and Devise's lock timers.
+  #
+  # The frozen instant is pinned 15 seconds into a step on purpose. rotp measures drift in
+  # SECONDS and applies it to the timestamp before flooring it into a 30-second step, so a
+  # clock frozen at a step boundary reaches the adjacent step even with a one-second drift.
+  # Freezing mid-step is what makes these assertions discriminate a one-step window from a
+  # one-second one instead of flapping with the wall clock.
+  MID_STEP = Time.at(1_800_000_015).utc # 1_800_000_015 % 30 == 15
+
+  setup do
+    travel_to MID_STEP
+    @user = create(:user)
+    @user.update!(otp_secret_key: ROTP::Base32.random, otp_module: :enabled)
+    @totp = ROTP::TOTP.new(@user.otp_secret_key)
+  end
+
+  test 'accepts a code minted one step behind' do
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.ago)),
+           'a code from the previous step must be accepted'
+    assert_equal 30.seconds.ago.to_i / 30 * 30, @user.reload.last_otp_at.to_i,
+                 'the matched step, not the moment of verification, is what gets recorded'
+  end
+
+  test 'accepts a code minted one step ahead' do
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.from_now)),
+           'a code from the next step must be accepted'
+  end
+
+  test 'rejects a code minted two steps behind' do
+    refute Users::VerifyOtp.call(@user, @totp.at(60.seconds.ago)),
+           'the window is one step either side, not "some drift"'
+    assert_nil @user.reload.last_otp_at, 'a rejected code must not move the OTP clock'
+  end
+
+  test 'rejects a code minted two steps ahead' do
+    refute Users::VerifyOtp.call(@user, @totp.at(60.seconds.from_now)),
+           'the window is one step either side, not "some drift"'
+    assert_nil @user.reload.last_otp_at, 'a rejected code must not move the OTP clock'
+  end
+
+  # A drift of one interval plus a little looks like a rounding difference but is a cliff: the
+  # spare seconds only buy anything at the edges of a step, and what they buy there is a second
+  # step of tolerance. These two check the edges, where mid-step assertions cannot tell 30 from 31.
+  test 'rejects a code two steps behind when the clock sits on a step boundary' do
+    travel_to Time.at(1_800_000_000).utc # 1_800_000_000 % 30 == 0
+
+    refute Users::VerifyOtp.call(@user, @totp.at(60.seconds.ago)),
+           'the drift must be exactly one interval, not one interval plus slack'
+  end
+
+  test 'rejects a code two steps ahead when the clock sits at the end of a step' do
+    travel_to Time.at(1_800_000_029).utc # 1_800_000_029 % 30 == 29
+
+    refute Users::VerifyOtp.call(@user, @totp.at(60.seconds.from_now)),
+           'the drift must be exactly one interval, not one interval plus slack'
+  end
+
+  test 'refuses a code that has already been spent' do
+    code = @totp.now
+
+    assert Users::VerifyOtp.call(@user, code), 'precondition: the current code is accepted once'
+    refute Users::VerifyOtp.call(@user, code), 'a spent code must stay spent'
+  end
+
+  test 'spending a code from the previous step leaves the current one usable' do
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.ago)), 'precondition: a behind code is accepted'
+
+    refute Users::VerifyOtp.call(@user, @totp.at(30.seconds.ago)), 'the behind code itself is spent'
+    assert Users::VerifyOtp.call(@user, @totp.now), 'the current code must still work'
+  end
+
+  # Accepting an ahead code records the step that code belonged to, and rotp keeps only
+  # timecodes strictly greater than the recorded one — so it spends the current step and the
+  # next one, not just the current one. Pinned here so the tradeoff cannot be lost in a refactor.
+  test 'spending a code from the next step also spends the current step and the one after' do
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.from_now)), 'precondition: an ahead code is accepted'
+
+    refute Users::VerifyOtp.call(@user, @totp.now), 'the current step is spent'
+
+    travel 30.seconds
+    refute Users::VerifyOtp.call(@user, @totp.now), 'the step the accepted code belonged to is spent too'
+
+    travel 30.seconds
+    assert Users::VerifyOtp.call(@user, @totp.now), 'the step after that must be usable again'
+  end
+
+  # The only device that can submit a next-step code is one running roughly a step fast, and
+  # such a device stops displaying that code the moment real time catches up. The next code it
+  # shows is the one after — so the wait is one code rotation, the same as with no drift at all.
+  test 'a fast device is not stranded by the step it just spent' do
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.from_now)), 'precondition: an ahead code is accepted'
+
+    travel 30.seconds
+    assert Users::VerifyOtp.call(@user, @totp.at(30.seconds.from_now)),
+           'the next code a fast device displays must be accepted'
+  end
+end


### PR DESCRIPTION
Four changes to how this app handles transport, rate-limit attribution, second-factor tolerance and content security. Each is independent; they share a branch because they all turned out to depend on the same question — what the deployment can tell the app about itself.

## Derive `force_ssl` from the configured root URL

`FORCE_SSL` was the only signal enabling HSTS and the `Secure` flag on a 30-day session cookie, and nothing in the hosting setup ever set it. Take the signal from `APP_ROOT_URL` instead: if the app is reached over https, that is what it insists on. `FORCE_SSL` remains an explicit override in both directions, and is now read as a boolean rather than compared against the literal string `true` — previously `FORCE_SSL=1` meant *off*.

`assume_ssl` moves with it, and that pairing is the important part. Both liveness probes reach the app over plain http with no `X-Forwarded-Proto`: the container's own `HEALTHCHECK` and the routing proxy's health check. `force_ssl` alone answers both with a redirect, and `curl -fsS` treats a redirect as success — so a container would go on reporting healthy while the proxy refused to route to it. Assuming the connection is already secure applies HSTS and the cookie flag without ever redirecting; the http-to-https redirect already happens at the proxy.

The session cookie now states `secure` and `same_site` at the declaration rather than inheriting them, and the mailer and route protocol read the same resolver instead of repeating the parse.

## Key the rate limits on the address the connection came from

The per-IP throttle key was derived from forwarded headers. Rails' trusted-proxy filtering decides which forwarded hops to *discard*, not whether to consult them at all, so on a deployment that is not behind a proxy — which is how the README documents running this — the value the limits keyed on did not originate with the app or with anything it controls. Setting `trusted_proxies` does not fix that; the filtering runs on both sides of the fallback.

Forwarded headers are now consulted only where the deployment declares a proxy, and the key falls back to a fixed sentinel rather than to nothing, because a throttle whose key is absent is a throttle that does not run.

The throttle tests also had a latent flake: rack-attack's window is aligned to the wall clock, so any test firing a burst across a minute boundary was counted as two short runs and failed having done nothing wrong. Their clock is now pinned inside one window. No assertion changed.

## Accept TOTP codes from the adjacent steps

A code was valid only inside the exact 30-second step it was minted in, so a device carrying any clock skew had a correctly-typed code rejected, and a self-hosted user has no operator to appeal to. Verify with one step of tolerance either side.

Worth noting for anyone reading the diff: rotp measures drift in **seconds** and applies it before flooring into a step, so the value has to be a whole interval — a smaller number widens the window during only part of each step. Replay protection is untouched: the matched step is what gets recorded, and only strictly later steps are accepted afterwards, so a spent code stays spent. This widens the momentarily-valid set from one code to three, against a per-account attempt limit that already exists.

## Emit a report-only Content-Security-Policy

No policy was emitted at all. This one is **report-only and enforces nothing** — `script-src` still allows inline handlers, because this app has inline event handlers, inline `<script>` blocks and a large number of inline `style` attributes, and an enforcing policy would take the UI down. Treat it as measurement, not protection: the point is to collect real violations before removing `unsafe-inline` and switching enforcement on.

Two departures worth calling out. `connect-src` deliberately carries no bare `ws:`/`wss:` scheme source — `'self'` already matches a same-origin WebSocket, and a bare scheme source carries no host constraint at all, which is the wrong thing to add to the one directive that bounds where data can go. It does carry Tauri's IPC origins, because this header governs the desktop webview: the desktop build sets no policy of its own and loads the Rails app over loopback. `form-action` is set because it inherits nothing and was otherwise unrestricted.

Violations POST to `/csp-report`, which is unauthenticated by necessity — a browser sends no session with a report. It logs a bounded, sanitised subset of each report: query strings are dropped (a violation on a password-reset page would otherwise write a live token to the log), control characters are stripped so a report cannot forge or rewrite a log line, values that would otherwise be read as exception names by log tooling are neutralised, and every field is capped in bytes. The endpoint is throttled, and it answers malformed, oversized, wrongly-shaped and invalidly-encoded bodies without raising — an endpoint that can be made to crash is an endpoint that can be made to write its own backtrace to the log.

## Known limitations

- **Do not publish the app's port directly when you terminate TLS in front of it.** With SSL enabled the app treats the connection as already secure, so a plaintext request arriving on a directly-published port is served rather than redirected. The proxy's redirect cannot protect a port that bypasses the proxy.
- **Behind a reverse proxy on a plain-http root URL, set `BEHIND_PROXY=true`.** Otherwise the app cannot tell that a proxy is in front, and the per-IP limits key on the proxy's own address — one shared budget for every client. It fails toward over-limiting rather than under-limiting, but it is worth setting.
- **The CSP does not protect anything yet.** Report-only with inline scripts allowed is step one of three.

## Follow-ups

- `docker-compose.yml` lists `APP_ROOT_URL` and `HOME_PAGE_URL` under both `env_file:` and `environment:`, and `environment:` wins — and its interpolation reads the shell or Compose's own `.env`, never `.env.docker`. So a value set in `.env.docker`, which is where `README.md` tells operators to put it, is silently replaced by `http://localhost:3737`. That breaks more than this branch: Action Cable's allowed origins and every generated mail and route URL resolve against localhost for anyone on a custom domain. Worth its own change and a release note, since fixing it starts honouring a value that has been ignored.
- Pass an explicit proxy signal from the hosting side, then decouple "TLS terminates upstream" from "SSL is enabled" so a directly-reachable port still redirects.
- Move the inline handlers to Stimulus, drop `unsafe-inline`, then enable enforcement — but check a real OAuth consent flow first, since `form-action` behaviour across a redirect has differed between engines.

## Testing

`bin/rails test` — 2869 runs, 9883 assertions, 0 failures (2810 on `main`). The added runs are the new tests and nothing else; no existing test was modified or weakened, and the only deleted test lines are comments that described the old behaviour.

Note for reviewers: nothing in CI runs the test suite, so the local run above is the only gate on it — code scanning covers a different surface.
