### PR TITLE
Match invalid-key errors against what the venues actually return

### DIFF
--- a/app/models/exchanges/bitvavo.rb
+++ b/app/models/exchanges/bitvavo.rb
@@ -1,8 +1,16 @@
 class Exchanges::Bitvavo < Exchange
   COINGECKO_ID = 'bitvavo'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
-    insufficient_funds: ['Insufficient funds.'],
-    invalid_key: ['Invalid API key.', 'Signature invalid.']
+    # Bitvavo returns a JSON envelope and its own prose, neither of which contained the strings
+    # previously configured here ('Insufficient funds.', 'Invalid API key.', 'Signature invalid.') —
+    # so nothing on this venue was ever classified. These are matched against captured bodies:
+    #   216 {"errorCode":216,"error":"You do not have sufficient balance to complete this operation."}
+    #   305 {"errorCode":305,"error":"No active API key found."}
+    #   301 {"errorCode":301,"error":"API Key must be of length 64."}
+    # Matched on the prose rather than the code so the pattern cannot collide with an unrelated
+    # number elsewhere in the payload (a timestamp, a quantity, an order id).
+    insufficient_funds: ['sufficient balance to complete'],
+    invalid_key: ['No active API key found', 'API Key must be of length']
   }.freeze
   ORDER_STATUS_MAP = {
     'new' => :open,

--- a/app/models/exchanges/bybit.rb
+++ b/app/models/exchanges/bybit.rb
@@ -5,8 +5,20 @@ class Exchanges::Bybit < Exchange
     # and parse_error_message re-strips the code, so the digits never reach a message — while as
     # a substring they would match any id or epoch that happens to contain them.
     insufficient_funds: ['Insufficient balance'],
-    invalid_key: %w[10003 10004]
+    # Messages, not codes — this list is substring-matched against error text by
+    # Exchange#invalid_key_error?. It previously held the bare codes 10003/10004, which no message
+    # ever contains, so a dead Bybit key was never flagged. The string below is Bybit's actual
+    # wording, taken from recorded failures on this venue; it reads like Binance's because Bybit
+    # reuses that phrasing. The codes moved to INVALID_KEY_CODES, which is what the retCode branch
+    # of get_api_key_validity actually needs.
+    invalid_key: ['Invalid API-key, IP, or permissions for action.']
   }.freeze
+
+  # Matched against the parsed retCode, never against a message — keeping them out of ERRORS stops
+  # a bare number being substring-matched into any id or timestamp that happens to contain it.
+  # Same split Bitget already uses for its probe codes.
+  INVALID_KEY_CODES = %w[10003 10004].freeze
+  private_constant :INVALID_KEY_CODES
   # https://bybit-exchange.github.io/docs/v5/enum#orderstatus
   ORDER_STATUS_MAP = {
     'Created' => :unknown,
@@ -355,7 +367,7 @@ class Exchanges::Bybit < Exchange
       ret_code = result.data['retCode']
       if ret_code.zero?
         Result::Success.new(true)
-      elsif ret_code.to_s.in?(ERRORS[:invalid_key])
+      elsif ret_code.to_s.in?(INVALID_KEY_CODES)
         Result::Success.new(false)
       else
         # For trading keys: non-auth errors (e.g. order not found) mean the key has trade permissions

--- a/app/models/exchanges/kucoin.rb
+++ b/app/models/exchanges/kucoin.rb
@@ -2,7 +2,11 @@ class Exchanges::Kucoin < Exchange
   COINGECKO_ID = 'kucoin'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
     insufficient_funds: ['Balance insufficient!', 'Insufficient balance'],
-    invalid_key: ['Invalid API-Key', 'Invalid KC-API-SIGN', 'Invalid passphrase'],
+    # 'The API key does not exist or site mismatch.' is code 400003, captured from a live probe —
+    # the message a revoked or wrong-environment key actually returns. Without it a dead KuCoin key
+    # was never flagged :incorrect, so the user saw failures with no prompt to replace it.
+    invalid_key: ['Invalid API-Key', 'Invalid KC-API-SIGN', 'Invalid passphrase',
+                  'The API key does not exist or site mismatch.'],
     # 400002: the signed timestamp fell outside KuCoin's window. Same class as Binance's -1021 —
     # a correct, NTP-synced clock still trips it whenever a request stalls behind a slow exchange
     # proxy for longer than the window. Retried, surfaced gray, no "your bot failed" email.

--- a/app/models/exchanges/mexc.rb
+++ b/app/models/exchanges/mexc.rb
@@ -2,7 +2,9 @@ class Exchanges::Mexc < Exchange
   COINGECKO_ID = 'mxc'.freeze # https://docs.coingecko.com/reference/exchanges-list
   ERRORS = {
     insufficient_funds: ['Insufficient balance.'],
-    invalid_key: ['Invalid Api-Key ID.', 'Signature for this request is not valid.'],
+    # 'Api key info invalid' is code 10072, captured from a live probe. The two Binance-clone
+    # strings below it are kept but unproven — MEXC never emitted either in any recorded failure.
+    invalid_key: ['Api key info invalid', 'Invalid Api-Key ID.', 'Signature for this request is not valid.'],
     # MEXC is a Binance API clone and emits the identical -1021 timestamp string. Same treatment.
     transient: ['Timestamp for this request is outside of the recvWindow', 'Timestamp for this request was']
   }.freeze

--- a/test/jobs/bot/action_job_error_classification_test.rb
+++ b/test/jobs/bot/action_job_error_classification_test.rb
@@ -25,7 +25,12 @@ class Bot::ActionJobErrorClassificationTest < ActiveSupport::TestCase
     kucoin_exchange: 'KuCoin API error 200004: Balance insufficient!',
     # Observed in production 2026-08-16. The venue says "spot balance", and hyperliquid.rb
     # wraps every rejection with a prefix.
-    hyperliquid_exchange: 'Hyperliquid order failed: Insufficient spot balance asset=10266'
+    hyperliquid_exchange: 'Hyperliquid order failed: Insufficient spot balance asset=10266',
+    # Captured production body — errorCode 216. The configured 'Insufficient funds.' appears
+    # nowhere in it, so substring matching alone did not revive Bitvavo.
+    bitvavo_exchange: '{"errorCode":216,"error":"You do not have sufficient balance to complete this operation."}',
+    # Alpaca sends the bare message on some paths and this envelope on others; both must classify.
+    alpaca_exchange: '{"buying_power":"0","code":40310000,"cost_basis":"10","message":"insufficient buying power"}'
   }.freeze
 
   # message => must NOT be swallowed as insufficient_funds. A false positive here parks the bot
@@ -66,6 +71,49 @@ class Bot::ActionJobErrorClassificationTest < ActiveSupport::TestCase
 
     assert_nil Bot::ActionJob.new.send(:ignorable_error_category, stub(exchange: exchange),
                                        RuntimeError.new('some unrelated explosion'))
+  end
+
+  # Exchange#invalid_key_error? decides whether a live failure flips the key to :incorrect and
+  # shows the user a "broken key" button. Same failure mode as the funds classifier: a string that
+  # does not appear in any real response means a dead key is never flagged, and the user is left
+  # with a bot that fails silently forever.
+  #
+  # Every body below was captured from the venue — from a failed-transaction row in production, or
+  # by calling a read-only endpoint with deliberately invalid credentials.
+  INVALID_KEY = {
+    # Probe: deadbeef key/secret.
+    kucoin_exchange: '{"code":"400003","msg":"The API key does not exist or site mismatch."}',
+    bitget_exchange: '{"code":"40037","msg":"Apikey does not exist","requestTime":1786905567776,"data":null}',
+    gemini_exchange: '{"result":"error","reason":"InvalidApiKey","message":"Invalid API key"}',
+    mexc_exchange: '{"code":10072,"msg":"Api key info invalid"}',
+    bitvavo_exchange: '{"errorCode":305,"error":"No active API key found."}',
+    # Production failed-transaction rows.
+    binance_exchange: 'Invalid API-key, IP, or permissions for action.',
+    bybit_exchange: 'Invalid API-key, IP, or permissions for action.',
+    kraken_exchange: 'EAPI:Invalid key'
+  }.freeze
+
+  # Real failures that are NOT a key problem. Flagging the key here would tell the user to replace
+  # a perfectly good key and hide the actual cause.
+  NOT_INVALID_KEY = {
+    # Geo restriction, not a credential problem.
+    kraken_exchange: 'EAccount:Invalid permissions:USDT trading restricted for DE.',
+    bitvavo_exchange: '{"errorCode":216,"error":"You do not have sufficient balance to complete this operation."}',
+    bitget_exchange: '{"code":"43012","msg":"Insufficient balance","requestTime":1781165647492,"data":null}'
+  }.freeze
+
+  INVALID_KEY.each do |factory, body|
+    test "#{factory} recognises its real invalid-key response" do
+      assert create(factory).invalid_key_error?([body]),
+             "#{factory}: a dead key must be flagged, not left failing silently"
+    end
+  end
+
+  NOT_INVALID_KEY.each do |factory, body|
+    test "#{factory} does not flag the key on #{body.truncate(48).inspect}" do
+      assert_not create(factory).invalid_key_error?([body]),
+                 "#{factory}: a non-credential failure must not condemn a working key"
+    end
   end
 
   private

--- a/test/models/exchanges/bitvavo_test.rb
+++ b/test/models/exchanges/bitvavo_test.rb
@@ -13,8 +13,10 @@ class Exchanges::BitvavoTest < ActiveSupport::TestCase
     errors = @exchange.known_errors
     assert errors[:insufficient_funds].present?
     assert errors[:invalid_key].present?
-    assert_includes errors[:insufficient_funds], 'Insufficient funds.'
-    assert_includes errors[:invalid_key], 'Invalid API key.'
+    # Matched against Bitvavo's captured prose (errorCode 216 / 305), not the strings this venue
+    # was previously configured with — none of which appear in any real response.
+    assert_includes errors[:insufficient_funds], 'sufficient balance to complete'
+    assert_includes errors[:invalid_key], 'No active API key found'
   end
 
   test 'minimum_amount_logic returns base_or_quote for market orders' do

--- a/test/models/exchanges/bybit_test.rb
+++ b/test/models/exchanges/bybit_test.rb
@@ -17,7 +17,10 @@ class Exchanges::BybitTest < ActiveSupport::TestCase
     # can never appear in a message — it only added substring-collision risk.
     assert_includes errors[:insufficient_funds], 'Insufficient balance'
     assert_not_includes errors[:insufficient_funds], '170131'
-    assert_includes errors[:invalid_key], '10003'
+    # Messages only. The retCode digits live in INVALID_KEY_CODES, because this list is
+    # substring-matched against error text and a bare number matches any id that contains it.
+    assert_includes errors[:invalid_key], 'Invalid API-key, IP, or permissions for action.'
+    assert_not_includes errors[:invalid_key], '10003'
   end
 
   test 'minimum_amount_logic returns base_or_quote for market orders' do


### PR DESCRIPTION
Follow-up to #184, which fixed the matcher. This fixes the strings it matches against.

## The problem

`Exchange#invalid_key_error?` decides whether a live failure flips an API key to `:incorrect` and shows a "broken key" prompt. It substring-matches the failure text against `known_errors[:invalid_key]`.

Five venues were configured with strings that appear in no real response. A dead key on any of them was never flagged — the bot just kept failing, with nothing surfaced to act on.

## Evidence

Every string below came from an actual response: a recorded failed-transaction body, or a read-only endpoint called with deliberately invalid credentials. No live key, no order, no funds involved.

| Venue | Was configured | Actually returned |
|---|---|---|
| Bitvavo | `'Invalid API key.'` | `{"errorCode":305,"error":"No active API key found."}` |
| Bitvavo | `'Insufficient funds.'` | `{"errorCode":216,"error":"You do not have sufficient balance to complete this operation."}` |
| MEXC | `'Invalid Api-Key ID.'` | `{"code":10072,"msg":"Api key info invalid"}` |
| KuCoin | *(nothing for 400003)* | `{"code":"400003","msg":"The API key does not exist or site mismatch."}` |
| Bybit | `%w[10003 10004]` | `Invalid API-key, IP, or permissions for action.` |

Gemini's `'InvalidApiKey'` and Bitget's `'Apikey does not exist'` were checked the same way and are already correct, so they are untouched.

Note the Bitvavo insufficient-funds row: #184 assumed substring matching would revive that venue. It does not — the configured literal is absent from the 216 body entirely, so it needed the real prose.

## Bybit

Its `invalid_key` list was doing double duty — exact-matched against the parsed `retCode` in `get_api_key_validity`, then substring-matched against message text by `invalid_key_error?` a few lines later. It could only ever satisfy one of the two, and it satisfied the one that doesn't reach the message.

The codes move to a private `INVALID_KEY_CODES`, the same split Bitget already uses for its probe codes. That also removes the hazard #184 flagged for `'170131'`: a bare number, substring-matched, hits any id or timestamp that contains those digits.

Bitvavo matches on prose rather than `errorCode` for the same reason.

## Tests

The table-driven test from #184 gains two tables, both built from captured bodies — one asserting each venue recognises its real invalid-key response, one asserting that failures which are *not* credential problems never condemn a working key. That second table is the important half: it pins Kraken's `EAccount:Invalid permissions:USDT trading restricted for DE.`, which is a geo restriction that must never flip a key, plus the insufficient-funds bodies for Bitvavo and Bitget.

```
3499 runs, 12111 assertions, 0 failures, 0 errors, 0 skips
rubocop: 675 files inspected, no offenses detected
```

The per-venue `known_errors` assertions for Bitvavo and Bybit were updated too — they asserted the old strings against themselves, which is why none of this showed up.

## Still unproven, deliberately left alone

- **IBKR** — keys are connected but no failure has ever been recorded, and it is OAuth-gated so it cannot be probed with fake credentials. Stays empty.
- **Alpaca crypto** — no crypto rejection recorded. Equities is proven and covered in both its bare and enveloped forms.
- **MEXC insufficient funds** — invalid-key is now proven; the funds string is not.

These need the condition to actually occur. Guessing is what put the wrong strings in here to begin with — one guess made while preparing this change ("KC-API-KEY not exists" for KuCoin 400003) turned out wrong when checked against the real response.

## Noticed while gathering evidence, not addressed here

- Binance `Symbol not whitelisted for API key.` and `This symbol is not permitted for this account.` — configuration errors with no category, so they stay on the red path indefinitely.
- Hyperliquid `String can't be coerced into Float` — recorded several times; that one is ours, not the venue's.
- Bitvavo `errorCode 109` is `"The matching engine did not respond in time. Operation may or may not have succeeded."` — textbook ambiguous, and must never be added to `placement_safe_transient`.
