### PR TITLE
Complete the Content Security Policy: no inline script, nonce for what gems render

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,11 @@
 import "@hotwired/turbo-rails";
 import "./controllers";
 import "./tauri";
+
+// Progressive web app support. All three layouts include this bundle, so the one
+// registration covers every page; registration is idempotent.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/service-worker.js").catch((error) => {
+    console.log("ServiceWorker registration failed: ", error);
+  });
+}

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,26 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="clipboard"
+// Copies a literal value to the clipboard.
+//
+// <span data-controller="clipboard"
+//       data-clipboard-text-value="https://example.com"
+//       data-action="click->clipboard#copy">
 export default class extends Controller {
-  static targets = ["input", "alert"];
+  static values = { text: String }
 
   copy() {
-    const input = this.inputTarget;
-
-    try {
-      navigator.clipboard.writeText(input.value);
-      this.#showAlert();
-    } catch (error) {
-      console.error("Clipboard copy failed", error);
-    }
-  }
-
-  #showAlert() {
-    const alert = this.alertTarget;
-    alert.style.visibility = "visible";
-
-    setTimeout(() => {
-      alert.style.visibility = "hidden";
-    }, 2000);
+    navigator.clipboard.writeText(this.textValue).catch((error) => {
+      console.error("Clipboard copy failed", error)
+    })
   }
 }

--- a/app/javascript/controllers/file_picker_controller.js
+++ b/app/javascript/controllers/file_picker_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="file-picker"
+// Opens a hidden file input from a visible button, and submits the form once a
+// file has been chosen.
+//
+// <form data-controller="file-picker">
+//   <button type="button" data-action="click->file-picker#open">Import</button>
+//   <input type="file" hidden
+//          data-file-picker-target="input"
+//          data-action="change->file-picker#submit">
+// </form>
+export default class extends Controller {
+  static targets = ["input"]
+
+  open() {
+    this.inputTarget.click()
+  }
+
+  submit() {
+    this.inputTarget.form.submit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -127,6 +127,9 @@ application.register("progress-bar", ProgressBarController)
 import RemovalsController from "./removals_controller"
 application.register("removals", RemovalsController)
 
+import RevealChromeController from "./reveal_chrome_controller"
+application.register("reveal-chrome", RevealChromeController)
+
 import RuleToggleController from "./rule_toggle_controller"
 application.register("rule-toggle", RuleToggleController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -49,6 +49,9 @@ application.register("donut-chart", DonutChartController)
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
 
+import FilePickerController from "./file_picker_controller"
+application.register("file-picker", FilePickerController)
+
 import FlatpickrController from "./flatpickr_controller"
 application.register("flatpickr", FlatpickrController)
 

--- a/app/javascript/controllers/index_filter_controller.js
+++ b/app/javascript/controllers/index_filter_controller.js
@@ -4,7 +4,17 @@ import { Controller } from "@hotwired/stimulus"
 // Filters index tiles based on search input matching name or description
 // Prioritizes name matches over description-only matches
 export default class extends Controller {
-  static targets = ["input", "tile", "empty", "container"]
+  static targets = ["input", "tile", "empty", "container", "categoryIdField", "nameField"]
+
+  // The tiles are submit buttons, so the form posts either way; this is what
+  // gives the post its subject. Click handlers run before submission, so the
+  // fields are populated by the time the form leaves.
+  select(event) {
+    const tile = event.currentTarget
+
+    this.categoryIdFieldTarget.value = tile.dataset.indexCategoryId || ""
+    this.nameFieldTarget.value = tile.dataset.indexName || ""
+  }
 
   filter() {
     const query = this.inputTarget.value.toLowerCase().trim()

--- a/app/javascript/controllers/reveal_chrome_controller.js
+++ b/app/javascript/controllers/reveal_chrome_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="reveal-chrome"
+// Pages rendered with content_for(:hide_chrome) start with the chrome hidden so a
+// modal can open over a bare background. A modalIsOpen event with a falsy detail
+// means the modal has closed, so the chrome comes back. On a page without the
+// class, removing it is a no-op.
+export default class extends Controller {
+  connect() {
+    window.addEventListener("modalIsOpen", this.#reveal)
+  }
+
+  disconnect() {
+    window.removeEventListener("modalIsOpen", this.#reveal)
+  }
+
+  #reveal = (event) => {
+    if (event.detail) return
+
+    this.element.classList.remove("hide-chrome")
+    window.removeEventListener("modalIsOpen", this.#reveal)
+  }
+}

--- a/app/javascript/tauri.js
+++ b/app/javascript/tauri.js
@@ -1,11 +1,11 @@
 if (window.__IS_TAURI__) {
     (async () => {
+        document.documentElement.classList.add('tauri');
+
         const { open } = await import('@tauri-apps/plugin-shell');
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         const { save } = await import('@tauri-apps/plugin-dialog');
         const { writeTextFile } = await import('@tauri-apps/plugin-fs');
-
-        document.documentElement.classList.add('tauri');
 
         const appWindow = getCurrentWindow();
 

--- a/app/javascript/tauri_boot.js
+++ b/app/javascript/tauri_boot.js
@@ -1,0 +1,5 @@
+// Sets the desktop class while the head is still parsing, before the stylesheet
+// applies, so the chrome never paints in its browser form first. The main bundle
+// cannot do this: it is deferred, and its desktop module resolves several dynamic
+// imports before it gets there.
+if (window.__IS_TAURI__) document.documentElement.classList.add("tauri");

--- a/app/views/bots/dca_indexes/pick_indices/new.html.erb
+++ b/app/views/bots/dca_indexes/pick_indices/new.html.erb
@@ -24,8 +24,9 @@
                   data-index-filter-target="tile"
                   data-index-order="<%= idx %>"
                   data-index-name="<%= index.name %>"
+                  data-index-category-id="<%= index.external_id %>"
                   data-index-description="<%= index.description %>"
-                  onclick="this.form.querySelector('#index_category_id').value='<%= j(index.external_id) %>'; this.form.querySelector('#index_name').value='<%= j(index.name) %>';">
+                  data-action="click->index-filter#select">
             <h4><%= index.name %></h4>
             <p><%= truncate(index.description, length: 150) %></p>
             <% if index.top_coins.present? %>
@@ -50,8 +51,8 @@
           </button>
         <% end %>
       <% end %>
-      <%= hidden_field_tag :index_category_id, '', id: 'index_category_id' %>
-      <%= hidden_field_tag :index_name, '', id: 'index_name' %>
+      <%= hidden_field_tag :index_category_id, '', id: 'index_category_id', data: { index_filter_target: 'categoryIdField' } %>
+      <%= hidden_field_tag :index_name, '', id: 'index_name', data: { index_filter_target: 'nameField' } %>
     <% end %>
 
     <div class="index-search__empty" data-index-filter-target="empty" style="display: none;">

--- a/app/views/bots/orders/_export.html.erb
+++ b/app/views/bots/orders/_export.html.erb
@@ -12,11 +12,12 @@
   </div>
 
   <div id="<%= dom_id(bot, :import) %>">
-    <%= form_with url: bot_import_path(bot), method: :post, multipart: true, data: { turbo: false }, id: dom_id(bot, :import_form) do |f| %>
-      <button type="button" class="sinput" onclick="this.nextElementSibling.click()">
+    <%= form_with url: bot_import_path(bot), method: :post, multipart: true, data: { turbo: false, controller: 'file-picker' }, id: dom_id(bot, :import_form) do |f| %>
+      <button type="button" class="sinput" data-action="click->file-picker#open">
         <%= t('bot.details.stats.import_csv') %>
       </button>
-      <%= f.file_field :file, accept: '.csv', hidden: true, onchange: "this.form.submit();" %>
+      <%= f.file_field :file, accept: '.csv', hidden: true,
+                       data: { file_picker_target: 'input', action: 'change->file-picker#submit' } %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,45 +14,14 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
+    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
     <%= yield :head if content_for?(:head) %>
-
-    <script>
-      // service worker registration for PWA
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register("/service-worker.js").then(function(registration) {
-          // console.log('ServiceWorker registration successful with scope: ', registration.scope);
-        }).catch(function(error) {
-          console.log('ServiceWorker registration failed: ', error);
-        });
-      }
-    </script>
-
-    <script>
-      (async () => {
-        if (window.__IS_TAURI__) {
-          document.documentElement.classList.add('tauri');
-
-          const { getCurrentWindow } = await import('@tauri-apps/api/window');
-          const appWindow = getCurrentWindow();
-
-          const dragRegion = document.querySelector('.titlebar-drag-region');
-          if (dragRegion) {
-            dragRegion.addEventListener('mousedown', async (e) => {
-              if (e.buttons === 1) {
-                await appWindow.startDragging();
-              }
-            });
-          }
-        }
-      })();
-    </script>
-    
   </head>
 
-  <body data-controller="hotwire-animations app-wake ticker-tooltips" data-locale="<%= I18n.locale %>" <% if content_for?(:hide_chrome) %>class="hide-chrome"<% end %>>
+  <body data-controller="hotwire-animations app-wake ticker-tooltips reveal-chrome" data-locale="<%= I18n.locale %>" <% if content_for?(:hide_chrome) %>class="hide-chrome"<% end %>>
 
     <div data-tauri-drag-region class="titlebar-drag-region"></div>
 
@@ -70,18 +39,6 @@
     </main>
 
     <%= turbo_frame_tag 'modal', src: (content_for(:modal_src) if content_for?(:modal_src)) %>
-
-    <% if content_for?(:hide_chrome) %>
-      <script>
-        function revealChrome(e) {
-          if (!e.detail) {
-            document.body.classList.remove('hide-chrome')
-            window.removeEventListener('modalIsOpen', revealChrome)
-          }
-        }
-        window.addEventListener('modalIsOpen', revealChrome)
-      </script>
-    <% end %>
 
   </body>
 </html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -9,22 +9,12 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
+    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <script>
-      // service worker registration for PWA
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register("/service-worker.js").then(function(registration) {
-          console.log('ServiceWorker registration successful with scope: ', registration.scope);
-        }).catch(function(error) {
-          console.log('ServiceWorker registration failed: ', error);
-        });
-      }
-    </script>
   </head>
 
   <body data-controller="hotwire-animations">

--- a/app/views/layouts/guest.html.erb
+++ b/app/views/layouts/guest.html.erb
@@ -8,13 +8,7 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
-    <script>
-      // Tauri detection - add class to html element for CSS targeting
-      if (window.__TAURI__) {
-        document.documentElement.classList.add('tauri');
-      }
-    </script>
-
+    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
@@ -22,17 +16,6 @@
     <%= csp_meta_tag %>
 
     <%= yield(:head) %>
-
-    <script>
-      let root = document.documentElement;
-
-      window.addEventListener("scroll", function() {
-        const distance = window.scrollY;
-        if (distance > 10) {
-          root.classList.add("has-been-scrolled");
-        }
-      });
-    </script>
   </head>
 
   <body data-controller="hotwire-animations">

--- a/app/views/settings/widgets/_mcp.html.erb
+++ b/app/views/settings/widgets/_mcp.html.erb
@@ -3,7 +3,7 @@
     <h4 class="modal__title"><%= t('settings.mcp.title') %></h4>
 
     <p class="text-center" style="text-wrap: balance"><%= t('settings.mcp.description') %></p>
-    <span class="tag tag--copy" id="mcp_url_display" data-url="<%= AppConfig.mcp_url %>" onclick="navigator.clipboard.writeText(this.dataset.url)" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= AppConfig.mcp_url&.sub(%r{\Ahttps?://}, '') %></span>
+    <span class="tag tag--copy" id="mcp_url_display" data-controller="clipboard" data-clipboard-text-value="<%= AppConfig.mcp_url %>" data-action="click->clipboard#copy" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= AppConfig.mcp_url&.sub(%r{\Ahttps?://}, '') %></span>
 
     <div id="mcp_tool_permissions" class="mcp-tool-permissions">
 

--- a/app/views/settings/widgets/_rest.html.erb
+++ b/app/views/settings/widgets/_rest.html.erb
@@ -11,10 +11,10 @@
     </p>
 
     <div class="mcp-tool-permissions__group">
-      <span class="tag tag--copy" id="rest_api_url_display" data-url="<%= AppConfig.api_url %>" onclick="navigator.clipboard.writeText(this.dataset.url)" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= AppConfig.api_url&.sub(%r{\Ahttps?://}, '') %></span>
+      <span class="tag tag--copy" id="rest_api_url_display" data-controller="clipboard" data-clipboard-text-value="<%= AppConfig.api_url %>" data-action="click->clipboard#copy" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= AppConfig.api_url&.sub(%r{\Ahttps?://}, '') %></span>
       <% token = current_user.personal_api_token %>
       <div class="rest-api-token">
-        <span class="tag tag--copy" data-token="<%= token.token %>" onclick="navigator.clipboard.writeText(this.dataset.token)" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= token.token %></span>
+        <span class="tag tag--copy" data-controller="clipboard" data-clipboard-text-value="<%= token.token %>" data-action="click->clipboard#copy" title="<%= t('button.copy') %>"><%= render 'svg/16x16_copy' %><%= token.token %></span>
         <%= button_to t('settings.rest.regenerate_token'),
           settings_regenerate_api_token_path,
           method: :post,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,22 +5,26 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 #
-# THIS POLICY DOES NOT YET DEFEND AGAINST INJECTED SCRIPT. It ships report-only, and
-# script-src still carries 'unsafe-inline' to keep the app's inline event handlers and
-# inline <script> blocks working. That combination reports; it enforces nothing. It is here
-# to measure real traffic and size the work, and it becomes protection only once the inline
-# handlers have moved into the bundle, 'unsafe-inline' is gone from script-src, and
-# CSP_ENFORCE=true is set.
+# script-src no longer concedes 'unsafe-inline'. No view in this app renders script
+# inline: handlers are Stimulus actions and blocks live in the bundle, which
+# test/linting/inline_javascript_test.rb keeps true for every file under app/views.
 #
-# Do NOT restore config.content_security_policy_nonce_generator, which the commented-out
-# default this replaced carried two lines below the policy. A nonce-source or hash-source
-# anywhere in a source list makes browsers ignore 'unsafe-inline' (CSP3, "does element match
-# source list for type and source": allow-all-inline returns "Does Not Allow" when a nonce
-# or hash is present), so adding one would break every inline handler, every inline <script>
-# and every style="" attribute in the app at once, plus the <style> Turbo injects for its
-# progress bar on each navigation. Enabling the policy does make csp_meta_tag start
-# rendering in the three layouts; with no generator it renders an empty tag, which Turbo
-# reads as "no nonce" and ignores.
+# The nonce below exists for the inline <script> elements this app does not write.
+# The jobs dashboard's import map is rendered by its engine, which already asks for
+# a nonce and gets an empty one without a generator; Turbo stamps the same nonce on
+# scripts it injects during stream and morph renders, reading it from csp_meta_tag.
+# Neither can be moved into a bundle, and both are refused once the policy enforces.
+#
+# The nonce is confined to script-src. Rails defaults nonce_directives to script-src
+# AND style-src, and a nonce-source anywhere in a source list makes browsers ignore
+# 'unsafe-inline' in that same list (CSP3, "does element match source list for type
+# and source": allow-all-inline returns "Does Not Allow" when a nonce is present).
+# style-src keeps 'unsafe-inline' on purpose — style="" attributes are used all over
+# the app and Turbo injects a <style> for its progress bar — so letting the nonce
+# reach it would unstyle every page at once.
+#
+# Still report-only: the header below is final, and shipping it in this disposition
+# is what lets real traffic report anything the inventory missed before it enforces.
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src     :self
@@ -37,7 +41,7 @@ Rails.application.configure do
     # still closes something — an injected <form action="https://evil/">.
     policy.form_action     :self
 
-    policy.script_src      :self, :unsafe_inline
+    policy.script_src      :self
     policy.style_src       :self, :unsafe_inline
 
     # No wss: or ws: on purpose. 'self' already matches wss:// from an https page and ws://
@@ -67,5 +71,28 @@ Rails.application.configure do
   # frame-src is deliberately absent. The app embeds no iframes, so it would guard nothing
   # today, and leaving default-src to catch a future embed is what surfaces one in the
   # reports rather than letting it through unnoticed.
-  config.content_security_policy_report_only = ENV['CSP_ENFORCE'] != 'true'
+  #
+  # Report-only, unconditionally. This release ships the final header and nothing
+  # else; the whole value of the stage is that it cannot break a page, and a
+  # disposition an environment variable can flip is not that. Enforcement is the
+  # next release's single change.
+  config.content_security_policy_report_only = true
+
+  # A per-request nonce, for the inline <script> elements the app does not render
+  # itself: the jobs dashboard's import map, and Turbo's own injected scripts,
+  # both of which already look for one. Random per response rather than derived
+  # from the session: a nonce that is constant for a session is guessable from any
+  # page the holder can see, and putting the session identifier in the markup is
+  # worse than the problem it solves. Safe against caching because no HTML
+  # response here is cached.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+  # script-src ONLY. Rails defaults this to %w[script-src style-src], and a
+  # nonce-source anywhere in a source list makes browsers ignore 'unsafe-inline'
+  # in that same list (CSP3, "does element match source list for type and
+  # source": allow-all-inline returns "Does Not Allow" when a nonce is present).
+  # style-src keeps 'unsafe-inline' because style="" attributes are used
+  # throughout the app and Turbo injects a <style> for its progress bar, so a
+  # nonce reaching this directive unstyles every page at once.
+  config.content_security_policy_nonce_directives = %w[script-src]
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# The authorization-server metadata this app publishes lists no
+# response_modes_supported, so RFC 8414's default is what it advertises: query and
+# fragment. form_post is neither, and its response posts a form to the client's
+# redirect_uri — which form-action 'self' does not permit, so it could not complete
+# even if the page rendered. Narrowing the flow lets Doorkeeper refuse it through
+# its own validation, so the condition is reported with the library's own error and
+# localized message rather than one hand-rolled here, and there is no controller
+# code to keep in step with its validation order.
+#
+# The delete comes first because the registry warns when it overrides a registered
+# flow, and this runs on every boot. `flows` is a public accessor. Everything else
+# mirrors the gem's own registration; `query` stays first, so the default response
+# mode is unchanged.
+Doorkeeper::GrantFlow.flows.delete(:authorization_code)
+Doorkeeper::GrantFlow.register(
+  :authorization_code,
+  response_type_matches: 'code',
+  response_type_strategy: Doorkeeper::Request::Code,
+  grant_type_matches: 'authorization_code',
+  grant_type_strategy: Doorkeeper::Request::AuthorizationCode,
+  response_mode_matches: %w[query fragment]
+)
+
 Doorkeeper.configure do
   orm :active_record
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,11 @@ Rails.application.routes.draw do
   post '/oauth/register', to: 'oauth/dynamic_registration#create'
 
   # Doorkeeper OAuth routes (/oauth/authorize, /oauth/token, /oauth/revoke)
-  use_doorkeeper
+  # The app has its own connected-clients UI in Settings and registers clients
+  # dynamically, so Doorkeeper's own management pages are surface with no use.
+  use_doorkeeper do
+    skip_controllers :applications, :authorized_applications
+  end
 
   # MCP endpoint (OAuth-protected)
   mount ActionMCP::Engine, at: '/mcp'

--- a/test/controllers/bots/dca_indexes/pick_indices_controller_test.rb
+++ b/test/controllers/bots/dca_indexes/pick_indices_controller_test.rb
@@ -67,14 +67,14 @@ class Bots::DcaIndexes::PickIndicesControllerTest < ActionDispatch::IntegrationT
     assert_match 'Layer 1', response.body
   end
 
-  test 'escapes a quote in the external id used by the tile onclick handler' do
+  test 'escapes a quote in the external id carried by the tile data attribute' do
     Index.create!(external_id: "ev'il", source: Index::SOURCE_COINGECKO,
                   name: 'Evil Index', weight: 1)
     MarketDataSettings.stubs(:current_provider).returns(MarketDataSettings::PROVIDER_COINGECKO)
 
     get new_bots_dca_indexes_pick_index_path
     assert_response :success
-    assert_match "value='ev\\&#39;il'", response.body
-    assert_no_match "value='ev&#39;il'", response.body
+    assert_match 'data-index-category-id="ev&#39;il"', response.body
+    assert_no_match 'data-index-category-id="ev\'il"', response.body
   end
 end

--- a/test/integration/bots/dca_indexes/pick_index_markup_test.rb
+++ b/test/integration/bots/dca_indexes/pick_index_markup_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Bots::DcaIndexes::PickIndexMarkupTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, admin: true, setup_completed: true)
+    sign_in @user
+
+    # The controller's require_market_data_configured before_action gates on
+    # MarketDataSettings.current_provider being present; stubbing it here also
+    # satisfies that gate, matching how the sibling controller test does it.
+    MarketDataSettings.stubs(:current_provider).returns(MarketDataSettings::PROVIDER_COINGECKO)
+
+    @index = create(:index, external_id: 'defi', name: 'DeFi', source: Index::SOURCE_COINGECKO)
+  end
+
+  test 'index tiles carry their identity as data attributes, not an inline handler' do
+    get new_bots_dca_indexes_pick_index_path
+
+    assert_response :success
+    assert_select 'button[data-index-category-id=?][data-index-name=?][data-action=?]',
+                  @index.external_id, @index.name, 'click->index-filter#select'
+    assert_select 'button[onclick]', false, 'an inline handler here fails silently, not visibly'
+    assert_select '#index_category_id[data-index-filter-target=?]', 'categoryIdField'
+    assert_select '#index_name[data-index-filter-target=?]', 'nameField'
+  end
+end

--- a/test/integration/bots/orders_export_test.rb
+++ b/test/integration/bots/orders_export_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Bots::OrdersExportTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, admin: true, setup_completed: true)
+    @bitcoin = create(:asset, :bitcoin)
+    @usd = create(:asset, :usd)
+    sign_in @user
+
+    exchange = create(:binance_exchange)
+    create(:api_key, user: @user, exchange: exchange, key_type: :trading, status: :correct)
+    @bot = create(:dca_single_asset,
+                  user: @user, exchange: exchange,
+                  base_asset: @bitcoin, quote_asset: @usd,
+                  status: :stopped, with_api_key: false)
+  end
+
+  test 'CSV import opens and submits through Stimulus, not inline handlers' do
+    get bot_path(id: @bot.id)
+
+    assert_response :ok
+    assert_select 'form[data-controller=?]', 'file-picker'
+    assert_select 'button[data-action=?]', 'click->file-picker#open'
+    assert_select 'input[type=file][data-file-picker-target=?][data-action=?]',
+                  'input', 'change->file-picker#submit'
+    assert_select 'button[onclick]', false, 'an inline handler cannot run under the policy'
+    assert_select 'input[onchange]', false, 'an inline handler cannot run under the policy'
+  end
+end

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -5,58 +5,90 @@ require 'test_helper'
 class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  # The whole header, in order. Pinning the string rather than a few substrings is the
-  # point: a directive that quietly widens (a bare scheme-source added to connect-src, say)
-  # still passes every "assert_includes" written against it.
-  EXPECTED = "default-src 'self'; font-src 'self' data:; img-src 'self' data: https:; " \
-             "object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; " \
-             "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; " \
-             "connect-src 'self' ipc: http://ipc.localhost; report-uri /csp-report"
-
   setup { @admin = create(:user, admin: true, setup_completed: true) }
 
-  # Report-only is the shipped disposition and this test says so on purpose: with
-  # script-src carrying 'unsafe-inline' the policy reports, it does not defend.
-  test 'emits a report-only policy on an unauthenticated page' do
+  # The whole header, in order, with only the per-request nonce factored out.
+  # Pinning the string rather than a few substrings is the point: a directive
+  # that quietly widens still passes every "assert_includes" written against it.
+  def expected_policy(nonce)
+    "default-src 'self'; font-src 'self' data:; img-src 'self' data: https:; " \
+      "object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; " \
+      "script-src 'self' 'nonce-#{nonce}'; style-src 'self' 'unsafe-inline'; " \
+      "connect-src 'self' ipc: http://ipc.localhost; report-uri /csp-report"
+  end
+
+  def policy_header
+    response.headers['Content-Security-Policy-Report-Only']
+  end
+
+  def meta_nonce
+    css_select('meta[name="csp-nonce"]').first&.[]('content')
+  end
+
+  # The header's nonce and the meta tag's must agree: Turbo reads the meta tag to
+  # stamp scripts it injects during stream and morph renders, so a mismatch means
+  # those scripts are refused once the policy is enforced.
+  test 'the policy matches, and its nonce is the one the page advertises' do
     get '/en/login'
 
     assert_response :success
     assert_nil response.headers['Content-Security-Policy'],
                'nothing is enforced yet; the header must be the report-only one'
-    assert_equal EXPECTED, response.headers['Content-Security-Policy-Report-Only']
+    assert_equal expected_policy(meta_nonce), policy_header
   end
 
   # Stands in for the manual click-through. The header comes from middleware, so what is
   # worth pinning is that it survives on the pages people actually sit on, including one
   # rendered by a controller that does not inherit ApplicationController (/up).
+  #
+  # These render a layout, so the meta tag is available and must agree with the
+  # header — comparing the header against a nonce parsed out of itself is circular.
+  # These render no layout and so advertise no meta nonce; the header is the only
+  # thing there is to read.
   test 'every representative page carries the same policy' do
     sign_in @admin
 
-    ['/en/bots', '/en/tracker', '/en/settings/connect', '/health-check', '/up'].each do |path|
+    ['/en/bots', '/en/tracker', '/en/settings/connect'].each do |path|
       get path
 
       assert_response :success, "#{path} did not render"
-      assert_equal EXPECTED, response.headers['Content-Security-Policy-Report-Only'],
-                   "#{path} carried no policy, or a different one"
+      assert_equal expected_policy(meta_nonce), policy_header, "#{path} carried a different policy"
+    end
+
+    ['/health-check', '/up'].each do |path|
+      get path
+
+      assert_response :success, "#{path} did not render"
+      nonce = policy_header[/'nonce-([^']+)'/, 1]
+
+      assert_equal expected_policy(nonce), policy_header, "#{path} carried a different policy"
     end
   end
 
-  # A nonce-source or hash-source anywhere in a source list makes browsers ignore
-  # 'unsafe-inline' (CSP3 "does element match source list", allow-all-inline), which would
-  # take out every inline handler, inline <script> block and style="" attribute at once.
-  # The commented-out initializer this replaces shipped the two nonce lines a keystroke
-  # away, so the absence is pinned rather than assumed. csp_meta_tag renders now that a
-  # policy exists; it must render empty.
-  test 'no nonce is generated, so unsafe-inline keeps working' do
+  # style-src must never take a nonce. A nonce-source anywhere in a source list
+  # makes browsers ignore 'unsafe-inline' in that list, and this app styles with
+  # style="" attributes throughout, so a nonce here unstyles the whole app at once.
+  # Rails' default nonce_directives includes style-src, which is why this is pinned.
+  test 'style-src carries no nonce' do
     get '/en/login'
 
-    assert_response :success
-    assert_nil Rails.application.config.content_security_policy_nonce_generator
-    refute_includes response.headers['Content-Security-Policy-Report-Only'], 'nonce-'
-    assert_select 'meta[name=?]', 'csp-nonce' do |tags|
-      assert tags.all? { |tag| tag['content'].blank? },
-             'a rendered nonce would make browsers ignore unsafe-inline'
-    end
+    assert_equal %w[script-src], Rails.application.config.content_security_policy_nonce_directives
+    assert_equal "style-src 'self' 'unsafe-inline'", policy_header[/style-src [^;]+/]
+    refute_match(/style-src[^;]*nonce-/, policy_header)
+  end
+
+  test 'script-src no longer concedes unsafe-inline' do
+    get '/en/login'
+
+    refute_match(/script-src[^;]*'unsafe-inline'/, policy_header)
+  end
+
+  test 'each response gets its own nonce' do
+    get '/en/login'
+    first = meta_nonce
+    get '/en/login'
+
+    assert_not_equal first, meta_nonce, 'a reused nonce is no better than unsafe-inline'
   end
 
   # 'self' already matches wss:// from an https page and ws:// from an http page on the
@@ -67,7 +99,7 @@ class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
   # scheme-part matches http and https too.
   test 'connect-src does not permit a websocket to an arbitrary host' do
     get '/en/login'
-    connect = response.headers['Content-Security-Policy-Report-Only'][/connect-src [^;]+/]
+    connect = policy_header[/connect-src [^;]+/]
 
     assert_equal "connect-src 'self' ipc: http://ipc.localhost", connect
     refute_match(/\bwss?:/, connect, 'a bare websocket scheme-source has no host constraint')
@@ -102,5 +134,58 @@ class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
     get '/en/login'
 
     assert_select 'script[src*=?]', 'tauri_boot'
+  end
+
+  # The source scanner in test/linting covers app/views. This covers what gems and
+  # helpers render, which no source scan can see: every script that reaches the
+  # browser is external or nonced, and no element arrives with an on* attribute.
+  test 'rendered pages carry no inline handler and no unnonced script' do
+    # /en/login is requested first, before signing in: Devise redirects a signed-in
+    # user away from it, and a redirect body would satisfy every assertion below
+    # while inspecting nothing.
+    assert_clean_of_inline_javascript('/en/login')
+
+    sign_in @admin
+    ['/en/bots', '/en/settings/connect', '/jobs'].each do |path|
+      assert_clean_of_inline_javascript(path)
+    end
+  end
+
+  def assert_clean_of_inline_javascript(path)
+    get path
+
+    assert_response :success, "#{path} did not render, so it proved nothing"
+
+    scripts = css_select('script')
+
+    assert_predicate scripts, :any?, "#{path} rendered no script at all — check the path"
+    scripts.each do |script|
+      assert script['src'].present? || script['nonce'].present?,
+             "#{path} rendered an inline script with no nonce"
+    end
+
+    # Attribute names rather than a regex over the body: a body match would fire on
+    # any text that happens to read like one, inside a URL or a data attribute.
+    handlers = css_select('*').flat_map { |node| node.attribute_nodes.map(&:name) }
+                              .select { |name| name.downcase.start_with?('on') }.uniq
+
+    assert_empty handlers, "#{path} rendered inline handler attributes"
+  end
+
+  # The dashboard whose inline script the nonce exists for. Asserting the tags are
+  # nonced is not enough on its own: a nonce that does not match the header's is
+  # refused just as a missing one is, and that mismatch is exactly what a
+  # misconfigured generator produces.
+  test 'the jobs dashboard renders importmap tags carrying this response nonce' do
+    sign_in @admin
+    get '/jobs'
+
+    assert_response :success
+    nonce = policy_header[/'nonce-([^']+)'/, 1]
+    importmap = css_select('script[type=importmap]')
+
+    assert_predicate importmap, :any?, 'the import map did not render'
+    assert_equal [nonce], importmap.map { |tag| tag['nonce'] }.uniq
+    assert_equal [nonce], css_select('script[type=module]:not([src])').map { |tag| tag['nonce'] }.uniq
   end
 end

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -82,4 +82,25 @@ class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
 
     assert_includes response.headers['Content-Security-Policy-Report-Only'], "form-action 'self'"
   end
+
+  test 'the signed-in layout ships no inline script block' do
+    sign_in @admin
+    get '/en/bots'
+
+    assert_response :success
+    assert_select 'script:not([src])', false, 'the application layout still has an inline block'
+  end
+
+  test 'the signed-out layout ships no inline script block' do
+    get '/en/login'
+
+    assert_response :success
+    assert_select 'script:not([src])', false, 'the devise layout still has an inline block'
+  end
+
+  test 'the desktop class is set by a script the policy allows' do
+    get '/en/login'
+
+    assert_select 'script[src*=?]', 'tauri_boot'
+  end
 end

--- a/test/integration/oauth_consent_screen_test.rb
+++ b/test/integration/oauth_consent_screen_test.rb
@@ -89,4 +89,59 @@ class OauthConsentScreenTest < ActionDispatch::IntegrationTest
     assert_not_equal 200, response.status, 'the consent screen must not render'
     assert_no_match(/#{Regexp.escape(I18n.t('settings.mcp.authorize_title'))}/, response.body)
   end
+
+  test 'the unused client-management pages are not routed' do
+    # recognize_path raises directly rather than going through a full request, which
+    # matters here: this suite's test environment renders routing errors as a debug
+    # page instead of letting them propagate through `get` (see
+    # bots/exchange_first_creation_test.rb for the same pattern already in use).
+    routes = Rails.application.routes
+    assert_raises(ActionController::RoutingError) { routes.recognize_path('/oauth/applications') }
+    assert_raises(ActionController::RoutingError) { routes.recognize_path('/oauth/authorized_applications') }
+  end
+
+  test 'the authorization endpoints still route' do
+    assert_recognizes({ controller: 'doorkeeper/authorizations', action: 'new' }, '/oauth/authorize')
+    assert_recognizes({ controller: 'doorkeeper/tokens', action: 'create' },
+                      path: '/oauth/token', method: :post)
+  end
+
+  # form_post renders a page whose script submits a form to the client's
+  # redirect_uri, which form-action 'self' does not permit. The metadata this app
+  # publishes advertises query and fragment only, so refusing it is what the
+  # metadata already says.
+  test 'form_post is refused rather than rendered' do
+    get '/oauth/authorize', params: {
+      client_id: @application.uid,
+      redirect_uri: @application.redirect_uri,
+      response_type: 'code',
+      response_mode: 'form_post',
+      code_challenge: 'a' * 43,
+      code_challenge_method: 'S256',
+      scope: 'mcp',
+      state: 'xyz'
+    }
+
+    # handle_auth_errors defaults to :render, so this renders rather than redirects.
+    assert_response :bad_request
+    assert_select 'form[name=redirect_form]', false, 'the auto-submitting page must not render'
+    assert_includes response.body, 'does not support this response mode'
+  end
+
+  # Companion to the refusal test above: proves the same parameter set reaches the
+  # consent screen when response_mode is absent, so the refusal above is actually
+  # about response_mode and not some other malformed parameter.
+  test 'the same request without a response mode reaches consent' do
+    get '/oauth/authorize', params: {
+      client_id: @application.uid,
+      redirect_uri: @application.redirect_uri,
+      response_type: 'code',
+      code_challenge: 'a' * 43,
+      code_challenge_method: 'S256',
+      scope: 'mcp',
+      state: 'xyz'
+    }
+
+    assert_response :success
+  end
 end

--- a/test/integration/settings_mcp_test.rb
+++ b/test/integration/settings_mcp_test.rb
@@ -74,4 +74,14 @@ class SettingsMcpTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'turbo-frame#mcp_settings'
   end
+
+  test 'the MCP url copies through a Stimulus action, not an inline handler' do
+    get settings_connect_path
+
+    assert_response :success
+    assert_select '#mcp_url_display[data-controller=?][data-action=?]',
+                  'clipboard', 'click->clipboard#copy'
+    assert_select '#mcp_url_display[data-clipboard-text-value=?]', AppConfig.mcp_url
+    assert_select '#mcp_url_display[onclick]', false, 'an inline handler cannot run under the policy'
+  end
 end

--- a/test/integration/settings_rest_token_test.rb
+++ b/test/integration/settings_rest_token_test.rb
@@ -128,4 +128,15 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
     assert_not_equal my_token_before, @user.reload.personal_api_token.token
     assert_equal other_token, other.reload.personal_api_token.token
   end
+
+  test 'the REST url and token copy through a Stimulus action, not an inline handler' do
+    get settings_connect_path
+
+    assert_response :success
+    assert_select '#rest_api_url_display[data-controller=?][data-action=?][data-clipboard-text-value=?]',
+                  'clipboard', 'click->clipboard#copy', AppConfig.api_url
+    assert_select '.tag--copy[data-controller=?][data-action=?][data-clipboard-text-value=?]',
+                  'clipboard', 'click->clipboard#copy', @user.personal_api_token.token
+    assert_select '.tag--copy[onclick]', false, 'an inline handler cannot run under the policy'
+  end
 end

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -38,7 +38,6 @@ class InlineJavascriptTest < ActiveSupport::TestCase
   # Views still carrying inline JavaScript. This list only ever shrinks.
   REMAINING = [
     'bots/dca_indexes/pick_indices/new.html.erb',
-    'bots/orders/_export.html.erb',
     'layouts/application.html.erb',
     'layouts/devise.html.erb',
     'layouts/guest.html.erb'

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -41,9 +41,7 @@ class InlineJavascriptTest < ActiveSupport::TestCase
     'bots/orders/_export.html.erb',
     'layouts/application.html.erb',
     'layouts/devise.html.erb',
-    'layouts/guest.html.erb',
-    'settings/widgets/_mcp.html.erb',
-    'settings/widgets/_rest.html.erb'
+    'layouts/guest.html.erb'
   ].freeze
 
   test 'no view carries inline JavaScript beyond the recorded remainder' do

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# script-src carries no 'unsafe-inline', so an inline event-handler attribute or
+# an inline <script> in a view is dead markup: the browser refuses to compile it.
+# This reads the view sources rather than a rendered page, so a view that no test
+# renders is covered too, and a handler added in any locale or partial is caught
+# at the point it is written.
+class InlineJavascriptTest < ActiveSupport::TestCase
+  VIEWS = Rails.root.join('app/views')
+
+  # Every shape that reaches the browser as an inline handler:
+  #   onclick="…"  onclick=…  onClick="…"   HTML attributes, quoted or not, any case
+  #   onclick: "…"  onclick: some_var       the Rails helper hash form
+  #   "onclick" => "…"                      the same, with a string key
+  # The hash forms matter most: they are invisible to a search for `on\w+=`, and
+  # that is exactly how one of these was missed when this work was scoped.
+  HANDLER = /(?<![a-z])(on[a-z]+)["']?\s*(?:=>?|:)/i
+
+  # `on[a-z]+` cannot tell an event name from a Ruby option that happens to start
+  # with "on", so the handful that do are named rather than pattern-matched around.
+  # `only_path:` is not among them: `[a-z]+` stops at the underscore, so the colon
+  # is never adjacent.
+  IGNORED_NAMES = %w[only once one].freeze
+
+  # A literal block in ERB or HAML, the HAML filter, and the helper that builds one.
+  SCRIPT = /<script\b|%script|:javascript\b|javascript_tag/i
+
+  # A javascript: URL is inline script wearing a URL, and script-src refuses it on
+  # the same grounds. Attribute forms only — quoted, unquoted, HAML hash and string
+  # key. A bare `link_to "x", "javascript:…"` is not caught: matching any quoted
+  # string that opens with `javascript:` would also fire on ordinary prose, and a
+  # lint that cries wolf gets switched off. The policy is the defence here; this is
+  # the early warning.
+  JAVASCRIPT_URL = /(?:href|src|action)["']?\s*(?:=>|[:=])\s*["']?\s*javascript:/i
+
+  # Views still carrying inline JavaScript. This list only ever shrinks.
+  REMAINING = [
+    'bots/dca_indexes/pick_indices/new.html.erb',
+    'bots/orders/_export.html.erb',
+    'layouts/application.html.erb',
+    'layouts/devise.html.erb',
+    'layouts/guest.html.erb',
+    'settings/widgets/_mcp.html.erb',
+    'settings/widgets/_rest.html.erb'
+  ].freeze
+
+  test 'no view carries inline JavaScript beyond the recorded remainder' do
+    assert_equal REMAINING, offending_views,
+                 'a view gained inline JavaScript, or a listed one no longer has any'
+  end
+
+  private
+
+  def offending_views
+    Dir.glob('**/*', base: VIEWS)
+       .select { |path| File.file?(VIEWS.join(path)) }
+       .select { |path| inline_javascript?(VIEWS.join(path)) }
+       .sort
+  end
+
+  def inline_javascript?(path)
+    source = File.read(path)
+
+    inline_handler?(source) || source.match?(SCRIPT) || source.match?(JAVASCRIPT_URL)
+  end
+
+  def inline_handler?(source)
+    source.scan(HANDLER).flatten.any? { |name| IGNORED_NAMES.exclude?(name.downcase) }
+  end
+end

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -37,7 +37,6 @@ class InlineJavascriptTest < ActiveSupport::TestCase
 
   # Views still carrying inline JavaScript. This list only ever shrinks.
   REMAINING = [
-    'bots/dca_indexes/pick_indices/new.html.erb',
     'layouts/application.html.erb',
     'layouts/devise.html.erb',
     'layouts/guest.html.erb'

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -24,8 +24,10 @@ class InlineJavascriptTest < ActiveSupport::TestCase
   # is never adjacent.
   IGNORED_NAMES = %w[only once one].freeze
 
-  # A literal block in ERB or HAML, the HAML filter, and the helper that builds one.
-  SCRIPT = /<script\b|%script|:javascript\b|javascript_tag/i
+  # A literal block in ERB or HAML, the HAML filter, the helper that builds one,
+  # and the two tag-builder forms that emit the same element: content_tag(:script,
+  # …) and tag.script.
+  SCRIPT = /<script\b|%script|:javascript\b|javascript_tag|content_tag\(\s*:script\b|tag\.script\b/i
 
   # A javascript: URL is inline script wearing a URL, and script-src refuses it on
   # the same grounds. Attribute forms only — quoted, unquoted, HAML hash and string

--- a/test/linting/inline_javascript_test.rb
+++ b/test/linting/inline_javascript_test.rb
@@ -36,11 +36,7 @@ class InlineJavascriptTest < ActiveSupport::TestCase
   JAVASCRIPT_URL = /(?:href|src|action)["']?\s*(?:=>|[:=])\s*["']?\s*javascript:/i
 
   # Views still carrying inline JavaScript. This list only ever shrinks.
-  REMAINING = [
-    'layouts/application.html.erb',
-    'layouts/devise.html.erb',
-    'layouts/guest.html.erb'
-  ].freeze
+  REMAINING = [].freeze
 
   test 'no view carries inline JavaScript beyond the recorded remainder' do
     assert_equal REMAINING, offending_views,


### PR DESCRIPTION
Completes the Content Security Policy so that `script-src` no longer permits inline script. This is the first of two releases: the policy here is final but still report-only, so real traffic can report anything the inventory missed before enforcement follows.

## Removing the inline script the app renders

Six inline event handlers become Stimulus actions:

- the three copy controls in the Settings → Connect widgets, via a rewritten `clipboard` controller (it existed but no view used it, so it is now value-based rather than target-based)
- the CSV import button and file field, via a new `file-picker` controller
- the index-picker tiles, which now carry their identity in data attributes read by the `index-filter` controller that already owns those tiles

Of the six inline `<script>` blocks in the layouts, three were dead and are deleted: the guest layout tested a global that is never defined, its scroll block set a class no stylesheet uses, and the application layout's drag handler was already superseded by `app/javascript/tauri.js`, which is in the bundle on every page and re-initialises on Turbo navigations. The service-worker registration moves into `application.js`, and the modal-chrome listener becomes a `reveal-chrome` controller that also cleans up after itself on navigation.

`app/javascript/tauri_boot.js` is new: a one-line entry point that sets the desktop class during head parse. The bundle cannot do this, because it is deferred and its desktop module resolves several dynamic imports first, which would show as a flash of browser-styled chrome on a cold desktop start.

## The nonce, and the OAuth surface

Two inline `<script>` elements are rendered by gems and cannot be bundled, so the policy gains a per-request nonce — the mechanism `importmap-rails` is already wired for. It is pinned to `script-src`; Rails defaults `nonce_directives` to include `style-src`, where a nonce would make browsers ignore that directive's `'unsafe-inline'` and stop every `style=""` attribute in the app from applying.

Doorkeeper's remaining inline script is handled by removing surface rather than forking gem views:

- `skip_controllers :applications, :authorized_applications` — nothing in the app referenced those ten routes, since connected clients have their own UI in Settings and clients register dynamically
- the `authorization_code` flow is re-registered without the `form_post` response mode. That response posts a form to the client's own redirect URI, which `form-action 'self'` does not permit, so it could not complete regardless. The authorization-server metadata already advertises only `query` and `fragment`, so this makes the implementation match what it publishes.

## Deliberately unchanged

`style-src` keeps `'unsafe-inline'` — inline `style=""` is used throughout the app and Turbo injects a `<style>` of its own — and the nonce never reaches it. Enforcement is not in this release: the disposition is report-only unconditionally, and `CSP_ENFORCE` is removed rather than set, so the measurement stage cannot be switched off by an environment.

## Verification

`test/linting/inline_javascript_test.rb` scans every file under `app/views` for inline handlers in both attribute and Rails hash forms, inline blocks in ERB and HAML, and `javascript:` URLs. It carries a census of offending files that this branch reduces to empty, so a view that regains inline JavaScript fails the suite even if no test renders it. `test/integration/content_security_policy_test.rb` pins the whole header with the nonce factored out, asserts the header's nonce matches the one the page advertises, asserts `style-src` carries no nonce, and checks that every script on a rendered page is external or nonced — including the jobs dashboard, whose import map is the reason the nonce exists.

3121 runs, 10671 assertions, 0 failures. Rubocop clean.

Walked by hand in the browser and in the desktop app: the copy controls, CSV export and import, the index picker, a modal over hidden chrome, titlebar drag, external links, and the native save dialog. No violations reported.
