### PR TITLE
Keep the encryption key banner out of the test output

### DIFF
--- a/test/config/encryption_key_check_test.rb
+++ b/test/config/encryption_key_check_test.rb
@@ -7,18 +7,27 @@ class EncryptionKeyCheckTest < ActiveSupport::TestCase
                                 .stubs(:data_written_under_another_key?).returns(!value)
   end
 
+  # capture_io on every emit_warning! call: the banner goes to stderr whatever the logger is,
+  # so an uncaptured call prints it into the test output. Capturing also lets these assert the
+  # thing that matters — that the operator sees it — rather than only what the caller gets back.
   test 'says nothing when everything stored decrypts' do
     stored_data_readable!(true)
 
     assert_equal :readable, EncryptionKeyCheck.readability(logger: nil)
-    assert_nil EncryptionKeyCheck.emit_warning!(logger: nil)
+    _out, err = capture_io { assert_nil EncryptionKeyCheck.emit_warning!(logger: nil) }
+
+    assert_empty err
   end
 
   test 'warns when something stored cannot be read' do
     stored_data_readable!(false)
-
     assert_equal :unreadable, EncryptionKeyCheck.readability(logger: nil)
-    assert_equal EncryptionKeyCheck::WARNING, EncryptionKeyCheck.emit_warning!(logger: nil)
+
+    emitted = nil
+    _out, err = capture_io { emitted = EncryptionKeyCheck.emit_warning!(logger: nil) }
+
+    assert_equal EncryptionKeyCheck::WARNING, emitted
+    assert_equal EncryptionKeyCheck::WARNING, err
   end
 
   # A database that is not ready is the normal state during db:prepare, not a fault. It must
@@ -29,7 +38,11 @@ class EncryptionKeyCheckTest < ActiveSupport::TestCase
                                 .raises(ActiveRecord::StatementInvalid, 'no such table: rules')
 
     assert_equal :indeterminate, EncryptionKeyCheck.readability(logger: nil)
-    assert_nothing_raised { assert_nil EncryptionKeyCheck.emit_warning!(logger: nil) }
+    _out, err = capture_io do
+      assert_nothing_raised { assert_nil EncryptionKeyCheck.emit_warning!(logger: nil) }
+    end
+
+    assert_empty err
   end
 
   # ...but it is not reported as health either.
@@ -49,7 +62,7 @@ class EncryptionKeyCheckTest < ActiveSupport::TestCase
     [true, false].each do |readable|
       stored_data_readable!(readable)
 
-      assert_nothing_raised { EncryptionKeyCheck.emit_warning!(logger: nil) }
+      capture_io { assert_nothing_raised { EncryptionKeyCheck.emit_warning!(logger: nil) } }
     end
   end
 


### PR DESCRIPTION
`EncryptionKeyCheck.emit_warning!` writes its banner to stderr regardless of the logger it is
given, so the two tests that take the unreadable path printed the full ENCRYPTION KEY NOTICE
into every test run. With parallel workers sharing one stderr and a banner larger than an
atomic pipe write, two copies interleaved mid-line — which reads as the banner spliced into
itself:

```
To see what is stored:
  docker compose run ============================== ENCRYPTION KEY NOTICE ====...
```

Nothing is wrong with the banner or with writing it to stderr at boot; the test file just
never captured it. `test/config/secret_key_base_guard_test.rb` already wraps every
`emit_warning!` call in `capture_io` and asserts on `err`, and this brings the newer file in
line.

The capture is also worth an assertion rather than a bare silencing. The readable and
indeterminate paths now assert stderr is empty, so a banner printed on a healthy instance's
boot fails a test instead of becoming noise, and the unreadable path asserts the operator
actually sees the banner rather than only that the caller gets it back.

Test-only. `bin/rails test` is green at 3105 runs / 10593 assertions, and the file goes from
27 to 32 assertions.
