### PR TITLE
Fix missing translation keys and silent preference failures in Settings

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -63,18 +63,22 @@ class SettingsController < ApplicationController
   end
 
   def update_time_zone
-    return unless current_user.update(update_time_zone_params)
-
-    flash[:notice] = t('settings.language_and_timezone.timezone.updated')
-    render turbo_stream: turbo_stream_page_refresh
+    if current_user.update(update_time_zone_params)
+      flash[:notice] = t('settings.language_and_timezone.updated')
+      render turbo_stream: turbo_stream_page_refresh
+    else
+      render_preference_error
+    end
   end
 
   def update_locale
-    return unless current_user.update(update_locale_params)
-
-    flash[:notice] = I18n.t('settings.language_and_timezone.language_updated', locale: current_user.locale)
-    new_locale = current_user.locale == I18n.default_locale.to_s ? nil : current_user.locale
-    render turbo_stream: turbo_stream_redirect(settings_account_path(locale: new_locale))
+    if current_user.update(update_locale_params)
+      flash[:notice] = I18n.t('settings.language_and_timezone.language_updated', locale: current_user.locale)
+      new_locale = current_user.locale == I18n.default_locale.to_s ? nil : current_user.locale
+      render turbo_stream: turbo_stream_redirect(settings_account_path(locale: new_locale))
+    else
+      render_preference_error
+    end
   end
 
   def update_password
@@ -471,6 +475,19 @@ class SettingsController < ApplicationController
   end
 
   private
+
+  # Both preference selects offer only valid options, so a rejection means a crafted request —
+  # but the actions still have to answer one. Falling through to an implicit render answered a
+  # PATCH with 204, which Turbo drops on the floor: the picker kept the value it was sent while
+  # nothing was saved and nothing was said.
+  #
+  # messages.values rather than full_messages: the locale files translate the inclusion message
+  # but carry no activerecord.attributes.user entry for time_zone or locale, so full_messages
+  # would post an English field name into a translated flash.
+  def render_preference_error
+    flash.now[:alert] = current_user.errors.messages.values.flatten.to_sentence
+    render turbo_stream: turbo_stream_prepend_flash, status: :unprocessable_entity
+  end
 
   # The single definition of "this user is connected to this client". Both the
   # Settings list and every per-client route authorize through it, so a client can

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,22 @@ class User < ApplicationRecord
   validate :validate_name, if: -> { new_record? || name_changed? }
   validate :validate_email, if: -> { new_record? || email_changed? }
   validate :password_complexity, if: -> { password.present? }
-  validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name), allow_nil: true }
-  validates :locale, inclusion: { in: ->(_) { I18n.available_locales.map(&:to_s) } }, allow_blank: true
+  # Absent and wrong are different answers, and only the validators may speak for "wrong".
+  # Each preference column gets exactly one spelling for "no preference", and it differs
+  # because the schemas differ: locale is nullable, so nil means "use I18n's default";
+  # time_zone is `null: false default "UTC"`, so there UTC *is* the absence of a preference.
+  # Left to the validators alone the two disagreed with their own columns — a blank locale
+  # persisted and then made I18n.t(locale: "") raise InvalidLocale, and a nil time_zone got
+  # past allow_nil only to hit the NOT NULL constraint, both 500s from a crafted form post.
+  #
+  # apply_to_nil on time_zone because nil is precisely the case being caught; normalizes
+  # skips nil by default, which would leave this doing nothing. Not needed for locale,
+  # where nil is already the answer.
+  normalizes :locale, with: lambda(&:presence)
+  normalizes :time_zone, with: ->(zone) { zone.presence || 'UTC' }, apply_to_nil: true
+
+  validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }
+  validates :locale, inclusion: { in: ->(_) { I18n.available_locales.map(&:to_s) } }, allow_nil: true
 
   # Devise hands the whole attempt budget back the moment a lock ages out:
   # Devise::Models::Lockable#valid_for_authentication? opens with `unlock_access! if
@@ -309,10 +323,6 @@ class User < ApplicationRecord
   end
 
   # ------------------------------------------------------------------------
-
-  def set_default_time_zone
-    self.time_zone = 'UTC' if time_zone.blank?
-  end
 
   def validate_name
     valid_name = name =~ Regexp.new(Name::PATTERN)

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -26,7 +26,7 @@
 
   .menu-mobile__divider
   = button_to destroy_user_session_path, method: :delete, class: "menu-mobile__item menu-mobile__button", data: { turbo: false } do
-    = t('links.logout')
+    = t('links.log_out')
 .menu
   .menu__section.menu__section--top.menu__section--logo
 
@@ -68,4 +68,4 @@
         = link_to t('links.account'), settings_account_path, class: "dropdown__item"
         .dropdown__item.dropdown__item--divider
         = button_to destroy_user_session_path, method: :delete, class: "dropdown__item dropdown__item--danger", data: { turbo: false } do
-          = t('links.logout')
+          = t('links.log_out')

--- a/app/views/settings/widgets/_language_and_time_zone.html.erb
+++ b/app/views/settings/widgets/_language_and_time_zone.html.erb
@@ -38,7 +38,7 @@
           <%= f.select :time_zone, sorted_time_zone_options, { selected: current_user.time_zone }, data: { action: "change->form--submit#submit" } %>
         </div>
         <small data-controller="clock" data-clock-time-zone-value="<%= ActiveSupport::TimeZone[current_user.time_zone].tzinfo.identifier %>">
-          <%= t('settings.language_and_timezone.timezone.current_time_is') %> <b data-clock-target="timestamp"><%= Time.current.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></b>
+          <%= t('settings.language_and_timezone.current_time_is') %> <b data-clock-target="timestamp"><%= Time.current.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></b>
         </small>
       <% end %>
     <% end %>

--- a/db/migrate/20260810120000_normalize_invalid_user_locales.rb
+++ b/db/migrate/20260810120000_normalize_invalid_user_locales.rb
@@ -1,0 +1,31 @@
+# users.locale had no validation until 2026-08-06, and settings#update_locale wrote the raw
+# param straight into it — so a row can hold "" or anything else that was ever POSTed. "" is
+# now normalised away on write and the inclusion validator refuses the rest, which would wedge
+# any such row: every later save, including an unrelated name or password change, would fail on
+# an attribute the user never touched. Reset them to NULL, which is what "no preference" has
+# always meant to every reader of the column.
+#
+# Self-contained on purpose (see BackfillConnectedClients): a migration-local model, and the
+# locale list frozen as it stood here rather than read from I18n — a historical migration that
+# tracks head-of-branch config breaks fresh installs and version-skipping upgrades.
+class NormalizeInvalidUserLocales < ActiveRecord::Migration[8.1]
+  # Verbatim copy of config.i18n.available_locales at the time this was written.
+  # Do not update it if that list changes.
+  LOCALES = %w[en pl es de nl fr pt ru it bg el sv da cs sk].freeze
+
+  class Person < ActiveRecord::Base
+    self.table_name = 'users'
+  end
+
+  def up
+    # The `locale: nil` clause is redundant under SQL's NOT IN, which already drops NULLs —
+    # it is here so that reading this migration does not require knowing that.
+    cleared = Person.where.not(locale: nil).where.not(locale: LOCALES).update_all(locale: nil)
+    say "Cleared #{cleared} unusable user locale(s)" if cleared.positive?
+    cleared
+  end
+
+  def down
+    # Nothing to undo: the values this cleared were ones no reader of the column could use.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_230550) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_120000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+
+# The account page and the two "change a preference" actions behind it.
+#
+# These assert that the *call sites* resolve — a locale-presence test would pass
+# happily while a view asks for a key one level too deep, which is exactly how
+# `links.logout` and `settings.language_and_timezone.timezone.*` survived. The view
+# helper answers a missing key with a `translation_missing` span whose text is the
+# humanised last segment, so the page looks almost right in English and shows English
+# in the other fourteen locales.
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    create(:user, admin: true, setup_completed: true) # platform requires an admin to exist
+    @user = create(:user, time_zone: 'UTC', locale: 'en')
+    sign_in @user
+  end
+
+  test 'account page resolves every translation it references' do
+    get settings_account_path
+
+    assert_response :success
+    assert_no_match(/translation_missing/, @response.body)
+  end
+
+  test 'navbar renders the logout link' do
+    # In English the missing-translation span humanises the last key segment to
+    # "Logout" and looks entirely correct, so this only bites in a locale where the
+    # real translation differs.
+    @user.update!(locale: 'pl')
+    get settings_account_path(locale: 'pl')
+
+    assert_includes @response.body, I18n.t('links.log_out', locale: :pl)
+  end
+
+  test 'the clock caption under the time-zone picker is translated' do
+    get settings_account_path
+
+    assert_includes @response.body, I18n.t('settings.language_and_timezone.current_time_is')
+  end
+
+  test 'a time-zone change flashes a translated confirmation' do
+    patch settings_update_time_zone_path, params: { user: { time_zone: 'Warsaw' } }
+
+    assert_response :success
+    assert_equal I18n.t('settings.language_and_timezone.updated'), flash[:notice]
+  end
+
+  # Both selects are inside turbo frames, so an out-of-range value takes a crafted
+  # request — but the model validates inclusion, so it is reachable, and today it
+  # falls through to a template that does not exist.
+  test 'a rejected time zone reports the error instead of raising' do
+    patch settings_update_time_zone_path, params: { user: { time_zone: 'Mars/Olympus_Mons' } }
+
+    assert_response :unprocessable_entity
+    assert_equal 'UTC', @user.reload.time_zone
+    assert_includes @response.body, 'salert--danger'
+  end
+
+  test 'a rejected locale reports the error instead of raising' do
+    patch settings_update_locale_path, params: { user: { locale: 'xx' } }
+
+    assert_response :unprocessable_entity
+    assert_equal 'en', @user.reload.locale
+    assert_includes @response.body, 'salert--danger'
+  end
+
+  # The two values that slipped past the validators entirely rather than failing them:
+  # `allow_blank` waved "" through, the row was written, and only then did I18n refuse the
+  # locale — a 500 with a corrupted row behind it, from a plain form post. `allow_nil` on
+  # time_zone waved nil into a `null: false` column.
+  test 'a blank locale clears the preference instead of being persisted as one' do
+    patch settings_update_locale_path, params: { user: { locale: '' } }
+
+    assert_response :success
+    assert_nil @user.reload.locale
+  end
+
+  # Absent and wrong are different answers. The schema declares `null: false default "UTC"`,
+  # so an absent zone means the default — on an update as much as on an insert, which is the
+  # half that used to reach the NOT NULL constraint instead.
+  test 'a null time zone falls back to the default instead of reaching the NOT NULL constraint' do
+    @user.update!(time_zone: 'Warsaw')
+
+    patch settings_update_time_zone_path,
+          params: { user: { time_zone: nil } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :success
+    assert_equal 'UTC', @user.reload.time_zone
+  end
+
+  # Defect 4 in the report: the name/email/password failure branches set no flash and
+  # re-render the field with `value: ""`. What saves them is the inline_form_errors
+  # initializer — the reason is attached to the field, inside the frame Turbo extracts.
+  test 'a rejected name comes back with the reason attached to the field' do
+    patch settings_update_name_path,
+          params: { user: { name: 'N4me' } },
+          headers: { 'Turbo-Frame' => 'update_name_form' }
+
+    assert_response :unprocessable_entity
+    assert_includes @response.body, I18n.t('devise.registrations.new.name_invalid')
+  end
+
+  test 'a wrong current password comes back with the reason attached to the field' do
+    patch settings_update_password_path,
+          params: { user: { current_password: 'WrongPassword1!', password: 'NewPassword1!',
+                            password_confirmation: 'NewPassword1!' } },
+          headers: { 'Turbo-Frame' => 'update_password_form' }
+
+    assert_response :unprocessable_entity
+    assert_includes @response.body, 'form__info--invalid'
+  end
+end

--- a/test/integration/locale_param_safety_test.rb
+++ b/test/integration/locale_param_safety_test.rb
@@ -52,7 +52,10 @@ class LocaleParamSafetyTest < ActionDispatch::IntegrationTest
 
     patch settings_update_locale_path, params: { user: { locale: 'zz' } }
 
-    assert_response :success
+    # 422, not the 2xx this asserted before: the rejection used to fall through to an implicit
+    # render, which answers a PATCH with 204 — indistinguishable from success to Turbo, which
+    # drops it silently. The action now says so.
+    assert_response :unprocessable_entity
     assert_equal 'en', user.reload.locale
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -20,8 +20,30 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, locale: nil)
     assert_predicate user, :valid?
 
+    # "" is still a legal thing to submit — it clears the preference — but it is normalised
+    # to nil rather than stored, so the column only ever holds a locale a reader can use.
     user.locale = ''
     assert_predicate user, :valid?
+    assert_nil user.locale
+  end
+
+  # The counterpart to the locale rule above, with the identity value each column declares:
+  # locale is nullable so "no preference" is nil; time_zone is `null: false default "UTC"`,
+  # so "no preference" is UTC itself. A wrong zone is still a wrong zone.
+  test 'no time zone preference falls back to the default' do
+    user = build(:user, time_zone: nil)
+    assert_predicate user, :valid?
+    assert_equal 'UTC', user.time_zone
+
+    user.time_zone = ''
+    assert_equal 'UTC', user.time_zone
+  end
+
+  test 'a junk time zone is rejected and not persisted' do
+    user = create(:user, time_zone: 'Warsaw')
+
+    refute user.update(time_zone: 'Mars/Olympus_Mons')
+    assert_equal 'Warsaw', user.reload.time_zone
   end
 
   test 'generates a two-factor secret when the seed was cleared' do


### PR DESCRIPTION
Four defects on the account settings page. Three are fixed here; the fourth turned out to be already handled, so it is only pinned with tests.

## Missing translation keys

`links.logout` and `settings.language_and_timezone.timezone.{updated,current_time_is}` are asked for but never defined. The real keys are `links.log_out` and `settings.language_and_timezone.{updated,current_time_is}`, translated in all 15 locales — the call sites were wrong, not the locale files.

In a view a missing key renders a `translation_missing` span whose text is the humanised last segment, so English read "Logout" and "Current time is" and looked correct while the other fourteen locales showed English. In the controller it produced a flash reading `Translation missing: en.settings.language_and_timezone.timezone.updated` after every time-zone change.

## Rejected preference changes were dropped silently

`update_time_zone` and `update_locale` were `return unless current_user.update(...)`. On a validation failure the action fell through to an implicit render, which answers a PATCH with `204 No Content` — Turbo discards it, so the picker kept displaying the value that had just been refused while nothing was saved and no error appeared. Both now render the reason with `422`.

The message comes from `errors.messages` rather than `full_messages`: the locale files translate the inclusion message but carry no `activerecord.attributes.user` entry for these two columns, so `full_messages` would put an English field name inside a translated flash.

## Two values that skipped validation instead of failing it

- `user[locale]=` empty — `allow_blank` let `""` through, the row was written, and `I18n.t(locale: "")` then raised `InvalidLocale`. A 500 that left a value in the column no reader could use, from a plain form post.
- `user[time_zone]=null` — `allow_nil` passed nil into a `null: false` column, reaching the NOT NULL constraint.

Both columns now normalise "no preference" to the single spelling their schema declares — `nil` for `locale` (nullable), `UTC` for `time_zone` (`null: false default "UTC"`) — leaving the validators to speak only for wrong values. This also closes the split where `User.create` with no time zone silently got `UTC` while `update(time_zone: nil)` was an error.

`User#set_default_time_zone` described exactly this behaviour but was never registered as a callback and never called, so it is deleted.

## Migration

`users.locale` had no validation until 2026-08-06 while `update_locale` wrote the raw param, so rows can hold `""` or any other submitted string. Such a row fails the inclusion validator on every subsequent save, which blocks unrelated name, email and password changes. `NormalizeInvalidUserLocales` resets them to NULL.

`users.time_zone` needs no equivalent: its validator has been in place since the column was added, and `null: false` made the only value that could bypass it unstorable.

## Name, email and password failure branches

These set no flash and re-render the field empty, but the reason is not lost: `config/initializers/inline_form_errors.rb` attaches it under the field, inside the frame Turbo extracts. Two tests pin that behaviour; no change was needed.

## Tests

`test/controllers/settings_controller_test.rb` is new and covers the page and both actions. One existing assertion in `test/integration/locale_param_safety_test.rb` moves from `:success` to `:unprocessable_entity` — its intent, "rejected, not persisted", is unchanged; it was passing on the accidental 204.

Full suite: 3163 runs, 0 failures. RuboCop clean.
