### PR TITLE
Classify exchange errors by substring, not exact equality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,4 @@ gem "haikunator", "~> 1.1"
 gem "sqids" # for obfuscating IDs
 gem 'ruby-technical-analysis', git: 'https://github.com/guillemap/ruby-technical-analysis' # TODO: use the official gem once https://github.com/johnnypaper/ruby-technical-analysis/pull/32 is merged
 gem 'hyperliquid-rb'
-gem 'honeymaker', '~> 0.10.0'
+gem 'honeymaker', '~> 0.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       railties (>= 5.1)
     hana (1.3.7)
     hashdiff (1.2.1)
-    honeymaker (0.10.0)
+    honeymaker (0.11.0)
       bigdecimal
       faraday (~> 2.0)
       faraday-net_http_persistent (~> 2.0)
@@ -621,7 +621,7 @@ DEPENDENCIES
   faraday-net_http_persistent (~> 2.3.0)
   haikunator (~> 1.1)
   haml-rails (~> 3.0)
-  honeymaker (~> 0.10.0)
+  honeymaker (~> 0.11.0)
   hyperliquid-rb
   importmap-rails
   jaro_winkler (~> 1.7)
@@ -741,7 +741,7 @@ CHECKSUMS
   haml-rails (3.1.0) sha256=4366474d973e4b9d5326cb216f2073150cfeff4c2a3c07fadb49a490ffdf610b
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  honeymaker (0.10.0) sha256=ea29c724a51f2f59290f53c0670786fecbb41d2fbc33ef0b38e114573cbcbb9d
+  honeymaker (0.11.0) sha256=c04e24f85ec5c8cac009455e31e2994b9a94c8e594f5ac749e00da9f6c73b5f2
   http-2 (1.2.1) sha256=d290f3b7daa70b8be8cd2260306c01243c73ec4df9d598feadaf0ed26e00b9b7
   httpx (1.8.1) sha256=8d9e003019b2c1a8f582daac9371ec9da96182c23064e211386eaad70b6e12e5
   hyperliquid-rb (0.1.1) sha256=0b02b2a17bf1eb431c76804b43d3492397dd4ff8cd308df39ecaf3459cd53087

--- a/app/jobs/bot/action_job.rb
+++ b/app/jobs/bot/action_job.rb
@@ -242,16 +242,31 @@ class Bot::ActionJob < BotJob
     bot.update_columns(transient_data: bot.transient_data.merge('waiting_for_market_open' => nil))
   end
 
+  # Substring, not equality — the same rule as its four siblings (Exchange#invalid_key_error?,
+  # #transient_error?, #placement_transient_error?, #throttled_error?). Exact equality only ever
+  # worked for the venues whose model happens to unwrap the response to a bare `msg` (Binance and
+  # its clones, Kraken, Coinbase). Everywhere else the raised string is a JSON envelope
+  # ({"code":"43012","msg":"Insufficient balance",…}) or carries a prefix ("Hyperliquid order
+  # failed: …", "Failed to read BTC balance for bot 88: …"), so a genuine out-of-funds rejection
+  # was never recognised: the bot took the red path — retry storm, "your bot failed" email — and
+  # notify_end_of_funds could not fire.
+  #
+  # The trade is a false positive silencing a real error, so the patterns must stay whole phrases.
+  # Blank ones are dropped: "".include? is true for every message and would file every failure on
+  # that venue as out-of-funds.
   def ignorable_error_category(bot, error)
     DO_NOT_RETRY_ERRORS.find do |category|
-      messages = Array(bot.exchange.known_errors[category]).compact
-      error.message.in?(messages)
+      messages = Array(bot.exchange.known_errors[category]).map(&:to_s).reject(&:blank?)
+      messages.any? { |m| error.message.include?(m) }
     end
   end
 
+  # notify_end_of_funds always names the QUOTE asset (Bot::Notifyable), but a selling bot spends
+  # base — so for a sell it would tell the user to top up the asset that did not run out.
+  # Bot::Fundable skips its own low-funds check while selling for exactly this reason. The
+  # classification still stands (don't retry-storm a balance rejection); only the wording changes.
   def notify_ignorable(bot, category, error)
-    case category
-    when :insufficient_funds
+    if category == :insufficient_funds && !bot.selling?
       bot.notify_end_of_funds
     else
       bot.notify_about_error(errors: humanized_errors(bot, error))

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -266,10 +266,19 @@ class Exchange < ApplicationRecord
   # reached the matching engine → re-placing with a fresh timestamp is safe), whereas a placement
   # network timeout OR an ambiguous exchange error is indistinguishable from a successful book hit, and
   # placement has no idempotency key → it must NOT be treated as safely transient. Do not widen this.
+  #
+  # A venue may add its own strings via known_errors[:placement_safe_transient], scoped to itself so
+  # one venue's wording can never vouch for another's. The bar is unchanged and deliberately high:
+  # the string must guarantee a PRE-TRADE rejection. Signed-timestamp rejections qualify because the
+  # timestamp is part of the signed payload — failing it fails authentication, and an unauthenticated
+  # request never reaches the matching engine. That is the same proof that admitted Binance's -1021.
+  # Note this is opt-in separately from known_errors[:transient]: being retryable on a READ says
+  # nothing about being safe to RE-PLACE, so the string must be listed twice, on purpose.
   def placement_transient_error?(errors)
+    patterns = PLACEMENT_SAFE_TRANSIENT_ERRORS + (known_errors[:placement_safe_transient] || []).map(&:to_s)
     Array(errors).any? do |err|
       msg = err.to_s
-      PLACEMENT_SAFE_TRANSIENT_ERRORS.any? { |m| msg.include?(m) }
+      patterns.any? { |m| msg.include?(m) }
     end
   end
 

--- a/app/models/exchanges/bitget.rb
+++ b/app/models/exchanges/bitget.rb
@@ -2,7 +2,15 @@ class Exchanges::Bitget < Exchange
   COINGECKO_ID = 'bitget'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
     insufficient_funds: ['Insufficient balance', 'Insufficient account balance'],
-    invalid_key: ['Invalid Api Key', 'Invalid ACCESS_KEY', 'Invalid signature', 'Apikey does not exist']
+    invalid_key: ['Invalid Api Key', 'Invalid ACCESS_KEY', 'Invalid signature', 'Apikey does not exist'],
+    # 40008: the signed timestamp fell outside Bitget's window — same class as KuCoin's 400002
+    # and Binance's -1021, and it fires for the same reason (a request stalled behind a slow
+    # exchange proxy, not a drifting clock). Retried instead of failing the bot loudly.
+    transient: ['Request timestamp expired'],
+    # Listed again, deliberately: 40008 is raised while verifying the signature (the timestamp is
+    # part of the signed payload), so the order never reached the book and re-placing it next
+    # interval cannot double-buy. See Exchange#placement_transient_error?.
+    placement_safe_transient: ['Request timestamp expired']
   }.freeze
 
   # API-key-validity probe (fake cancel_order) classification by Bitget response code. Kept out of
@@ -114,7 +122,10 @@ class Exchanges::Bitget < Exchange
     return result if result.failure?
 
     data = result.data['data']
-    return Result::Failure.new("Failed to get #{name} balances") if data.nil?
+    # As in Exchanges::Kucoin: this path calls get_account_assets directly and so bypasses the
+    # client's code check. Carry the venue's reason through instead of flattening it, or
+    # invalid_key_error? has nothing to read on the tracker-sync path.
+    return Result::Failure.new("Failed to get #{name} balances: #{result.data.values_at('code', 'msg').compact.join(' ')}") if data.nil?
 
     asset_ids ||= assets.pluck(:id)
     balances = asset_ids.to_h do |asset_id|

--- a/app/models/exchanges/bybit.rb
+++ b/app/models/exchanges/bybit.rb
@@ -1,7 +1,10 @@
 class Exchanges::Bybit < Exchange
   COINGECKO_ID = 'bybit_spot'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
-    insufficient_funds: ['170131', 'Insufficient balance'],
+    # '170131' removed: the client returns retMsg only (Clients::Bybit#create_order/#get_order)
+    # and parse_error_message re-strips the code, so the digits never reach a message — while as
+    # a substring they would match any id or epoch that happens to contain them.
+    insufficient_funds: ['Insufficient balance'],
     invalid_key: %w[10003 10004]
   }.freeze
   # https://bybit-exchange.github.io/docs/v5/enum#orderstatus

--- a/app/models/exchanges/hyperliquid.rb
+++ b/app/models/exchanges/hyperliquid.rb
@@ -1,7 +1,11 @@
 class Exchanges::Hyperliquid < Exchange
   COINGECKO_ID = 'hyperliquid-spot'.freeze
   ERRORS = {
-    insufficient_funds: ['Insufficient balance', 'Not enough balance'],
+    # 'Insufficient spot balance' is the wording observed in production (2026-08-16): the venue
+    # says "Insufficient spot balance asset=10266", so neither of the two generic entries below
+    # is a substring of it. Every rejection also arrives behind a "Hyperliquid order failed: "
+    # prefix (see set_order), which is why exact matching could never have worked here.
+    insufficient_funds: ['Insufficient spot balance', 'Insufficient balance', 'Not enough balance'],
     invalid_key: ['Invalid API key', 'Authentication failed', 'Invalid signature']
   }.freeze
 

--- a/app/models/exchanges/ibkr.rb
+++ b/app/models/exchanges/ibkr.rb
@@ -3,7 +3,14 @@ class Exchanges::Ibkr < Exchange
   # login/expired-LST blip must NEVER flip a valid key to :incorrect (ApiKeyFailureHandling). We
   # only add genuine credential-rejection strings here once observed in the staging logs.
   ERRORS = {
-    insufficient_funds: ['insufficient', 'buying power'],
+    # Deliberately empty. These were the bare tokens 'insufficient' and 'buying power', which
+    # never matched under the old exact-equality classifier and are far too loose for the
+    # substring one: IBKR reports market-data subscription, trading-permission and short-locate
+    # problems in prose containing "insufficient", and our own Clients::Ibkr#place_order wraps an
+    # unanswered precautionary prompt as "Order not confirmed: …" — those prompts routinely
+    # mention buying power. Any of those would park the bot and email "add funds" for a problem
+    # funding cannot fix. Populate from a captured rejection body, not from a guess.
+    insufficient_funds: [],
     invalid_key: [],
     transient: ['not authenticated', 'competing', 'session', 'Please query /accounts first',
                 'live session token', 'Bad Request: no bridge']

--- a/app/models/exchanges/kucoin.rb
+++ b/app/models/exchanges/kucoin.rb
@@ -2,7 +2,15 @@ class Exchanges::Kucoin < Exchange
   COINGECKO_ID = 'kucoin'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
     insufficient_funds: ['Balance insufficient!', 'Insufficient balance'],
-    invalid_key: ['Invalid API-Key', 'Invalid KC-API-SIGN', 'Invalid passphrase']
+    invalid_key: ['Invalid API-Key', 'Invalid KC-API-SIGN', 'Invalid passphrase'],
+    # 400002: the signed timestamp fell outside KuCoin's window. Same class as Binance's -1021 —
+    # a correct, NTP-synced clock still trips it whenever a request stalls behind a slow exchange
+    # proxy for longer than the window. Retried, surfaced gray, no "your bot failed" email.
+    transient: ['Invalid KC-API-TIMESTAMP'],
+    # Listed again, deliberately: 400002 is raised while verifying the signature (the timestamp is
+    # part of the signed payload), so the order never reached the book and re-placing it next
+    # interval cannot double-buy. See Exchange#placement_transient_error?.
+    placement_safe_transient: ['Invalid KC-API-TIMESTAMP']
   }.freeze
 
   include Exchange::Dryable # decorators for: get_order, get_orders, cancel_order, get_api_key_validity, set_market_order, set_limit_order
@@ -100,7 +108,11 @@ class Exchanges::Kucoin < Exchange
     return result if result.failure?
 
     data = result.data['data']
-    return Result::Failure.new("Failed to get #{name} balances") if data.nil?
+    # This path calls get_accounts directly, so it never sees the client's own code check —
+    # a rejected read arrives as a 200 envelope with no 'data'. Carry the venue's reason through:
+    # invalid_key_error? reads this text to decide whether to flag the key, and a bare
+    # "Failed to get KuCoin balances" tells it (and an operator) nothing.
+    return Result::Failure.new("Failed to get #{name} balances: #{result.data.values_at('code', 'msg').compact.join(' ')}") if data.nil?
 
     asset_ids ||= assets.pluck(:id)
     balances = asset_ids.to_h do |asset_id|

--- a/test/jobs/bot/action_job_error_classification_test.rb
+++ b/test/jobs/bot/action_job_error_classification_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+# Bot::ActionJob#ignorable_error_category decides whether a failed run is "out of funds"
+# (notify_end_of_funds, reschedule cleanly) or "something broke" (red email, retry storm,
+# bot parked in :retrying). Getting it wrong in the second direction is the silent-bot class.
+#
+# Every other test around known_errors asserts the constants against themselves, which proves
+# nothing about matching. These feed the message a venue ACTUALLY produces — reconstructed from
+# the client code, or copied out of a production log where noted — through the real classifier.
+class Bot::ActionJobErrorClassificationTest < ActiveSupport::TestCase
+  # message => must classify as :insufficient_funds
+  OUT_OF_FUNDS = {
+    # Model unwraps the JSON envelope to the bare msg (Exchanges::Binance#parse_error_message).
+    binance_exchange: 'Account has insufficient balance for requested action.',
+    bitrue_exchange: 'Account has insufficient balance for requested action.',
+    # Kraken splats its error array; a single-error response arrives bare.
+    kraken_exchange: 'EOrder:Insufficient funds',
+    coinbase_exchange: 'Insufficient balance in source account',
+    # Bybit's client returns retMsg only — note the trailing period the config lacks.
+    bybit_exchange: 'Insufficient balance.',
+    # Raw HTTP-200/4xx JSON envelope, passed through untouched.
+    bitget_exchange: '{"code":"43012","msg":"Insufficient balance","requestTime":1786893362617,"data":null}',
+    gemini_exchange: '{"result":"error","reason":"InsufficientFunds","message":"Insufficient funds"}',
+    # Post-honeymaker-fix shape: "<Venue> API error <code>: <msg>".
+    kucoin_exchange: 'KuCoin API error 200004: Balance insufficient!',
+    # Observed in production 2026-08-16. The venue says "spot balance", and hyperliquid.rb
+    # wraps every rejection with a prefix.
+    hyperliquid_exchange: 'Hyperliquid order failed: Insufficient spot balance asset=10266'
+  }.freeze
+
+  # message => must NOT be swallowed as insufficient_funds. A false positive here parks the bot
+  # and tells the user to add money for a problem money cannot fix.
+  NOT_OUT_OF_FUNDS = {
+    binance_exchange: 'Invalid API-key, IP, or permissions for action.',
+    hyperliquid_exchange: 'Hyperliquid order failed: Price must be divisible by tick size',
+    kucoin_exchange: 'KuCoin API error 400002: Invalid KC-API-TIMESTAMP.',
+    bitget_exchange: '{"code":"40008","msg":"Request timestamp expired","requestTime":1786893362617,"data":null}',
+    # Our own wrap (Clients::Ibkr#place_order) around an unanswered precautionary prompt. IBKR's
+    # prompts routinely mention buying power; the order was not placed for a funding reason.
+    ibkr_exchange: 'Order not confirmed: this order will reduce your available buying power below zero',
+    # A permission problem, not a funding one.
+    ibkr_exchange_permissions: 'Trading permissions are insufficient for this instrument'
+  }.freeze
+
+  OUT_OF_FUNDS.each do |factory, message|
+    test "#{factory} classifies #{message.truncate(60).inspect} as insufficient_funds" do
+      assert_equal :insufficient_funds, classify(factory, message),
+                   "#{factory}: a real out-of-funds rejection must reach notify_end_of_funds"
+    end
+  end
+
+  NOT_OUT_OF_FUNDS.each do |key, message|
+    test "#{key} does not classify #{message.truncate(60).inspect} as insufficient_funds" do
+      factory = key.to_s.sub(/_permissions\z/, '').to_sym
+      assert_nil classify(factory, message),
+                 "#{key}: a non-funding failure must not be silenced as \"add funds\""
+    end
+  end
+
+  # A blank pattern makes String#include? true for every message, which would file every
+  # failure on that venue as out-of-funds. Cheap guard on a path that decides whether a user
+  # is told to send money.
+  test 'a blank configured pattern never matches' do
+    exchange = create(:binance_exchange)
+    exchange.stubs(:known_errors).returns(insufficient_funds: ['', nil])
+
+    assert_nil Bot::ActionJob.new.send(:ignorable_error_category, stub(exchange: exchange),
+                                       RuntimeError.new('some unrelated explosion'))
+  end
+
+  private
+
+  def classify(factory, message)
+    exchange = create(factory)
+    Bot::ActionJob.new.send(:ignorable_error_category, stub(exchange: exchange), RuntimeError.new(message))
+  end
+end

--- a/test/jobs/bot/action_job_test.rb
+++ b/test/jobs/bot/action_job_test.rb
@@ -214,6 +214,22 @@ module ActionJobBehaviorTests
       end
     end
 
+    # end_of_funds always names the QUOTE asset (Bot::Notifyable#notify_end_of_funds). A selling
+    # bot spends base, so that mail would tell the user to top up the asset that did not run out.
+    # Bot::Fundable already skips its low-funds check while selling for the same reason.
+    test 'a selling bot out of base gets the real error, not the quote-asset end_of_funds mail' do
+      bot = create_bot
+      setup_action_job_mocks(bot)
+      bot.stubs(:selling?).returns(true)
+      bot.stubs(:execute_action).returns(Result::Failure.new('insufficient buying power'))
+      bot.exchange.stubs(:known_errors).returns(insufficient_funds: ['insufficient buying power'])
+      bot.expects(:notify_end_of_funds).never
+      bot.expects(:notify_about_error).once
+
+      Bot::ActionJob.new.perform(bot)
+      assert_equal 'retrying', bot.reload.status
+    end
+
     test 'does not schedule next job when break_reschedule is true' do
       bot = create_bot
       setup_action_job_mocks(bot)

--- a/test/models/exchanges/bitget_test.rb
+++ b/test/models/exchanges/bitget_test.rb
@@ -17,6 +17,29 @@ class Exchanges::BitgetTest < ActiveSupport::TestCase
     assert_kind_of Array, errors[:invalid_key]
   end
 
+  # 40008 is a stalled request, not a broken bot: retry it like Binance's -1021 instead of
+  # failing the run loudly. Observed in production 2026-08-16 while the UK exchange proxy hung.
+  test 'transient_error? recognises an expired request timestamp' do
+    assert @exchange.transient_error?(
+      ['{"code":"40008","msg":"Request timestamp expired","requestTime":1786893362617,"data":null}']
+    )
+  end
+
+  test 'transient_error? does not swallow an ordinary rejection' do
+    assert_not @exchange.transient_error?(['{"code":"43012","msg":"Insufficient balance"}'])
+  end
+
+  # 40008 is rejected during signature verification, so the order never reached the book —
+  # re-placing it next interval cannot double-buy. Without this, a placement rejected by a
+  # stalled proxy still writes a phantom `failed` transaction and emails the user.
+  test 'placement_transient_error? treats an expired timestamp as a pre-trade rejection' do
+    assert @exchange.placement_transient_error?(['{"code":"40008","msg":"Request timestamp expired"}'])
+  end
+
+  test 'placement_transient_error? stays false for an ambiguous failure' do
+    assert_not @exchange.placement_transient_error?(['{"code":"43012","msg":"Insufficient balance"}'])
+  end
+
   test 'minimum_amount_logic returns base_or_quote for market orders' do
     assert_equal :base_or_quote, @exchange.minimum_amount_logic(order_type: :market_order)
   end

--- a/test/models/exchanges/bybit_test.rb
+++ b/test/models/exchanges/bybit_test.rb
@@ -13,7 +13,10 @@ class Exchanges::BybitTest < ActiveSupport::TestCase
     errors = @exchange.known_errors
     assert errors[:insufficient_funds].present?
     assert errors[:invalid_key].present?
-    assert_includes errors[:insufficient_funds], '170131'
+    # Not '170131': the client hands us retMsg with the code already stripped, so a bare code
+    # can never appear in a message — it only added substring-collision risk.
+    assert_includes errors[:insufficient_funds], 'Insufficient balance'
+    assert_not_includes errors[:insufficient_funds], '170131'
     assert_includes errors[:invalid_key], '10003'
   end
 

--- a/test/models/exchanges/kucoin_test.rb
+++ b/test/models/exchanges/kucoin_test.rb
@@ -17,6 +17,27 @@ class Exchanges::KucoinTest < ActiveSupport::TestCase
     assert_kind_of Array, errors[:invalid_key]
   end
 
+  # 400002 is a stalled request, not a broken bot: retry it like Binance's -1021 instead of
+  # failing the run loudly. Observed in production 2026-08-16 while the UK exchange proxy hung.
+  test 'transient_error? recognises a stale KC-API-TIMESTAMP rejection' do
+    assert @exchange.transient_error?(['{"code":"400002","msg":"Invalid KC-API-TIMESTAMP."}'])
+  end
+
+  test 'transient_error? does not swallow an ordinary rejection' do
+    assert_not @exchange.transient_error?(['KuCoin API error 200004: Balance insufficient!'])
+  end
+
+  # 400002 is rejected during signature verification, so the order never reached the book —
+  # re-placing it next interval cannot double-buy. Without this, a placement rejected by a
+  # stalled proxy still writes a phantom `failed` transaction and emails the user.
+  test 'placement_transient_error? treats a stale timestamp as a pre-trade rejection' do
+    assert @exchange.placement_transient_error?(['{"code":"400002","msg":"Invalid KC-API-TIMESTAMP."}'])
+  end
+
+  test 'placement_transient_error? stays false for an ambiguous failure' do
+    assert_not @exchange.placement_transient_error?(['KuCoin API error 200004: Balance insufficient!'])
+  end
+
   test 'minimum_amount_logic returns base_or_quote for market orders' do
     assert_equal :base_or_quote, @exchange.minimum_amount_logic(order_type: :market_order)
   end


### PR DESCRIPTION
Requires honeymaker 0.11.0 (deltabadger/honeymaker#1), bumped here.

## The bug

`Bot::ActionJob#ignorable_error_category` matched the raised message against `known_errors[:insufficient_funds]` with **exact equality**:

```ruby
error.message.in?(messages)
```

Its four siblings in `Exchange` — `invalid_key_error?`, `transient_error?`, `placement_transient_error?`, `throttled_error?` — have always matched by substring.

Exact equality only ever worked for venues whose model unwraps the response to a bare `msg` (the Binance family, Kraken, Coinbase). Everywhere else the raised string is a JSON envelope, or carries a prefix:

```
{"code":"43012","msg":"Insufficient balance","requestTime":…}
Hyperliquid order failed: Insufficient spot balance asset=…
```

Neither equals the configured literal, so a genuine out-of-funds rejection was never recognised. Rather than `notify_end_of_funds` and a clean reschedule, those bots took the red path — retry storm plus a "your bot failed" email, every tick, for something the user could fix in a minute.

**Ten of fifteen venues were affected.** The existing per-venue tests asserted the `ERRORS` constants against themselves, so none of this was visible.

## The fix

Substring matching, plus a blank-pattern guard — `"".include?` is true for every message and would file every failure on that venue as out-of-funds.

Widening the matcher makes loose patterns dangerous, so the entries authored as bare tokens are corrected in the same commit:

| Venue | Change | Reason |
|---|---|---|
| IBKR | `insufficient_funds` emptied | `'insufficient'` / `'buying power'` collide with market-data, trading-permission and short-locate errors, and with our own `"Order not confirmed: …"` wrap — IBKR precautionary prompts routinely mention buying power |
| Bybit | `'170131'` dropped | the client returns `retMsg` with the code stripped, so it could never match, only collide with an id or epoch |
| Hyperliquid | `+ 'Insufficient spot balance'` | the wording the venue actually uses; neither existing entry is a substring of it |

### Sell-side notification

`notify_end_of_funds` always names the **quote** asset, but a selling bot spends base — so for a sell it told the user to top up the asset that had not run out. `notify_ignorable` now mirrors `Bot::Fundable`, which already skips its low-funds check while selling for the same reason. The classification is unchanged (a balance rejection should not retry-storm); only the wording differs.

### Stale-timestamp rejections

KuCoin `400002` and Bitget `40008` fire whenever a request stalls longer than the venue's signing window. Both are now `transient` so they retry gray instead of failing a run loudly.

Both are additionally opt-in placement-safe through a new `known_errors[:placement_safe_transient]` key, scoped per venue so one venue's wording can never vouch for another's. The bar on that allowlist is unchanged and deliberately high — the string must guarantee a pre-trade rejection. These qualify: the timestamp is part of the signed payload, so failing it fails authentication, and an unauthenticated request never reaches the matching engine. That is the same proof that admitted Binance's `-1021`. Being retryable on a read says nothing about being safe to re-place, so the string is listed twice, on purpose.

### Balance paths

`Exchanges::Kucoin#get_balances` and `Exchanges::Bitget#get_balances` call `get_accounts` / `get_account_assets` directly and so bypass the client's own code check. Both flattened the venue's reason into `"Failed to get X balances"`, leaving `invalid_key_error?` nothing to read on the tracker-sync path. They now carry the code and msg through.

## Tests

New `test/jobs/bot/action_job_error_classification_test.rb` is table-driven over the message each venue actually produces — reconstructed from the client code, or taken from an observed production string — and asserts both directions: that a real out-of-funds rejection classifies, and that a non-funding failure is **not** silenced as "add funds" (auth errors, tick-size rejections, timestamp rejections, and the IBKR prompt wrap).

```
3486 runs, 12096 assertions, 0 failures, 0 errors, 0 skips
rubocop: 675 files inspected, no offenses detected
```

Verified end to end against the published honeymaker 0.11.0, driving the real KuCoin client over its HTTP-200 error envelope:

| response | message | outcome |
|---|---|---|
| `200004` | `KuCoin API error 200004: Balance insufficient!` | `:insufficient_funds` |
| `400002` | `KuCoin API error 400002: Invalid KC-API-TIMESTAMP.` | `transient` |

## Deliberately not included

These need a captured rejection body rather than a guess, which is how the wrong entries got there in the first place:

- **Bitvavo** — `'Insufficient funds.'` does not appear in its errorCode-216 text, so substring alone does not revive it. Best fixed by matching the code, for which `BITVAVO_NOT_FOUND_CODES` is the precedent.
- **Alpaca crypto** — the configured string is the equities margin wording; crypto rejects on cash with different text.
- **MEXC** — architecturally able to match, but no fixture pins its real wording.
- **IBKR** — emptied here; needs real bodies to repopulate.
- **KuCoin `400003`** — returns `KC-API-KEY not exists`, absent from its `invalid_key` list, so a dead key is never flagged `:incorrect`.

Also out of scope, noted while auditing: `:throttle` is absent from every venue but Kraken, so `throttled_error?` short-circuits and `BotJob::RATE_LIMIT_WAIT` is effectively dead for 14 of 15 venues.
