### PR TITLE
Require honeymaker 0.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,4 @@ gem "haikunator", "~> 1.1"
 gem "sqids" # for obfuscating IDs
 gem 'ruby-technical-analysis', git: 'https://github.com/guillemap/ruby-technical-analysis' # TODO: use the official gem once https://github.com/johnnypaper/ruby-technical-analysis/pull/32 is merged
 gem 'hyperliquid-rb'
-gem 'honeymaker', '~> 0.11.0'
+gem 'honeymaker', '~> 0.11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       railties (>= 5.1)
     hana (1.3.7)
     hashdiff (1.2.1)
-    honeymaker (0.11.0)
+    honeymaker (0.11.1)
       bigdecimal
       faraday (~> 2.0)
       faraday-net_http_persistent (~> 2.0)
@@ -621,7 +621,7 @@ DEPENDENCIES
   faraday-net_http_persistent (~> 2.3.0)
   haikunator (~> 1.1)
   haml-rails (~> 3.0)
-  honeymaker (~> 0.11.0)
+  honeymaker (~> 0.11.1)
   hyperliquid-rb
   importmap-rails
   jaro_winkler (~> 1.7)
@@ -741,7 +741,7 @@ CHECKSUMS
   haml-rails (3.1.0) sha256=4366474d973e4b9d5326cb216f2073150cfeff4c2a3c07fadb49a490ffdf610b
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  honeymaker (0.11.0) sha256=c04e24f85ec5c8cac009455e31e2994b9a94c8e594f5ac749e00da9f6c73b5f2
+  honeymaker (0.11.1) sha256=202af3953eb2cb93b9160b4318c2bb175e4af63d51c3e39c9d1ed079c2bac897
   http-2 (1.2.1) sha256=d290f3b7daa70b8be8cd2260306c01243c73ec4df9d598feadaf0ed26e00b9b7
   httpx (1.8.1) sha256=8d9e003019b2c1a8f582daac9371ec9da96182c23064e211386eaad70b6e12e5
   hyperliquid-rb (0.1.1) sha256=0b02b2a17bf1eb431c76804b43d3492397dd4ff8cd308df39ecaf3459cd53087


### PR DESCRIPTION
0.11.1 is the release that labels a local exception with its class and a `client_error` flag (deltabadger/honeymaker#2), so a `TypeError` raised inside a client no longer reaches the error classifiers looking like something the exchange said.

The constraint was `~> 0.11.0`. That resolves to 0.11.1, but it also still permits 0.11.0 — a version without the labelling — on any fresh resolve. This floors it at the version the behaviour depends on.

```
Gemfile       gem 'honeymaker', '~> 0.11.1'
Gemfile.lock  honeymaker (0.11.1)
```

Verified against the installed gem, driving a local exception through a real client:

| | |
|---|---|
| message | `TypeError: String cant be coerced into Float` |
| `client_error` | `true` |
| `transient_error?` | `false` — not retried as a venue blip |
| `ignorable_error_category` | `nil` — not misfiled as insufficient funds |

```
3499 runs, 12111 assertions, 0 failures, 0 errors, 0 skips
```