### PR TITLE
Compare Alpaca buying power, not cash, for low-funds warnings

### DIFF
--- a/app/models/bot/fundable.rb
+++ b/app/models/bot/fundable.rb
@@ -24,8 +24,9 @@ module Bot::Fundable
     result = get_balance(asset_id: quote_asset_id)
     return false if result.failure?
 
-    quote_balance = result.data
-    quote_balance[:free] < required_balance_buffer
+    # Not the settled balance: on a margin venue a bot spends buying power, and which figure
+    # applies depends on what it trades, so the exchange picks.
+    exchange.spendable_balance(result.data, tickers: tickers) < required_balance_buffer
   end
 
   private

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -126,6 +126,13 @@ class Exchange < ApplicationRecord
     Result::Success.new(result.data[asset_id])
   end
 
+  # What an account can actually spend, which is not always its settled balance — margin venues
+  # let a bot spend against borrowed buying power. Takes an already-fetched balance hash, so
+  # asking costs no extra network read. Overridden by the venues where the two differ.
+  def spendable_balance(balance, tickers: nil)
+    balance[:free]
+  end
+
   def get_last_price(ticker:, force: false)
     raise NotImplementedError, "#{self.class.name} must implement get_last_price"
   end

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -94,6 +94,21 @@ class Exchanges::Alpaca < Exchange
     clock['is_open'] == true
   end
 
+  # Margin accounts run settled cash at or below zero by design; buying power is what Alpaca
+  # checks when an order lands, so cash alone false-alarms every margin user.
+  #
+  # ponytail: all_crypto? is approximate — non-marginable equities aren't flagged in our catalog,
+  # DcaIndex#tickers is every quote-matching ticker rather than the bot's allocations, and a mixed
+  # dual bot has both. All three then resolve to :buying_power, i.e. a missed warning, never the
+  # false alarm this fixes. any_crypto? would invert that and keep false-alarming index bots.
+  # Upgrade path: persist Alpaca's `marginable` flag on Ticker/ExchangeAsset (it's venue metadata)
+  # and give bots a funding_tickers that reports real allocations.
+  def spendable_balance(balance, tickers: nil)
+    # Crypto is non-marginable at Alpaca — it spends settled cash, not stock-backed leverage.
+    key = all_crypto?(tickers) ? :non_marginable_buying_power : :buying_power
+    balance[key] || balance[:free]
+  end
+
   def next_market_open_at(tickers: nil)
     return Time.current if all_crypto?(tickers)
 
@@ -212,11 +227,19 @@ class Exchanges::Alpaca < Exchange
       [asset_id, { free: 0, locked: 0 }]
     end
 
-    # USD cash
+    # USD cash. :free stays settled cash — AccountBalance::Sync values the portfolio from it, and
+    # buying power is borrowed, not owned. The spend figures ride along for #spendable_balance.
+    # &.to_d, not .to_d: nil.to_d is 0, which would turn an absent field into a hard zero and make
+    # every account look broke.
     usd_asset = asset_from_symbol('USD')
     if usd_asset && asset_ids.include?(usd_asset.id)
-      cash = account_result.data['cash'].to_d
-      balances[usd_asset.id] = { free: cash, locked: 0 }
+      account = account_result.data
+      balances[usd_asset.id] = {
+        free: account['cash'].to_d,
+        locked: 0,
+        buying_power: account['buying_power']&.to_d,
+        non_marginable_buying_power: account['non_marginable_buying_power']&.to_d
+      }
     end
 
     # Positions. Stocks resolve via the existing bare-symbol map (position symbol ==

--- a/test/models/bot/fundable_test.rb
+++ b/test/models/bot/fundable_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class Bot::FundableTest < ActiveSupport::TestCase
+  # quote_amount 100 on a daily interval => 100 / 1.day * 3.days == 300
+  BUFFER = 300
+
+  # Cash-only venues (everything except Alpaca) keep comparing settled balance, unchanged.
+
+  test 'funds_are_low? is true when a cash venue is under the buffer' do
+    bot = create(:dca_single_asset, :started)
+    bot.stubs(:get_balance).returns(Result::Success.new({ free: (BUFFER - 1).to_d, locked: 0 }))
+
+    assert_predicate bot, :funds_are_low?
+  end
+
+  test 'funds_are_low? is false when a cash venue clears the buffer' do
+    bot = create(:dca_single_asset, :started)
+    bot.stubs(:get_balance).returns(Result::Success.new({ free: (BUFFER + 1).to_d, locked: 0 }))
+
+    refute_predicate bot, :funds_are_low?
+  end
+
+  # Alpaca margin accounts run settled cash at or below zero by design — buying power is what
+  # the venue actually checks when an order lands. Comparing cash false-alarmed every margin user.
+
+  test 'funds_are_low? is false for a stock bot when buying power clears the buffer despite zero cash' do
+    bot = alpaca_bot(base_asset: create(:asset, symbol: 'AAPL', category: 'Stock'))
+    bot.stubs(:get_balance).returns(Result::Success.new(alpaca_balance(cash: 0, buying_power: 5000)))
+
+    refute_predicate bot, :funds_are_low?
+  end
+
+  # Crypto is non-marginable at Alpaca: it spends settled cash, so stock-backed leverage must not
+  # count toward the buffer.
+  test 'funds_are_low? is true for a crypto bot when only marginable buying power is available' do
+    bot = alpaca_bot(base_asset: create(:asset, :bitcoin))
+    bot.stubs(:get_balance)
+       .returns(Result::Success.new(alpaca_balance(cash: 0, buying_power: 5000, non_marginable: 0)))
+
+    assert_predicate bot, :funds_are_low?
+  end
+
+  test 'funds_are_low? is still true when an Alpaca account is genuinely empty' do
+    bot = alpaca_bot(base_asset: create(:asset, symbol: 'AAPL', category: 'Stock'))
+    bot.stubs(:get_balance).returns(Result::Success.new(alpaca_balance(cash: 0, buying_power: 0)))
+
+    assert_predicate bot, :funds_are_low?
+  end
+
+  # A balance hash missing a spend figure must fall back to settled cash, never compare nil.
+
+  test 'funds_are_low? falls back to cash for a crypto bot when non-marginable buying power is absent' do
+    bot = alpaca_bot(base_asset: create(:asset, :bitcoin))
+    balance = { free: (BUFFER + 1).to_d, locked: 0, buying_power: 5000.to_d }
+    bot.stubs(:get_balance).returns(Result::Success.new(balance))
+
+    refute_predicate bot, :funds_are_low?
+  end
+
+  test 'funds_are_low? falls back to cash for a stock bot when buying power is absent' do
+    bot = alpaca_bot(base_asset: create(:asset, symbol: 'AAPL', category: 'Stock'))
+    balance = { free: (BUFFER + 1).to_d, locked: 0, non_marginable_buying_power: 0.to_d }
+    bot.stubs(:get_balance).returns(Result::Success.new(balance))
+
+    refute_predicate bot, :funds_are_low?
+  end
+
+  test 'funds_are_low? is false when the balance call fails' do
+    bot = alpaca_bot(base_asset: create(:asset, :bitcoin))
+    bot.stubs(:get_balance).returns(Result::Failure.new('connection error'))
+
+    refute_predicate bot, :funds_are_low?
+  end
+
+  private
+
+  def alpaca_bot(base_asset:)
+    create(:dca_single_asset, :started, exchange: create(:alpaca_exchange), base_asset: base_asset)
+  end
+
+  def alpaca_balance(cash:, buying_power:, non_marginable: nil)
+    {
+      free: cash.to_d,
+      locked: 0,
+      buying_power: buying_power.to_d,
+      non_marginable_buying_power: non_marginable&.to_d
+    }
+  end
+end

--- a/test/models/exchanges/alpaca_test.rb
+++ b/test/models/exchanges/alpaca_test.rb
@@ -422,6 +422,74 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
     assert_equal 10.to_d, result.data[aapl.id][:free]
   end
 
+  # == get_balances spend figures (margin: cash is not what the venue checks) ==
+
+  test 'get_balances reports settled cash as free and carries both buying-power figures' do
+    usd = usd_with_ticker
+
+    Clients::Alpaca.any_instance.stubs(:get_account).returns(
+      Result::Success.new({ 'cash' => '0.0', 'buying_power' => '5000.0',
+                            'non_marginable_buying_power' => '250.0' })
+    )
+    Clients::Alpaca.any_instance.stubs(:get_positions).returns(Result::Success.new([]))
+
+    result = with_dry_run(false) { @exchange.get_balances(asset_ids: [usd.id]) }
+    assert_predicate result, :success?
+
+    balance = result.data[usd.id]
+    # :free stays cash — AccountBalance::Sync values the portfolio from it, and buying power is
+    # borrowed money, not a holding.
+    assert_equal 0.to_d, balance[:free]
+    assert_equal 5000.to_d, balance[:buying_power]
+    assert_equal 250.to_d, balance[:non_marginable_buying_power]
+  end
+
+  # nil.to_d is 0, so a plain .to_d would turn an absent field into a hard zero and make every
+  # account look broke. Absence has to survive as nil for #spendable_balance to fall back.
+  test 'get_balances leaves an omitted buying-power field nil rather than zero' do
+    usd = usd_with_ticker
+
+    Clients::Alpaca.any_instance.stubs(:get_account).returns(Result::Success.new({ 'cash' => '100.0' }))
+    Clients::Alpaca.any_instance.stubs(:get_positions).returns(Result::Success.new([]))
+
+    result = with_dry_run(false) { @exchange.get_balances(asset_ids: [usd.id]) }
+    assert_predicate result, :success?
+
+    balance = result.data[usd.id]
+    assert_equal 100.to_d, balance[:free]
+    assert_nil balance[:buying_power]
+    assert_nil balance[:non_marginable_buying_power]
+  end
+
+  # == spendable_balance ==
+
+  test 'spendable_balance returns buying power for a stock ticker' do
+    aapl = create(:asset, external_id: 'alpaca_uuid-aapl2', symbol: 'AAPL', category: 'Stock')
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    ticker = create(:ticker, exchange: @exchange, base_asset: aapl, quote_asset: usd, ticker: 'AAPL')
+    balance = { free: 0.to_d, buying_power: 5000.to_d, non_marginable_buying_power: 0.to_d }
+
+    assert_equal 5000.to_d, @exchange.spendable_balance(balance, tickers: [ticker])
+  end
+
+  test 'spendable_balance returns non-marginable buying power for a crypto ticker' do
+    btc = create(:asset, :bitcoin)
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    ticker = create(:ticker, exchange: @exchange, base_asset: btc, quote_asset: usd, ticker: 'BTC/USD')
+    balance = { free: 0.to_d, buying_power: 5000.to_d, non_marginable_buying_power: 250.to_d }
+
+    assert_equal 250.to_d, @exchange.spendable_balance(balance, tickers: [ticker])
+  end
+
+  test 'spendable_balance falls back to free when the figure it wants is absent' do
+    btc = create(:asset, :bitcoin)
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    ticker = create(:ticker, exchange: @exchange, base_asset: btc, quote_asset: usd, ticker: 'BTC/USD')
+    balance = { free: 100.to_d, buying_power: 5000.to_d }
+
+    assert_equal 100.to_d, @exchange.spendable_balance(balance, tickers: [ticker])
+  end
+
   test 'fetch_withdrawal_fees! returns empty success' do
     result = @exchange.fetch_withdrawal_fees!
     assert_predicate result, :success?
@@ -525,6 +593,15 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
   def trading_key!(key: 'mk', secret: 'ms', passphrase: 'paper', status: :correct)
     create(:api_key, exchange: @exchange, key_type: :trading, status: status,
                      raw_key: key, raw_secret: secret, raw_passphrase: passphrase)
+  end
+
+  # USD resolves through a ticker's quote side (Exchange#asset_from_symbol), so the balance
+  # branch only runs when the exchange has one.
+  def usd_with_ticker
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    base = create(:asset, external_id: 'alpaca_uuid-msft', symbol: 'MSFT', category: 'Stock')
+    create(:ticker, exchange: @exchange, base_asset: base, quote_asset: usd, ticker: 'MSFT')
+    usd
   end
 
   test 'get_tickers_prices authenticates with a resolved trading key when no client was set' do


### PR DESCRIPTION
Margin-enabled Alpaca accounts receive "Your Alpaca account is running out of USD" while holding plenty of buying power.

## Cause

`Bot::Fundable#funds_are_low?` compares the quote asset's free balance against a 3-day spend buffer. For Alpaca that free balance is `account['cash']`, and on a margin account cash sits at, near, or below zero by design — `buying_power` is what Alpaca checks when an order lands. So the alert fires on a healthy account.

Only the email is affected. Nothing gates order placement on this check: the other `get_balance` callers are the sell-side base check and withdrawals, neither on the buy path.

## Change

`get_balances` keeps reporting cash as `:free` — `AccountBalance::Sync` and `BotApi::Exchanges::Balances` value the portfolio from it, and buying power is borrowed money, not a holding. Both spend figures ride along as extra keys instead.

Which figure applies depends on what the bot trades, and `get_balances` has no bot context while the caller does. So a new `Exchange#spendable_balance(balance, tickers:)` picks between them, mirroring the existing `market_open?(tickers:)` pattern: base implementation returns `:free`, Alpaca overrides. Crypto is non-marginable at Alpaca, so a crypto bot compares `non_marginable_buying_power`. Every other exchange is unchanged.

Absent fields stay `nil` rather than becoming `0` through `nil.to_d`, so a partial `/v2/account` response falls back to settled cash instead of reporting an empty account.

## Known ceiling

`all_crypto?` is approximate in three cases: non-marginable equities aren't flagged in our catalog, `DcaIndex#tickers` returns every quote-matching ticker rather than the bot's allocations, and mixed dual bots have both. All three resolve to `buying_power` — a missed warning, never the false alarm this fixes. `any_crypto?` would invert that and keep false-alarming every index bot, preserving the bug for a whole bot class.

The upgrade path is in a `ponytail:` comment: persist Alpaca's `marginable` flag on `Ticker`/`ExchangeAsset` (it's venue metadata) and give bots a `funding_tickers` that reports real allocations. Neither is worth a migration and a fleet backfill for an advisory email today.

## Out of scope, noticed while here

`Notifications::BotAlerts` has no callers anywhere in `app/` — a dead parallel implementation of these alerts, including a throttled `end_of_funds` that the live path (`Bot::Notifyable`) lacks. Worth deleting separately.

## Not addressed: margin-usage warnings

Also raised was whether to warn when margin usage grows. Alpaca already issues margin calls; re-implementing a broker's risk system off a polled snapshot means every threshold is wrong for someone, and we own the liability when we're late.

## Tests

8 new in `test/models/bot/fundable_test.rb`, 5 in the Alpaca exchange test: cash-venue fallback unchanged, the margin stock case, crypto not borrowing, genuinely-empty still alerting, and each missing-key fallback driven through `get_balances` from a partial account response.

Full suite: 3176 runs, 0 failures. Rubocop clean.
