### PR TITLE
Let ActiveRecord Encryption use its own key material

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -10,15 +10,38 @@
 # /app/storage/.secrets. Only set this if you have a specific reason to manage it
 # yourself, and then generate it with: openssl rand -hex 64
 #
-# WARNING: this is the encryption key for EVERY encrypted field in the app — exchange
-# API keys, your two-factor secret, withdrawal addresses and market-data settings.
-# Changing it on an existing install makes all of them unreadable and will LOCK YOU
-# OUT if you use two-factor authentication. It is not just "re-enter your API keys".
+# WARNING: on an install that does not set the encryption keys below, this value is
+# also what derives them — every encrypted field in the app: exchange API keys, your
+# two-factor secret, withdrawal addresses and market-data settings. Changing it there
+# makes all of them unreadable and will LOCK YOU OUT if you use two-factor
+# authentication. It is not just "re-enter your API keys". Setting the two keys below
+# stops that being true.
 # Run `rake deltabadger:encryption:report` first to see what is stored. If this
 # install ever ran on a value published in this repo, REVOKE those exchange keys at
 # their source — re-entering them is not enough. See the README section "Moving to
 # a new SECRET_KEY_BASE" for the recovery steps.
 SECRET_KEY_BASE=
+
+# =============================================================================
+# ENCRYPTION KEYS
+# =============================================================================
+# Leave EMPTY unless you know you want to manage these. An install created from
+# scratch generates them into /app/storage/.secrets, where they are independent of
+# SECRET_KEY_BASE — which is what lets SECRET_KEY_BASE be replaced without touching
+# stored data.
+#
+# An install created before these existed derives them from SECRET_KEY_BASE instead.
+# To move it over, run:
+#   docker compose run --rm --no-deps deltabadger \
+#     rake deltabadger:encryption:derived_keys
+# and put both printed values here. That changes nothing by itself — they are the
+# values already in use — but afterwards SECRET_KEY_BASE no longer determines them.
+#
+# Set BOTH or NEITHER. The app refuses to start with only one, because a key used
+# against a different salt cannot read anything already stored. Never put in values
+# other than the ones that wrote your data: it would make all of it unreadable.
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=
 
 # =============================================================================
 # APPLICATION URLs

--- a/README.md
+++ b/README.md
@@ -120,6 +120,32 @@ For production deployments:
 - Use a reverse proxy (nginx, Traefik) for HTTPS
 - Set `APP_ROOT_URL` and `HOME_PAGE_URL` to your domain in `.env.docker`
 
+### Replacing SECRET_KEY_BASE without losing data
+
+An install that sets `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY` and
+`ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` keeps its stored data encrypted under those,
+not under `SECRET_KEY_BASE`. Replacing `SECRET_KEY_BASE` there ends every session and leaves
+stored data untouched — no credentials to re-enter, no two-factor to re-enrol. Password reset
+and confirmation emails already sent stop working, and your REST API and MCP tokens are
+unaffected, so revoke those separately if the old value was ever exposed.
+
+Installs created from scratch after these keys existed already have them. To check:
+
+```bash
+docker compose run --rm --no-deps deltabadger \
+  rake deltabadger:encryption:derived_keys
+```
+
+If your install does not have them yet, that command prints the two values it currently
+derives. Put both wherever this install's environment comes from, recreate the container with
+`docker compose up -d --force-recreate`, and confirm it starts and your credentials still
+read. `SECRET_KEY_BASE` is free to change from then on.
+
+If your compose file defines more than one service, set them in **every** service block. They
+share one database, and different values leave each unable to read the other's writes.
+
+Only ever set them to the values that command prints. Any others make stored data unreadable.
+
 ### Moving to a new SECRET_KEY_BASE
 
 `SECRET_KEY_BASE` is the encryption key for everything encrypted in this instance —

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,8 +1,131 @@
+# Key material for ActiveRecord Encryption.
+#
+# Both values may be supplied directly. When they are not, they are derived from
+# secret_key_base, which is what every install did before these variables existed — so an
+# install that sets neither behaves byte-for-byte as it always has and needs no migration.
+#
+# Supplying them decouples stored data from the session secret. The two have opposite
+# lifecycles: replacing a session secret should cost a re-login, while replacing a data key
+# costs re-encrypting everything. Derived from one value they move together, so changing the
+# session secret makes every stored credential unreadable and locks out anyone using
+# two-factor.
+#
+# The derivation below must not change. It is the only way an operator holding an older
+# secret can recompute the key that wrote their data.
+module EncryptionKeys
+  class ConfigurationError < StandardError; end
+
+  PRIMARY_KEY_VAR = 'ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'
+  SALT_VAR = 'ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT'
+
+  # Written into the secrets file when an install is first set up with keys supplied through
+  # its environment. Without it, losing those later looks identical to an install that never
+  # had them: both variables absent is a valid state, so the app would quietly derive a
+  # different pair from the stored SECRET_KEY_BASE and read nothing.
+  EXTERNAL_MARKER_VAR = 'ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL'
+
+  def self.derived_primary_key(secret)
+    Digest::SHA256.hexdigest("#{secret}-ar-encryption-primary")
+  end
+
+  def self.derived_salt(secret)
+    Digest::SHA256.hexdigest("#{secret}-ar-encryption-salt")
+  end
+
+  def self.independent?(env = ENV)
+    env[PRIMARY_KEY_VAR].presence.present? && env[SALT_VAR].presence.present?
+  end
+
+  def self.partially_configured?(env = ENV)
+    [env[PRIMARY_KEY_VAR].presence, env[SALT_VAR].presence].compact.size == 1
+  end
+
+  # A key used against a different salt decrypts nothing. support_unencrypted_data is on, so
+  # that failure does not raise on read — the value comes back as its own ciphertext, and a
+  # later write to that attribute stores it re-encrypted, past recovery even with the
+  # original secret. Refusing to start is the last point at which that is preventable.
+  #
+  # Safe to raise on, unlike SecretKeyBaseGuard: these are configurations an operator has just
+  # introduced, not a state an existing install is stranded in. Raising does stop every
+  # environment-loading command, including deltabadger:encryption:derived_keys, so the
+  # messages carry what is needed rather than naming a command that cannot run.
+  def self.validate!(env = ENV, secret:)
+    if env[EXTERNAL_MARKER_VAR].presence && !independent?(env)
+      raise ConfigurationError, <<~MESSAGE
+        This install was set up with its own encryption keys, supplied through its
+        environment, and they are not set now.
+
+        Restore #{PRIMARY_KEY_VAR} and
+        #{SALT_VAR} to the values this install was created with.
+        Nothing else reads its data. They are not in the secrets file — that file only
+        records that they came from elsewhere.
+
+        Starting without them would not fail on its own: it would derive a different pair
+        from SECRET_KEY_BASE and quietly read nothing, which is why this stops instead.
+
+        If those values are gone for good, remove the #{EXTERNAL_MARKER_VAR} line from the
+        secrets file. This install will then start, and its stored credentials will need
+        replacing at their source.
+      MESSAGE
+    end
+
+    return nil unless partially_configured?(env)
+
+    missing = env[PRIMARY_KEY_VAR].presence ? SALT_VAR : PRIMARY_KEY_VAR
+    present = missing == SALT_VAR ? PRIMARY_KEY_VAR : SALT_VAR
+
+    raise ConfigurationError, <<~MESSAGE
+      #{present} is set but #{missing} is not.
+
+      These two are a pair. A key used against a different salt cannot read anything this
+      install has stored, so it will not start on half of one.
+
+      If this install was already using its own encryption keys and one has gone missing,
+      put the ORIGINAL #{missing} back. Only that value reads your data. Recover it from
+      wherever this install's environment is configured, or from a backup of it.
+
+      Do NOT substitute the values below in that case. They are derived from SECRET_KEY_BASE
+      and are the ones an install that has NEVER used its own keys is currently encrypting
+      with. Using them on an install that has is what would make its data unreadable.
+
+      If you were part-way through setting these for the first time, the matching pair is:
+
+        #{PRIMARY_KEY_VAR}=#{derived_primary_key(secret)}
+        #{SALT_VAR}=#{derived_salt(secret)}
+
+      If you meant to keep deriving them from SECRET_KEY_BASE, remove #{present} instead.
+
+      If the original is gone for good, remove #{present} as well. The data it encrypted is
+      unreadable either way, and removing it at least lets this install start so that
+      `rake deltabadger:encryption:report` and `:reset` can run.
+    MESSAGE
+  end
+
+  def self.primary_key(env = ENV, secret:)
+    env[PRIMARY_KEY_VAR].presence || derived_primary_key(secret)
+  end
+
+  def self.key_derivation_salt(env = ENV, secret:)
+    env[SALT_VAR].presence || derived_salt(secret)
+  end
+
+  # Whether configured values were taken from this secret rather than generated
+  # independently. Values taken from it are exactly as recoverable as it is, which is what
+  # SecretKeyBaseGuard needs before telling an operator whether stored data is exposed.
+  def self.derived_from_secret?(env = ENV, secret:)
+    return false unless independent?(env)
+
+    env[PRIMARY_KEY_VAR] == derived_primary_key(secret) && env[SALT_VAR] == derived_salt(secret)
+  end
+end
+
 Rails.application.configure do
   secret = Rails.application.secret_key_base
 
-  config.active_record.encryption.primary_key = Digest::SHA256.hexdigest("#{secret}-ar-encryption-primary")
-  config.active_record.encryption.key_derivation_salt = Digest::SHA256.hexdigest("#{secret}-ar-encryption-salt")
+  EncryptionKeys.validate!(secret: secret)
+
+  config.active_record.encryption.primary_key = EncryptionKeys.primary_key(secret: secret)
+  config.active_record.encryption.key_derivation_salt = EncryptionKeys.key_derivation_salt(secret: secret)
 
   # Allow reading data that was not yet encrypted (for migration transition)
   config.active_record.encryption.support_unencrypted_data = true

--- a/config/initializers/encryption_key_check.rb
+++ b/config/initializers/encryption_key_check.rb
@@ -1,0 +1,66 @@
+# Says so at startup when this instance holds encrypted values its configured keys cannot
+# read. Worth naming: a value that fails to decrypt comes back as its own ciphertext rather
+# than raising, so nothing looks wrong until a credential appears as a base64 blob.
+#
+# Warns rather than refusing to start, for the reason recorded in secret_key_base_guard.rb: an
+# instance in this state still holds recoverable data and is the one that needs
+# deltabadger:encryption:report and :reset. Refusing would also deny db:migrate on a schema old
+# enough that the scan below queries a table it has not created yet, and would reach the
+# desktop build as nothing more than "application failed to start".
+module EncryptionKeyCheck
+  WARNING = <<~MESSAGE.freeze
+    ============================== ENCRYPTION KEY NOTICE =============================
+    Some stored values cannot be read with the encryption keys this instance is
+    configured with. They were written under different ones.
+
+    Anything not yet saved over is intact, and a correct key still reads it. This
+    cannot tell which of these values have already been written since — saving over one
+    replaces it for good — so restore the right key before changing any credential here,
+    and before leaving this instance running.
+
+    The usual causes:
+
+      * #{EncryptionKeys::PRIMARY_KEY_VAR} or
+        #{EncryptionKeys::SALT_VAR} set to something other
+        than the values that wrote this data. Restore them and start again.
+      * SECRET_KEY_BASE replaced on an instance that derives its encryption keys from
+        it. Restore the previous value and start again.
+      * More than one container on this volume running with different values. They all
+        need the same ones.
+
+    To see what is stored:
+      docker compose run --rm --no-deps deltabadger rake deltabadger:encryption:report
+
+    If the previous values are gone for good, the credentials cannot be recovered and
+    must be replaced at their source. See the README section
+    "Moving to a new SECRET_KEY_BASE".
+    ==================================================================================
+  MESSAGE
+
+  # :readable | :unreadable | :indeterminate
+  def self.readability(logger: Rails.logger)
+    EncryptedCredentials::Report.new.data_written_under_another_key? ? :unreadable : :readable
+  rescue StandardError => e
+    # Could not tell. On a database that is not prepared yet this is the normal state and means
+    # nothing is wrong, so it is a log line rather than a banner — but it is not reported as
+    # health either.
+    logger.info("Encryption key check did not complete: #{e.class}") if logger
+    :indeterminate
+  end
+
+  def self.emit_warning!(logger: Rails.logger)
+    return nil unless readability(logger: logger) == :unreadable
+
+    logger.error(WARNING) if logger
+    warn(WARNING)
+    WARNING
+  end
+end
+
+# Deferred: the check reads through the models, which are not loaded while initializers run.
+# Skipped during asset precompilation, which Rails runs with a generated dummy secret.
+Rails.application.config.after_initialize do
+  if Rails.env.production? && ENV['SECRET_KEY_BASE_DUMMY'].blank?
+    EncryptionKeyCheck.emit_warning!
+  end
+end

--- a/config/initializers/secret_key_base_guard.rb
+++ b/config/initializers/secret_key_base_guard.rb
@@ -86,6 +86,16 @@ module SecretKeyBaseGuard
          your key actually is, so this deletion is what rotates anything at all.
          A new one is written only when that file is absent; an existing one is
          never overwritten.
+         If you set ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY and
+         ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT — anywhere: that file,
+         .env.docker, or a compose file — remove both lines as well. They override
+         the new key, so leaving them in place means the credentials you add at
+         step 8 are encrypted under the same one you are replacing. No pair is
+         written for you here, since that happens only for an install with no
+         database, so once you are back up run
+         `rake deltabadger:encryption:derived_keys` and set what it prints BEFORE
+         step 8. Skip that and this install goes back to deriving them from
+         SECRET_KEY_BASE, with the same exposure the next time it changes.
          If your value comes from a compose file instead — the Umbrel app
          definition sets it from APP_SEED — put a freshly generated value in
          both service blocks rather than blanking it:  openssl rand -hex 64
@@ -146,6 +156,60 @@ module SecretKeyBaseGuard
     ==================================================================================
   MESSAGE
 
+  # Reached when the secret is weak but the encryption keys are kept separately, so nothing
+  # stored derives from it. Sessions are still forgeable, which is enough to be signed in as
+  # the operator — but the stored credentials are not readable from this value, and sending
+  # someone to revoke every exchange key over it would be wrong.
+  PUBLISHED_SESSIONS_WARNING = <<~MESSAGE.freeze
+    ================================ SECURITY WARNING ================================
+    SECRET_KEY_BASE is a value published in the public repository.
+
+    This instance keeps its encryption keys separately, so what is stored here does not
+    derive from this value and is not readable from it. What this value does do is sign
+    and encrypt session cookies: anyone who can reach this instance can sign into it as
+    you, without needing the database.
+
+    Replace it. Because the encryption keys are kept separately, stored data is
+    unaffected:
+
+      1. Revoke this instance's own REST API token and every connected MCP client, under
+         Settings. They are bearer tokens that do not derive from this value, so
+         replacing it does not end them, and anyone who signed in as you could have
+         issued one.
+      2. Put a fresh value in place of the published one, wherever this install takes it
+         from — /app/storage/.secrets, .env.docker, or your compose file:
+           openssl rand -hex 64
+         Leave the two encryption key variables exactly as they are.
+      3. Recreate the container:
+           docker compose up -d --force-recreate
+      4. Sign in again. Every session ends, which is the point. Any password reset or
+         confirmation email already sent stops working — request a new one.
+    ==================================================================================
+  MESSAGE
+
+  # As above, for a secret that is merely short. See SHORT_WARNING for why this cannot assert
+  # whether the value ever leaked.
+  SHORT_SESSIONS_WARNING = <<~MESSAGE.freeze
+    ================================ SECURITY NOTICE =================================
+    SECRET_KEY_BASE is shorter than #{MINIMUM_LENGTH} characters.
+
+    This instance keeps its encryption keys separately, so stored credentials do not
+    derive from this value. It still signs and encrypts session cookies, and a short one
+    is cheap to brute-force offline from a single captured cookie, which yields the
+    ability to sign in as you.
+
+    Replacing it leaves stored data untouched. Put a fresh value wherever this install
+    takes it from, leaving the encryption key variables as they are:
+      openssl rand -hex 64
+    then `docker compose up -d --force-recreate` and sign in again. Any password reset
+    or confirmation email already sent stops working.
+
+    If this value has ever been anywhere public, also revoke this instance's REST API
+    token and its connected MCP clients: those do not derive from it and outlive the
+    replacement.
+    ==================================================================================
+  MESSAGE
+
   # Published in this repository, so every install that copied it shares one key that
   # anybody can read. This is a compromise, not a weakness.
   def self.published?(secret)
@@ -162,9 +226,21 @@ module SecretKeyBaseGuard
     published?(secret) || short?(secret)
   end
 
-  def self.warning_for(secret)
-    return PUBLISHED_WARNING if published?(secret)
-    return SHORT_WARNING if short?(secret)
+  # Whether a weak secret also exposes what is stored. True when the encryption keys derive
+  # from it, and equally true when they were taken from it — those are exactly as recoverable
+  # as the secret itself. False only when they were generated independently, in which case a
+  # weak secret costs sessions rather than credentials.
+  def self.data_exposed_by?(secret, env = ENV)
+    return true unless EncryptionKeys.independent?(env)
+
+    EncryptionKeys.derived_from_secret?(env, secret: secret)
+  end
+
+  def self.warning_for(secret, env = ENV)
+    exposed = data_exposed_by?(secret, env)
+
+    return exposed ? PUBLISHED_WARNING : PUBLISHED_SESSIONS_WARNING if published?(secret)
+    return exposed ? SHORT_WARNING : SHORT_SESSIONS_WARNING if short?(secret)
 
     nil
   end

--- a/deltabadger/docker-compose.yml
+++ b/deltabadger/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       QUEUE_DATABASE_PATH: /app/storage/production_queue.sqlite3
       CACHE_DATABASE_PATH: /app/storage/production_cache.sqlite3
       CABLE_DATABASE_PATH: /app/storage/production_cable.sqlite3
+      # Setting ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY and
+      # ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT here holds stored data independent of
+      # this value. Both services share one database, so both blocks need the same values
+      # or neither can read what the other wrote.
       SECRET_KEY_BASE: ${APP_SEED}-secret-key-base
       HOME_PAGE_URL: http://${DEVICE_DOMAIN_NAME}:3737
       APP_ROOT_URL: http://${DEVICE_DOMAIN_NAME}:3737
@@ -41,6 +45,10 @@ services:
       QUEUE_DATABASE_PATH: /app/storage/production_queue.sqlite3
       CACHE_DATABASE_PATH: /app/storage/production_cache.sqlite3
       CABLE_DATABASE_PATH: /app/storage/production_cache.sqlite3
+      # Setting ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY and
+      # ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT here holds stored data independent of
+      # this value. Both services share one database, so both blocks need the same values
+      # or neither can read what the other wrote.
       SECRET_KEY_BASE: ${APP_SEED}-secret-key-base
       HOME_PAGE_URL: http://${DEVICE_DOMAIN_NAME}:3737
       APP_ROOT_URL: http://${DEVICE_DOMAIN_NAME}:3737

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,11 +4,11 @@ set -e
 # Deltabadger Docker Entrypoint Script
 # Supports multiple process types: web, jobs, migrate, console, standalone
 
-SECRETS_FILE="/app/storage/.secrets"
+SECRETS_FILE="${SECRETS_FILE:-/app/storage/.secrets}"
 
 # Ensure storage directory exists
 ensure_storage_directory() {
-    mkdir -p /app/storage
+    mkdir -p "$(dirname "$SECRETS_FILE")"
 }
 
 # Generate a random hex string
@@ -24,7 +24,41 @@ generate_hex() {
     fi
 }
 
+# Whether a value arrived through this container's environment. Blank after trimming counts
+# as absent, matching how the app reads these: a value of "   " looks supplied to the shell
+# and empty to Rails, and that disagreement would suppress a stored key while the app quietly
+# derived a different one.
+supplied_externally() {
+    [ -n "$(printf '%s' "$1" | tr -d '[:space:]')" ]
+}
+
+# Whether this install might already hold data. Its stored values were encrypted under keys
+# derived from SECRET_KEY_BASE, so it must keep deriving them: inventing new ones would make
+# all of it unreadable. Reachable without doing anything unusual — restoring a database
+# without the hidden secrets file, while SECRET_KEY_BASE comes from the environment, arrives
+# here with data present and no secrets file.
+#
+# Answers "not provably empty", not "has rows". Anything it cannot see the inside of counts as
+# occupied: DATABASE_URL and PRIMARY_DATABASE_URL both override the configured primary
+# database and point somewhere the path check cannot see. Being wrong in this direction leaves
+# an install deriving its keys, which is recoverable; being wrong in the other makes its data
+# unreadable, which is not.
+install_may_have_database() {
+    supplied_externally "${DATABASE_URL:-}" && return 0
+    supplied_externally "${PRIMARY_DATABASE_URL:-}" && return 0
+    [ -e "${DATABASE_PATH:-/app/storage/production.sqlite3}" ]
+}
+
 # Generate secrets file if it doesn't exist
+#
+# The early return is also the migration boundary for the encryption keys: an install that
+# already has this file never gains them, so it keeps deriving them and its stored data keeps
+# decrypting.
+#
+# Nothing supplied through the environment is written here. A stored copy of a value that is
+# currently coming from elsewhere is ignored while that source exists and silently adopted
+# when it stops, and adopting the wrong one makes stored data unreadable. Absent instead, the
+# same loss stops the container on the check in load_secrets.
 generate_secrets() {
     if [ -f "$SECRETS_FILE" ]; then
         echo "Loading existing secrets from $SECRETS_FILE"
@@ -33,23 +67,69 @@ generate_secrets() {
 
     echo "Generating new secrets..."
 
-    local secret_key_base=$(generate_hex 64)
+    local temporary_file
+    temporary_file=$(mktemp "${SECRETS_FILE}.XXXXXX")
+    trap 'rm -f "$temporary_file"' RETURN
 
-    cat > "$SECRETS_FILE" << EOF
-# Auto-generated secrets for Deltabadger
-# Generated on $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-# DO NOT DELETE - these are required for data encryption
-SECRET_KEY_BASE=${secret_key_base}
-EOF
+    {
+        echo "# Auto-generated secrets for Deltabadger"
+        echo "# Generated on $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+        echo "# DO NOT DELETE - these are required for data encryption"
 
-    chmod 600 "$SECRETS_FILE"
-    echo "Secrets generated and saved to $SECRETS_FILE"
+        if supplied_externally "${SECRET_KEY_BASE:-}"; then
+            echo "#"
+            echo "# SECRET_KEY_BASE comes from this container's environment and is not stored"
+            echo "# here. Remove it there and this container stops rather than starting on a"
+            echo "# different one."
+        else
+            echo "SECRET_KEY_BASE=$(generate_hex 64)"
+        fi
+
+        if supplied_externally "${ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY:-}${ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT:-}"; then
+            echo "#"
+            echo "# Encryption keys are supplied through this container's environment, so they"
+            echo "# are not written here. A different pair stored in this file would sit as a"
+            echo "# fallback and take over silently if that environment were ever lost, and"
+            echo "# nothing written under the supplied keys would read. The marker below"
+            echo "# records where they came from, so losing them stops this install instead."
+            echo "ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL=true"
+        elif install_may_have_database; then
+            echo "#"
+            echo "# This install already had a database when this file was written, so its"
+            echo "# encryption keys are still derived from SECRET_KEY_BASE and are not stored"
+            echo "# here. Run 'rake deltabadger:encryption:derived_keys' to move off that."
+        else
+            echo "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=$(generate_hex 32)"
+            echo "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=$(generate_hex 32)"
+        fi
+    } > "$temporary_file"
+
+    chmod 600 "$temporary_file"
+
+    # ln is atomic and fails if the target already exists. A deployment can run more than one
+    # container against the same volume, so losing this race means another wrote first: take
+    # its file rather than the values generated here, or the two encrypt under different keys
+    # and neither can read what the other wrote.
+    if ln "$temporary_file" "$SECRETS_FILE" 2>/dev/null; then
+        echo "Secrets generated and saved to $SECRETS_FILE"
+    else
+        echo "Another process created $SECRETS_FILE first; using that one"
+    fi
 }
 
 # Load secrets from file into environment
 load_secrets() {
     if [ -f "$SECRETS_FILE" ]; then
         echo "Loading secrets from $SECRETS_FILE..."
+
+        # The encryption key and its salt are a pair: a key used against a different salt
+        # reads nothing this install has stored. If either arrives from the environment,
+        # neither is taken from the file, so a half-supplied pair stays half-supplied and the
+        # app refuses to start rather than running on a mixed one.
+        local encryption_keys_supplied=""
+        if supplied_externally "${ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY:-}${ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT:-}"; then
+            encryption_keys_supplied="yes"
+        fi
 
         # Source the file directly to handle all formats properly
         # First, clean the file of any Windows line endings and whitespace issues
@@ -84,6 +164,21 @@ load_secrets() {
                         export DEVISE_SECRET_KEY="$value"
                         echo "  Loaded DEVISE_SECRET_KEY (legacy)"
                     fi
+                    ;;
+                ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY)
+                    if [ -z "$encryption_keys_supplied" ]; then
+                        export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="$value"
+                        echo "  Loaded ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"
+                    fi
+                    ;;
+                ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT)
+                    if [ -z "$encryption_keys_supplied" ]; then
+                        export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="$value"
+                        echo "  Loaded ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"
+                    fi
+                    ;;
+                ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL)
+                    export ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL="$value"
                     ;;
             esac
         done < "$SECRETS_FILE"
@@ -224,4 +319,7 @@ main() {
     esac
 }
 
-main "$@"
+# Sourced by tests to exercise the functions above without starting a server.
+if [ -z "${DELTABADGER_ENTRYPOINT_SOURCED:-}" ]; then
+    main "$@"
+fi

--- a/lib/tasks/encryption.rake
+++ b/lib/tasks/encryption.rake
@@ -174,6 +174,22 @@ namespace :deltabadger do
       puts 'Then recreate the container, which is what picks up the change:'
       puts '  docker compose up -d --force-recreate'
       puts 'Starting the stopped container instead brings the old value back with it.'
+
+      # Left set, these override the new secret, so the replacement credentials issued below
+      # would be encrypted under exactly the key this reset exists to get away from.
+      if EncryptionKeys.independent?
+        puts "\nThis install also sets its own encryption keys. Remove both lines wherever"
+        puts "they are set — #{EncryptionKeys::PRIMARY_KEY_VAR} and"
+        puts "#{EncryptionKeys::SALT_VAR} — or the credentials you enter next"
+        puts 'are encrypted under the same key you are replacing.'
+        puts 'The container will not create a replacement pair: that happens only for an'
+        puts 'install with no database, and yours has one. Once it is back up on the new'
+        puts 'secret, run'
+        puts '  rake deltabadger:encryption:derived_keys'
+        puts 'and set what it prints, BEFORE entering the replacement credentials. Otherwise'
+        puts 'this install goes back to deriving its encryption keys from SECRET_KEY_BASE,'
+        puts 'and the next time that changes you lose the new credentials the same way.'
+      end
       puts "\nIssue the replacement credentials, re-enable two-factor, re-issue your REST"
       puts 'API token, reconnect your MCP clients, and restart your bots and rules — until'
       puts "the app is running there is nowhere to store the new credentials.\n\n"
@@ -183,6 +199,73 @@ namespace :deltabadger do
         puts 'generate a fresh key pair, register it in their portal, and wait for IBKR to'
         puts "activate it.\n\n"
       end
+    end
+
+    # Reports, never writes. The entrypoint owns /app/storage/.secrets, and where the value
+    # has to go differs per deployment — that file, .env.docker, or every service block of a
+    # compose file. Writing here would also report success for something that only takes
+    # effect on the next container create.
+    desc 'Print the encryption keys this install derives from SECRET_KEY_BASE (read-only)'
+    task derived_keys: :environment do
+      # These are derived from the CURRENT secret. If what is stored cannot be read, that
+      # secret is not the one that wrote it, so they are not the keys in use and setting them
+      # would make the loss permanent. An indeterminate check is treated the same way: it says
+      # nothing about which keys are right, and unlike a boot, refusing here costs nothing —
+      # this is one command, and it can be re-run.
+      if EncryptionKeyCheck.readability != :readable
+        puts <<~MESSAGE
+
+          Whether this instance can read what it has stored could not be confirmed, so the
+          values this command derives may not be the ones that encrypted your data. They are
+          not printed: setting the wrong pair would replace a recoverable state with an
+          unrecoverable one.
+
+          Restore the SECRET_KEY_BASE, or the encryption keys, that this data was written
+          under, then run this again.
+
+          To see what is stored:  rake deltabadger:encryption:report
+        MESSAGE
+        next
+      end
+
+      if EncryptionKeys.independent?
+        puts <<~MESSAGE
+
+          This install already keeps its encryption keys separate from SECRET_KEY_BASE. There
+          is nothing to do: SECRET_KEY_BASE can be replaced without affecting stored data.
+
+          The keys in use are not printed here, and the values this command would otherwise
+          derive are NOT the ones encrypting your data — putting those in would make all of it
+          unreadable.
+        MESSAGE
+        next
+      end
+
+      secret = Rails.application.secret_key_base
+
+      puts <<~MESSAGE
+
+        These are the ActiveRecord Encryption keys this install currently derives from its
+        SECRET_KEY_BASE. Setting them explicitly changes nothing on its own — they are the
+        values already in use — but once they are set, SECRET_KEY_BASE no longer determines
+        them and can be replaced without making stored data unreadable.
+
+          #{EncryptionKeys::PRIMARY_KEY_VAR}=#{EncryptionKeys.derived_primary_key(secret)}
+          #{EncryptionKeys::SALT_VAR}=#{EncryptionKeys.derived_salt(secret)}
+
+        Set BOTH. A key used against a different salt reads nothing this install has stored,
+        and the app refuses to start with only one of them.
+
+        Put them where this install's environment comes from — /app/storage/.secrets, or
+        .env.docker, or the compose file. If your compose file defines more than one service,
+        set them in every service block: they share one database, so different values leave
+        each unable to read what the other wrote.
+
+        Then recreate the container so the values are picked up:
+          docker compose up -d --force-recreate
+
+        Nothing has been written. Copy the two lines above yourself.
+      MESSAGE
     end
   end
 end

--- a/test/config/docker_entrypoint_secrets_test.rb
+++ b/test/config/docker_entrypoint_secrets_test.rb
@@ -1,0 +1,245 @@
+# test/config/docker_entrypoint_secrets_test.rb
+require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'open3'
+
+# Drives the entrypoint's secret provisioning directly. SECRETS_FILE is overridable precisely
+# so this is runnable outside a container.
+class DockerEntrypointSecretsTest < ActiveSupport::TestCase
+  SCRIPT = Rails.root.join('docker-entrypoint.sh')
+  PRIMARY = 'ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'.freeze
+  SALT = 'ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT'.freeze
+  MARKER = 'ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL'.freeze
+
+  # Sources the script without running main, calls setup_secrets, and reports what the app
+  # process would actually see in its environment.
+  def run_setup(dir, env = {})
+    command = <<~SH
+      DELTABADGER_ENTRYPOINT_SOURCED=1
+      export DELTABADGER_ENTRYPOINT_SOURCED
+      . "#{SCRIPT}"
+      setup_secrets 1>&2 || exit 1
+      echo "SECRET_KEY_BASE=${SECRET_KEY_BASE}"
+      echo "#{PRIMARY}=${#{PRIMARY}}"
+      echo "#{SALT}=${#{SALT}}"
+      echo "#{MARKER}=${#{MARKER}}"
+    SH
+
+    Open3.capture3(
+      { 'SECRETS_FILE' => File.join(dir, '.secrets'),
+        'DATABASE_PATH' => File.join(dir, 'production.sqlite3') }.merge(env),
+      'bash', '-c', command
+    )
+  end
+
+  def provision(dir, env = {})
+    stdout, stderr, status = run_setup(dir, env)
+    assert status.success?, "entrypoint failed: #{stderr}"
+    stdout.lines.to_h { |line| line.strip.split('=', 2) }
+  end
+
+  def secrets_file(dir) = File.read(File.join(dir, '.secrets'))
+
+  test 'a fresh install is provisioned with all three values' do
+    Dir.mktmpdir do |dir|
+      result = provision(dir)
+
+      assert_equal 128, result['SECRET_KEY_BASE'].length
+      assert_equal 64, result[PRIMARY].length
+      assert_equal 64, result[SALT].length
+      assert_not_equal result[PRIMARY], result[SALT]
+    end
+  end
+
+  test 'the generated file is not world readable' do
+    Dir.mktmpdir do |dir|
+      provision(dir)
+
+      assert_equal '600', format('%o', File.stat(File.join(dir, '.secrets')).mode & 0o777)
+    end
+  end
+
+  # An install that already holds data was encrypted under keys derived from its
+  # SECRET_KEY_BASE. Handing it new random ones makes all of that unreadable. This is
+  # reachable without doing anything strange: restore a database, do not copy the hidden
+  # secrets file, keep supplying SECRET_KEY_BASE from the environment.
+  test 'an install with a database is never given generated encryption keys' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'production.sqlite3'), 'not empty')
+
+      result = provision(dir, 'SECRET_KEY_BASE' => 'preserved-from-the-environment')
+
+      assert_equal '', result[PRIMARY]
+      assert_equal '', result[SALT]
+      assert_equal 'preserved-from-the-environment', result['SECRET_KEY_BASE']
+    end
+  end
+
+  # A zero-byte database file is still a database. Treating it as absent would hand a
+  # half-created install a random pair.
+  test 'an empty database file still counts as a database' do
+    Dir.mktmpdir do |dir|
+      FileUtils.touch(File.join(dir, 'production.sqlite3'))
+
+      assert_equal '', provision(dir)[PRIMARY]
+    end
+  end
+
+  # A database supplied by URL is invisible to the path check, so the gate has to treat
+  # either URL variable as an install that may already hold data.
+  test 'a database supplied by URL is never given generated encryption keys' do
+    %w[DATABASE_URL PRIMARY_DATABASE_URL].each do |variable|
+      Dir.mktmpdir do |dir|
+        result = provision(dir, variable => 'sqlite3:/restored/production.sqlite3')
+
+        assert_equal '', result[PRIMARY], "#{variable} should have suppressed key generation"
+        assert_equal '', result[SALT], "#{variable} should have suppressed key generation"
+      end
+    end
+  end
+
+  # The migration boundary. An existing install already has this file, so it is never
+  # rewritten and never gains the new keys — which is what makes its data keep decrypting.
+  test 'an existing secrets file is left exactly as it was' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, '.secrets')
+      File.write(path, "SECRET_KEY_BASE=existing-value\n")
+      File.chmod(0o600, path)
+
+      result = provision(dir)
+
+      assert_equal "SECRET_KEY_BASE=existing-value\n", File.read(path)
+      assert_equal 'existing-value', result['SECRET_KEY_BASE']
+      assert_equal '', result[PRIMARY]
+    end
+  end
+
+  # The key and its salt have to come from one source. Taking one from the environment and
+  # the other from the file yields a mixed pair that reads nothing, and it would pass a
+  # both-present check.
+  test 'one key supplied externally does not pick up the other from the file' do
+    Dir.mktmpdir do |dir|
+      provision(dir)
+      result = provision(dir, PRIMARY => 'supplied-externally')
+
+      assert_equal 'supplied-externally', result[PRIMARY]
+      assert_equal '', result[SALT], 'the salt must not be taken from the file'
+    end
+  end
+
+  test 'both keys supplied externally win over the file' do
+    Dir.mktmpdir do |dir|
+      provision(dir)
+      result = provision(dir, PRIMARY => 'external-primary', SALT => 'external-salt')
+
+      assert_equal 'external-primary', result[PRIMARY]
+      assert_equal 'external-salt', result[SALT]
+    end
+  end
+
+  # The shell sees "   " as supplied; the app sees it as absent. Left disagreeing, the file
+  # keys would be suppressed while the app fell back to deriving them, and stored data would
+  # stop being readable.
+  test 'a whitespace-only supplied key does not suppress the stored pair' do
+    Dir.mktmpdir do |dir|
+      generated = provision(dir)
+      result = provision(dir, PRIMARY => '   ')
+
+      assert_equal generated[PRIMARY], result[PRIMARY]
+      assert_equal generated[SALT], result[SALT]
+    end
+  end
+
+  # Writing a different pair into the file would leave a fallback that takes over silently if
+  # the supplied environment is ever lost, and nothing written under the supplied keys would
+  # read.
+  test 'keys supplied externally on a first boot are not shadowed by a stored pair' do
+    Dir.mktmpdir do |dir|
+      provision(dir, PRIMARY => 'external-primary', SALT => 'external-salt')
+
+      assert_not_includes secrets_file(dir), "#{PRIMARY}="
+      assert_not_includes secrets_file(dir), "#{SALT}="
+    end
+  end
+
+  # ...and the file records that they came from elsewhere, so a later boot without them stops
+  # rather than deriving a different pair from the stored secret.
+  test 'a first boot with external keys records that they are external' do
+    Dir.mktmpdir do |dir|
+      provision(dir, PRIMARY => 'external-primary', SALT => 'external-salt')
+
+      assert_includes secrets_file(dir), "#{MARKER}=true"
+      assert_equal 'true', provision(dir)[MARKER]
+    end
+  end
+
+  # A secret supplied externally must not be shadowed either. Storing a different random one
+  # leaves a value that is ignored while the environment supplies one and silently adopted
+  # when it stops — and on an install that derives its encryption keys, adopting it makes
+  # everything unreadable.
+  test 'a secret supplied externally is not shadowed by a stored one' do
+    Dir.mktmpdir do |dir|
+      result = provision(dir, 'SECRET_KEY_BASE' => 'supplied-externally')
+
+      assert_equal 'supplied-externally', result['SECRET_KEY_BASE']
+      assert_not_includes secrets_file(dir), 'SECRET_KEY_BASE='
+    end
+  end
+
+  # ...so losing it fails closed on the check the entrypoint already performs, rather than
+  # starting on an unrelated value.
+  test 'losing an externally supplied secret fails closed rather than inventing one' do
+    Dir.mktmpdir do |dir|
+      provision(dir, 'SECRET_KEY_BASE' => 'supplied-externally')
+
+      stdout, stderr, status = run_setup(dir)
+
+      assert_not status.success?, 'it should refuse to continue without a secret'
+      assert_match(/SECRET_KEY_BASE not found/, stderr + stdout)
+    end
+  end
+
+  test 'the file is read back when it already holds the new keys' do
+    Dir.mktmpdir do |dir|
+      assert_equal provision(dir), provision(dir)
+    end
+  end
+
+  # Umbrel runs web and jobs against one shared volume. If they could each generate their own
+  # keys the two halves would encrypt under different ones and neither could read what the
+  # other wrote. Generation and adoption have to be a single atomic step.
+  test 'concurrent first boots all adopt the same keys' do
+    Dir.mktmpdir do |dir|
+      command = <<~SH
+        DELTABADGER_ENTRYPOINT_SOURCED=1
+        export DELTABADGER_ENTRYPOINT_SOURCED
+        . "#{SCRIPT}"
+        for i in 1 2 3 4 5 6 7 8; do
+          (
+            setup_secrets >/dev/null 2>&1
+            echo "${#{PRIMARY}}:${#{SALT}}"
+          ) &
+        done
+        wait
+      SH
+
+      stdout, stderr, status = Open3.capture3(
+        { 'SECRETS_FILE' => File.join(dir, '.secrets'),
+          'DATABASE_PATH' => File.join(dir, 'production.sqlite3') }, 'bash', '-c', command
+      )
+
+      assert status.success?, "entrypoint failed: #{stderr}"
+      adopted = stdout.split("\n").map(&:strip).reject(&:empty?)
+      assert_equal 8, adopted.size
+      assert_equal 1, adopted.uniq.size, "containers disagreed: #{adopted.uniq.inspect}"
+
+      # And what they adopted is what is actually on disk, not merely consistent with each
+      # other.
+      primary, salt = adopted.first.split(':')
+      assert_includes secrets_file(dir), "#{PRIMARY}=#{primary}"
+      assert_includes secrets_file(dir), "#{SALT}=#{salt}"
+      assert_equal 1, Dir.glob(File.join(dir, '.secrets*')).size, 'a temporary file was left behind'
+    end
+  end
+end

--- a/test/config/encryption_key_check_test.rb
+++ b/test/config/encryption_key_check_test.rb
@@ -1,0 +1,81 @@
+# test/config/encryption_key_check_test.rb
+require 'test_helper'
+
+class EncryptionKeyCheckTest < ActiveSupport::TestCase
+  def stored_data_readable!(value)
+    EncryptedCredentials::Report.any_instance
+                                .stubs(:data_written_under_another_key?).returns(!value)
+  end
+
+  test 'says nothing when everything stored decrypts' do
+    stored_data_readable!(true)
+
+    assert_equal :readable, EncryptionKeyCheck.readability(logger: nil)
+    assert_nil EncryptionKeyCheck.emit_warning!(logger: nil)
+  end
+
+  test 'warns when something stored cannot be read' do
+    stored_data_readable!(false)
+
+    assert_equal :unreadable, EncryptionKeyCheck.readability(logger: nil)
+    assert_equal EncryptionKeyCheck::WARNING, EncryptionKeyCheck.emit_warning!(logger: nil)
+  end
+
+  # A database that is not ready is the normal state during db:prepare, not a fault. It must
+  # not raise, and it must not print the banner.
+  test 'an unprepared database is indeterminate and produces no banner' do
+    EncryptedCredentials::Report.any_instance
+                                .stubs(:data_written_under_another_key?)
+                                .raises(ActiveRecord::StatementInvalid, 'no such table: rules')
+
+    assert_equal :indeterminate, EncryptionKeyCheck.readability(logger: nil)
+    assert_nothing_raised { assert_nil EncryptionKeyCheck.emit_warning!(logger: nil) }
+  end
+
+  # ...but it is not reported as health either.
+  test 'an indeterminate check is logged rather than passed over' do
+    EncryptedCredentials::Report.any_instance
+                                .stubs(:data_written_under_another_key?).raises(NoMethodError, 'boom')
+    logger = mock('logger')
+    logger.expects(:info).with(regexp_matches(/did not complete/))
+
+    assert_equal :indeterminate, EncryptionKeyCheck.readability(logger: logger)
+  end
+
+  # Nothing here may take an instance down. An instance in this state still holds recoverable
+  # data and is the one that needs the recovery task; refusing to run would be the lockout
+  # this whole change exists to prevent.
+  test 'no state raises' do
+    [true, false].each do |readable|
+      stored_data_readable!(readable)
+
+      assert_nothing_raised { EncryptionKeyCheck.emit_warning!(logger: nil) }
+    end
+  end
+
+  test 'the warning names the encryption key variables' do
+    assert_includes EncryptionKeyCheck::WARNING, EncryptionKeys::PRIMARY_KEY_VAR
+    assert_includes EncryptionKeyCheck::WARNING, EncryptionKeys::SALT_VAR
+  end
+
+  # It must not tell anyone to re-enter credentials: that would overwrite ciphertext a
+  # corrected key could still recover.
+  test 'the warning says to restore the previous values, not to re-enter data' do
+    assert_match(/restore/i, EncryptionKeyCheck::WARNING)
+    assert_no_match(/re-enter/i, EncryptionKeyCheck::WARNING)
+  end
+
+  test 'the warning names the command that shows what is stored' do
+    assert_includes EncryptionKeyCheck::WARNING, 'deltabadger:encryption:report'
+  end
+
+  # The module can be perfect and never called. Locating the boot branch by source text is the
+  # technique test/config/secret_key_base_guard_test.rb already uses for the same reason.
+  test 'the check is wired into boot, in production, on the deferred hook' do
+    source = Rails.root.join('config/initializers/encryption_key_check.rb').read
+
+    assert_match(/after_initialize/, source)
+    assert_match(/Rails\.env\.production\?/, source)
+    assert_match(/EncryptionKeyCheck\.emit_warning!/, source)
+  end
+end

--- a/test/config/encryption_keys_test.rb
+++ b/test/config/encryption_keys_test.rb
@@ -1,0 +1,265 @@
+# test/config/encryption_keys_test.rb
+require 'test_helper'
+require 'open3'
+
+# Resolution is pure and tested by passing an env hash rather than mutating ENV or
+# reconfiguring ActiveRecord::Encryption — global reconfiguration leaks across the parallel
+# test workers. Same approach as SslConfigurationTest.
+class EncryptionKeysTest < ActiveSupport::TestCase
+  SECRET = 'a-secret-key-base-value'.freeze
+  OTHER_SECRET = 'a-completely-different-secret'.freeze
+
+  # Written out literally rather than by calling the module, so a change to the module cannot
+  # silently redefine what "unchanged" means for an install that never opts in.
+  LEGACY_PRIMARY = Digest::SHA256.hexdigest("#{SECRET}-ar-encryption-primary").freeze
+  LEGACY_SALT = Digest::SHA256.hexdigest("#{SECRET}-ar-encryption-salt").freeze
+
+  test 'with neither variable set it reproduces the legacy derivation exactly' do
+    assert_equal LEGACY_PRIMARY, EncryptionKeys.primary_key({}, secret: SECRET)
+    assert_equal LEGACY_SALT, EncryptionKeys.key_derivation_salt({}, secret: SECRET)
+  end
+
+  test 'with both variables set they are used verbatim' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => 'primary-from-env',
+            EncryptionKeys::SALT_VAR => 'salt-from-env' }
+
+    assert_equal 'primary-from-env', EncryptionKeys.primary_key(env, secret: SECRET)
+    assert_equal 'salt-from-env', EncryptionKeys.key_derivation_salt(env, secret: SECRET)
+  end
+
+  # The whole point: the encryption key stops moving when the secret does.
+  test 'configured keys do not move when the secret changes' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => 'primary-from-env',
+            EncryptionKeys::SALT_VAR => 'salt-from-env' }
+
+    assert_equal EncryptionKeys.primary_key(env, secret: SECRET),
+                 EncryptionKeys.primary_key(env, secret: OTHER_SECRET)
+    assert_equal EncryptionKeys.key_derivation_salt(env, secret: SECRET),
+                 EncryptionKeys.key_derivation_salt(env, secret: OTHER_SECRET)
+  end
+
+  test 'without them both values move with the secret, which is the coupling being removed' do
+    assert_not_equal EncryptionKeys.primary_key({}, secret: SECRET),
+                     EncryptionKeys.primary_key({}, secret: OTHER_SECRET)
+    assert_not_equal EncryptionKeys.key_derivation_salt({}, secret: SECRET),
+                     EncryptionKeys.key_derivation_salt({}, secret: OTHER_SECRET)
+  end
+
+  test 'blank values are treated as absent' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => '', EncryptionKeys::SALT_VAR => '  ' }
+
+    assert_equal LEGACY_PRIMARY, EncryptionKeys.primary_key(env, secret: SECRET)
+    assert_not EncryptionKeys.independent?(env)
+    assert_not EncryptionKeys.partially_configured?(env)
+  end
+
+  test 'independent? is true only when both are present' do
+    assert EncryptionKeys.independent?(EncryptionKeys::PRIMARY_KEY_VAR => 'p',
+                                       EncryptionKeys::SALT_VAR => 's')
+    assert_not EncryptionKeys.independent?(EncryptionKeys::PRIMARY_KEY_VAR => 'p')
+    assert_not EncryptionKeys.independent?({})
+  end
+
+  # A key against the wrong salt makes every stored value fail to decrypt. Because
+  # support_unencrypted_data is on, that failure is silent: the read returns the raw
+  # ciphertext and a later write to that attribute stores it re-encrypted, past recovery.
+  # This combination must never reach a running app.
+  test 'validate! raises when only the primary key is set' do
+    error = assert_raises(EncryptionKeys::ConfigurationError) do
+      EncryptionKeys.validate!({ EncryptionKeys::PRIMARY_KEY_VAR => 'p' }, secret: SECRET)
+    end
+
+    assert_includes error.message, EncryptionKeys::SALT_VAR
+  end
+
+  test 'validate! raises when only the salt is set' do
+    error = assert_raises(EncryptionKeys::ConfigurationError) do
+      EncryptionKeys.validate!({ EncryptionKeys::SALT_VAR => 's' }, secret: SECRET)
+    end
+
+    assert_includes error.message, EncryptionKeys::PRIMARY_KEY_VAR
+  end
+
+  # A partial pair stops every environment-loading command, including the task that would
+  # tell the operator what to put back. So the message has to carry the values itself rather
+  # than naming a command they cannot run.
+  test 'the partial-pair message carries the derived values' do
+    error = assert_raises(EncryptionKeys::ConfigurationError) do
+      EncryptionKeys.validate!({ EncryptionKeys::PRIMARY_KEY_VAR => 'p' }, secret: SECRET)
+    end
+
+    assert_includes error.message, LEGACY_SALT
+  end
+
+  # An install that was ALREADY using its own keys and lost one must not be told to
+  # substitute the derived pair: those are not the values encrypting its data, and using
+  # them would make all of it unreadable. Restoring the original comes first.
+  test 'the partial-pair message says to restore the original before offering derived values' do
+    error = assert_raises(EncryptionKeys::ConfigurationError) do
+      EncryptionKeys.validate!({ EncryptionKeys::PRIMARY_KEY_VAR => 'p' }, secret: SECRET)
+    end
+
+    restore_index = error.message.index('ORIGINAL')
+    derived_index = error.message.index(LEGACY_SALT)
+
+    assert restore_index, 'the message must tell the operator to restore the original value'
+    assert restore_index < derived_index,
+           'restoring the original must come before the derived values are offered'
+    assert_match(/never used its own keys/i, error.message)
+  end
+
+  # Losing externally supplied keys must not look like an install that never had them:
+  # both absent is otherwise a legitimate state, and the app would quietly derive a
+  # different pair and read nothing.
+  test 'validate! raises when the marker is set but the keys are gone' do
+    error = assert_raises(EncryptionKeys::ConfigurationError) do
+      EncryptionKeys.validate!({ EncryptionKeys::EXTERNAL_MARKER_VAR => 'true' }, secret: SECRET)
+    end
+
+    assert_match(/set up with its own encryption keys/i, error.message)
+    assert_includes error.message, EncryptionKeys::EXTERNAL_MARKER_VAR
+  end
+
+  test 'validate! accepts the marker when the keys are present' do
+    assert_nil EncryptionKeys.validate!(
+      { EncryptionKeys::EXTERNAL_MARKER_VAR => 'true',
+        EncryptionKeys::PRIMARY_KEY_VAR => 'p', EncryptionKeys::SALT_VAR => 's' }, secret: SECRET
+    )
+  end
+
+  test 'validate! accepts both set and neither set' do
+    assert_nil EncryptionKeys.validate!({}, secret: SECRET)
+    assert_nil EncryptionKeys.validate!(
+      { EncryptionKeys::PRIMARY_KEY_VAR => 'p', EncryptionKeys::SALT_VAR => 's' }, secret: SECRET
+    )
+  end
+
+  # Tells the guard whether configured values still expose the data. Values taken FROM a
+  # secret are exactly as recoverable as that secret.
+  test 'derived_from_secret? recognises values taken from the current secret' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => LEGACY_PRIMARY,
+            EncryptionKeys::SALT_VAR => LEGACY_SALT }
+
+    assert EncryptionKeys.derived_from_secret?(env, secret: SECRET)
+    assert_not EncryptionKeys.derived_from_secret?(env, secret: OTHER_SECRET)
+  end
+
+  test 'derived_from_secret? is false for independently generated values' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => SecureRandom.hex(32),
+            EncryptionKeys::SALT_VAR => SecureRandom.hex(32) }
+
+    assert_not EncryptionKeys.derived_from_secret?(env, secret: SECRET)
+  end
+
+  test 'derived_from_secret? is false when nothing is configured' do
+    assert_not EncryptionKeys.derived_from_secret?({}, secret: SECRET)
+  end
+
+  # THE WIRING TESTS. These boot the app in a subprocess and read back what
+  # ActiveRecord::Encryption is actually configured with. Asserting against the module
+  # in-process proves nothing: with the variables cleared, an initializer that ignored
+  # EncryptionKeys would compute the same fallback and pass. Only a boot with the variables
+  # SET can tell the two apart.
+  test 'a boot with both variables set uses them, and they do not move with the secret' do
+    primary = SecureRandom.hex(32)
+    salt = SecureRandom.hex(32)
+    configured = { EncryptionKeys::PRIMARY_KEY_VAR => primary, EncryptionKeys::SALT_VAR => salt }
+
+    first = booted_encryption_config(configured.merge('SECRET_KEY_BASE' => SecureRandom.hex(64)))
+    second = booted_encryption_config(configured.merge('SECRET_KEY_BASE' => SecureRandom.hex(64)))
+
+    assert_equal [primary, salt], first, 'the initializer ignored the configured keys'
+    assert_equal first, second, 'the configured keys moved when the secret changed'
+  end
+
+  # The control. Without them the values still track the secret, which is what makes the
+  # test above meaningful rather than vacuously true.
+  test 'a boot with neither variable set still derives from the secret' do
+    first = booted_encryption_config('SECRET_KEY_BASE' => SecureRandom.hex(64))
+    second = booted_encryption_config('SECRET_KEY_BASE' => SecureRandom.hex(64))
+
+    assert_not_equal first, second
+  end
+
+  # THE MONEY TEST, through the real model and the real attribute type.
+  # with_encryption_context is block-scoped and thread-local, so unlike reconfiguring
+  # globally it cannot leak into another test or worker.
+  test 'a stored value survives a secret change when the keys are configured' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => SecureRandom.hex(32),
+            EncryptionKeys::SALT_VAR => SecureRandom.hex(32) }
+
+    record = with_keys(env, secret: SECRET) do
+      AppConfig.create!(key: 'encryption_keys_probe', value: 'stored-value')
+    end
+    stored = raw_value(record.id)
+
+    read_back = with_keys(env, secret: OTHER_SECRET) { AppConfig.find(record.id).value }
+
+    assert_equal 'stored-value', read_back
+    assert_equal stored, raw_value(record.id), 'reading must not rewrite the stored ciphertext'
+  end
+
+  # The failure this change removes. Note it does NOT raise: support_unencrypted_data returns
+  # the ciphertext as though it were the value, which is why a wrong key is dangerous rather
+  # than merely broken.
+  test 'without configured keys a secret change makes the stored value unreadable' do
+    record = with_keys({}, secret: SECRET) do
+      AppConfig.create!(key: 'encryption_keys_probe', value: 'stored-value')
+    end
+
+    read_back = with_keys({}, secret: OTHER_SECRET) { AppConfig.find(record.id).value }
+
+    assert_not_equal 'stored-value', read_back
+    assert ActiveRecord::Encryption.encryptor.encrypted?(read_back),
+           'the failed read should have returned the ciphertext, which is the hazard'
+  end
+
+  # Setting the values an install already derives has to be a no-op: data written before has
+  # to read back after, or opting in would destroy everything.
+  test 'setting the derived values reads back data written before they were set' do
+    record = with_keys({}, secret: SECRET) do
+      AppConfig.create!(key: 'encryption_keys_probe', value: 'stored-value')
+    end
+    pinned = { EncryptionKeys::PRIMARY_KEY_VAR => LEGACY_PRIMARY,
+               EncryptionKeys::SALT_VAR => LEGACY_SALT }
+
+    read_back = with_keys(pinned, secret: OTHER_SECRET) { AppConfig.find(record.id).value }
+
+    assert_equal 'stored-value', read_back
+  end
+
+  private
+
+  # Boots the app and reports what ActiveRecord::Encryption ended up configured with.
+  def booted_encryption_config(env)
+    script = 'print [ActiveRecord::Encryption.config.primary_key, ' \
+             'ActiveRecord::Encryption.config.key_derivation_salt].join("|")'
+    stdout, stderr, status = Open3.capture3(
+      ENV.to_h.merge('RAILS_ENV' => 'test').merge(env),
+      Rails.root.join('bin/rails').to_s, 'runner', script, chdir: Rails.root.to_s
+    )
+    assert status.success?, "boot failed: #{stderr}"
+    stdout.strip.split('|')
+  end
+
+  # Runs the block with the key provider the app would use for this env and secret.
+  # Block-scoped, so nothing leaks past it.
+  def with_keys(env, secret:, &block)
+    ActiveRecord::Encryption.with_encryption_context(
+      key_provider: provider_for(env, secret: secret), &block
+    )
+  end
+
+  def provider_for(env, secret:)
+    derived = ActiveSupport::KeyGenerator
+              .new(EncryptionKeys.primary_key(env, secret: secret),
+                   hash_digest_class: ActiveRecord::Encryption.config.hash_digest_class)
+              .generate_key(EncryptionKeys.key_derivation_salt(env, secret: secret),
+                            ActiveRecord::Encryption.cipher.key_length)
+    ActiveRecord::Encryption::KeyProvider.new([ActiveRecord::Encryption::Key.new(derived)])
+  end
+
+  def raw_value(id)
+    AppConfig.connection.select_value("SELECT value FROM app_configs WHERE id = #{id}")
+  end
+end

--- a/test/config/secret_key_base_guard_test.rb
+++ b/test/config/secret_key_base_guard_test.rb
@@ -399,4 +399,82 @@ class SecretKeyBaseGuardTest < ActiveSupport::TestCase
   def readme_recovery_section
     File.read(Rails.root.join('README.md'))[/### Moving to a new SECRET_KEY_BASE.*?\n### /m]
   end
+
+  test 'data is exposed when no independent keys are configured' do
+    assert SecretKeyBaseGuard.data_exposed_by?('dev-secret-key-not-for-production', {})
+  end
+
+  # Values taken FROM the secret are exactly as recoverable as the secret itself.
+  test 'data is exposed when the configured keys were taken from this secret' do
+    secret = 'dev-secret-key-not-for-production'
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => EncryptionKeys.derived_primary_key(secret),
+            EncryptionKeys::SALT_VAR => EncryptionKeys.derived_salt(secret) }
+
+    assert SecretKeyBaseGuard.data_exposed_by?(secret, env)
+  end
+
+  test 'data is not exposed when the configured keys are independent' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => SecureRandom.hex(32),
+            EncryptionKeys::SALT_VAR => SecureRandom.hex(32) }
+
+    assert_not SecretKeyBaseGuard.data_exposed_by?('dev-secret-key-not-for-production', env)
+  end
+
+  test 'a published secret with exposed data gets the full recovery procedure' do
+    assert_equal SecretKeyBaseGuard::PUBLISHED_WARNING,
+                 SecretKeyBaseGuard.warning_for('dev-secret-key-not-for-production', {})
+  end
+
+  test 'a published secret with independent keys gets the shorter procedure' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => SecureRandom.hex(32),
+            EncryptionKeys::SALT_VAR => SecureRandom.hex(32) }
+
+    assert_equal SecretKeyBaseGuard::PUBLISHED_SESSIONS_WARNING,
+                 SecretKeyBaseGuard.warning_for('dev-secret-key-not-for-production', env)
+  end
+
+  # Telling an operator to revoke every exchange key is expensive and, where the data was
+  # never derivable from this secret, wrong.
+  test 'the shorter procedure does not send the operator to revoke exchange keys' do
+    assert_not_includes SecretKeyBaseGuard::PUBLISHED_SESSIONS_WARNING, 'exchange'
+    assert_includes SecretKeyBaseGuard::PUBLISHED_WARNING, 'REVOKE'
+  end
+
+  # Bearer tokens are stored in the clear and survive the replacement, so someone who could
+  # forge a session may have minted one that outlives it.
+  test 'the shorter procedure still says to revoke API and MCP tokens' do
+    assert_match(/MCP/, SecretKeyBaseGuard::PUBLISHED_SESSIONS_WARNING)
+  end
+
+  # Password-reset and confirmation links are signed with this value, so they stop working.
+  test 'the shorter procedure warns that pending email links stop working' do
+    assert_match(/password/i, SecretKeyBaseGuard::PUBLISHED_SESSIONS_WARNING)
+  end
+
+  test 'a short secret with independent keys gets the shorter notice' do
+    env = { EncryptionKeys::PRIMARY_KEY_VAR => SecureRandom.hex(32),
+            EncryptionKeys::SALT_VAR => SecureRandom.hex(32) }
+
+    assert_equal SecretKeyBaseGuard::SHORT_SESSIONS_WARNING,
+                 SecretKeyBaseGuard.warning_for('a' * 10, env)
+  end
+
+  test 'a strong secret still warns about nothing' do
+    assert_nil SecretKeyBaseGuard.warning_for(SecureRandom.hex(64), {})
+  end
+
+  # An operator who set the derived pair has it overriding the new secret. Without this, the
+  # credentials they enter at the end of the recovery are encrypted under the same key they
+  # were recovering from, and the whole procedure achieves nothing.
+  test 'the full recovery says to clear the encryption key variables too' do
+    assert_includes SecretKeyBaseGuard::PUBLISHED_WARNING, EncryptionKeys::PRIMARY_KEY_VAR
+    assert_includes SecretKeyBaseGuard::PUBLISHED_WARNING, EncryptionKeys::SALT_VAR
+  end
+
+  # An install with a database is never handed a generated pair, so promising one would leave
+  # the operator re-coupled to SECRET_KEY_BASE without knowing it.
+  test 'the full recovery does not promise a pair that will not be generated' do
+    assert_no_match(/generated for you/i, SecretKeyBaseGuard::PUBLISHED_WARNING)
+    assert_includes SecretKeyBaseGuard::PUBLISHED_WARNING, 'deltabadger:encryption:derived_keys'
+  end
 end

--- a/test/lib/tasks/encryption_rake_test.rb
+++ b/test/lib/tasks/encryption_rake_test.rb
@@ -238,4 +238,97 @@ class EncryptionRakeTest < ActiveSupport::TestCase
 
     assert_no_match(/revoke/i, out)
   end
+
+  test 'derived_keys prints both variables with the values this install derives' do
+    output = capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }.first
+    secret = Rails.application.secret_key_base
+
+    assert_includes output, "#{EncryptionKeys::PRIMARY_KEY_VAR}=#{EncryptionKeys.derived_primary_key(secret)}"
+    assert_includes output, "#{EncryptionKeys::SALT_VAR}=#{EncryptionKeys.derived_salt(secret)}"
+  end
+
+  # The values it prints have to be the ones the initializer resolves, or setting them would
+  # change the key and make everything stored unreadable.
+  test 'derived_keys matches what the initializer resolves with nothing configured' do
+    output = capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }.first
+    secret = Rails.application.secret_key_base
+
+    assert_includes output, EncryptionKeys.primary_key({}, secret: secret)
+    assert_includes output, EncryptionKeys.key_derivation_salt({}, secret: secret)
+  end
+
+  # On an install that already has its own keys, the derived values are NOT the ones
+  # encrypting its data. Printing them next to an instruction to copy them in would replace
+  # working keys with wrong ones.
+  test 'derived_keys prints no values once the install has its own keys' do
+    EncryptionKeys.stubs(:independent?).returns(true)
+    output = capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }.first
+    secret = Rails.application.secret_key_base
+
+    assert_not_includes output, EncryptionKeys.derived_primary_key(secret)
+    assert_not_includes output, EncryptionKeys.derived_salt(secret)
+    assert_match(/already/i, output)
+  end
+
+  # The common failure is SECRET_KEY_BASE replaced on an install with no configured pair.
+  # independent? is false there, so without this guard the task would print keys derived from
+  # the NEW, wrong secret and describe them as the values already in use.
+  test 'derived_keys prints no values when stored data cannot be read' do
+    EncryptionKeyCheck.stubs(:readability).returns(:unreadable)
+    output = capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }.first
+
+    assert_not_includes output, EncryptionKeys.derived_primary_key(Rails.application.secret_key_base)
+    assert_match(/not printed/i, output)
+  end
+
+  # Same for a check that could not complete. A locked or damaged database says nothing about
+  # which keys are right, and printing a pair on that basis is what makes a loss permanent.
+  test 'derived_keys prints no values when readability could not be determined' do
+    EncryptionKeyCheck.stubs(:readability).returns(:indeterminate)
+    output = capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }.first
+
+    assert_not_includes output, EncryptionKeys.derived_primary_key(Rails.application.secret_key_base)
+    assert_match(/not printed/i, output)
+  end
+
+  # The entrypoint owns the secrets file. A task that wrote it would be a second writer with
+  # no coordination, and on a compose-supplied install would write to a file that governs
+  # nothing.
+  test 'derived_keys writes nothing' do
+    File.expects(:write).never
+    File.expects(:open).never
+
+    capture_io { Rake::Task['deltabadger:encryption:derived_keys'].invoke }
+  end
+
+  # The reset output is the authoritative copy of this procedure — an operator in a terminal
+  # is not reading the README. Left set, these re-encrypt the replacement credentials under
+  # the key the reset exists to get away from.
+  test 'reset tells an install with its own encryption keys to clear them' do
+    EncryptionKeys.stubs(:independent?).returns(true)
+    ENV['CONFIRM'] = 'clear-credentials'
+    output = capture_io { Rake::Task['deltabadger:encryption:reset'].invoke }.first
+
+    assert_includes output, EncryptionKeys::PRIMARY_KEY_VAR
+    assert_includes output, EncryptionKeys::SALT_VAR
+  end
+
+  # An install with a database is never handed a generated pair, so promising one would leave
+  # the operator re-coupled to SECRET_KEY_BASE without knowing it.
+  test 'reset does not promise a pair that will not be generated' do
+    EncryptionKeys.stubs(:independent?).returns(true)
+    ENV['CONFIRM'] = 'clear-credentials'
+    output = capture_io { Rake::Task['deltabadger:encryption:reset'].invoke }.first
+
+    assert_no_match(/will be generated|generated for you/i, output)
+    assert_includes output, 'deltabadger:encryption:derived_keys'
+  end
+
+  test 'reset says nothing about them on an install that does not set them' do
+    EncryptionKeys.stubs(:independent?).returns(false)
+    ENV['CONFIRM'] = 'clear-credentials'
+    output = capture_io { Rake::Task['deltabadger:encryption:reset'].invoke }.first
+
+    assert_not_includes output, EncryptionKeys::PRIMARY_KEY_VAR
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,15 @@ ENV['RAILS_ENV'] ||= 'test'
 # (handy for pointing `rails server` at a real data-api) would otherwise flip the
 # whole suite into hosted mode and fail every stock/market-data assertion.
 # Same intent as WebMock.disable_net_connect! below: cut the suite off from ambient config.
-%w[MARKET_DATA_URL MARKET_DATA_TOKEN MARKET_DATA_PROVIDER_NAME].each { |key| ENV.delete(key) }
+#
+# The encryption keys are here for the same reason and one more: with them set, the app
+# encrypts under those instead of deriving from secret_key_base, so a developer who had
+# exported them would run a suite configured differently from CI.
+%w[
+  MARKET_DATA_URL MARKET_DATA_TOKEN MARKET_DATA_PROVIDER_NAME
+  ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+  ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL
+].each { |key| ENV.delete(key) }
 
 require_relative '../config/environment'
 require 'rails/test_help'


### PR DESCRIPTION
`SECRET_KEY_BASE` is currently the root of the ActiveRecord Encryption key *and* the session
secret. Those have opposite lifecycles — replacing a session secret should cost a re-login,
while replacing a data key costs re-encrypting everything — so binding them means the cheap
operation inherits the cost of the expensive one. Today, changing `SECRET_KEY_BASE` makes every
stored credential unreadable and locks out anyone using two-factor.

Underneath that is a derivation salt that is not independent of the key it salts. Rails'
encryption is built on the opposite assumption: `key_derivation_salt` is a stable per-install
constant and `primary_key` is the rotatable input. That is what
`config.active_record.encryption.previous` is designed around, and why `KeyGenerator.new`
takes no salt. Deriving both from one value inverts that, and every workaround for it is
compensating code written against Rails internals.

This restores the invariant rather than working around it.

## What changes

`ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY` and `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` are
read if set, and otherwise derived exactly as before. An install that sets neither is
byte-for-byte unchanged and needs no migration. The fallback derivation stays in the codebase
permanently: it is the only way to recompute the key that wrote a given install's data from an
older secret.

Installs created from scratch get their own generated pair, so `SECRET_KEY_BASE` is free to
change from the start. Anything created earlier opts in with
`rake deltabadger:encryption:derived_keys`, which prints the values that install already
derives — setting them changes nothing at the time and frees the secret afterwards.

Nothing here re-encrypts stored data, and no existing procedure changes shape. `db/schema.rb`
is untouched; there is no migration.

## Guards, all of them tested

A failed decrypt does not raise. `support_unencrypted_data` returns the ciphertext as though it
were the value, so a wrong key is invisible until a stored value surfaces as a base64 blob, and
saving over one replaces it for good. Everything below exists because of that.

- **Half a pair refuses to start.** A key used against a different salt reads nothing. The
  message carries the values it needs, since that state stops the task that would otherwise
  print them — and it leads with restoring the original, because an install that already had
  its own keys must not substitute derived ones.
- **Only a provably fresh install gets generated keys** — no secrets file *and* no database, by
  path or by `DATABASE_URL`. Restoring a database without the hidden secrets file, while the
  secret comes from the environment, otherwise arrives with data present and no file.
- **Creation and adoption are one atomic step.** More than one container can share a volume;
  losing the race means adopting the winner's file, not continuing on locally generated values.
- **The key and its salt come from one source.** One supplied through the environment never
  combines with the other read from the file, and blank-after-trimming counts as absent so the
  shell and the app agree on what "set" means.
- **Nothing supplied through the environment is stored.** A stored copy of a value coming from
  elsewhere is ignored while that source exists and adopted silently when it stops. Absent
  instead, the same loss stops the container. Keys supplied that way leave a marker, so losing
  them is distinguishable from never having had them.
- **A startup note** names the state if it happens anyway, and says to restore a key rather
  than re-enter anything.
- **`derived_keys` prints nothing when the values would be wrong** — once an install has its
  own keys, or while stored values cannot be read, what it derives is not what encrypted them.

## Adjustments to existing text

The startup note assumed `secret_key_base` always determines the encryption key. Where the two
are configured separately that no longer holds, so it now distinguishes the cases, including
when the configured keys were derived from the secret and therefore track it exactly.

It also covers what replacing the secret does not reach: REST API and MCP bearer tokens derive
from nothing, and password reset and confirmation links already sent stop working. The reset
task's own output gains the same distinction, since that is the copy read in a terminal.

## Verification

3105 runs, 0 failures, 0 errors. Rubocop clean.

The wiring tests boot the app in a subprocess with the variables set and read back what
`ActiveRecord::Encryption` is actually configured with. Asserting in-process proves nothing:
with the variables cleared, an initializer that ignored the new module computes the same
fallback and passes. The round-trip test goes through `AppConfig` and the real attribute type,
and asserts the stored ciphertext is unchanged by reading it.

Rehearsed end to end: the entrypoint provisions a fresh install, and Rails resolves exactly the
provisioned key, identical across two different `SECRET_KEY_BASE` values, where an install
without them resolves two different keys.

## Follow-ups, deliberately not here

`support_unencrypted_data = true` is a migration affordance that became permanent global
configuration, and it is what turns a wrong key into a silent one. Scoping it per-attribute or
removing it needs evidence this change does not: whether any install still holds genuinely
unencrypted rows.

Re-encrypting stored data remains unbuilt. After this it would be stock Rails — hold the salt,
rotate the key, `previous:` — rather than the bespoke thing it would have had to be.
