### PR TITLE
Describe the code, not the machines it runs on

### DIFF
--- a/app/models/exchange_proxy.rb
+++ b/app/models/exchange_proxy.rb
@@ -1,6 +1,6 @@
 class ExchangeProxy
-  # AppConfig (platform-claimed, self-hosted) beats ENV (container-injected, hosted).
-  # A hosted container never has the AppConfig rows, so fleet behavior is unchanged.
+  # A proxy stored in AppConfig wins over PROXY_<EXCHANGE> in the environment, so a claimed
+  # subscription overrides whatever the container was started with. Neither is required.
   def self.for(exchange)
     exchange_name = exchange.to_s
     AppConfig.get("proxy_#{exchange_name.downcase}").presence ||

--- a/app/models/market_data_settings.rb
+++ b/app/models/market_data_settings.rb
@@ -10,15 +10,13 @@ class MarketDataSettings
     AppConfig.market_data_provider
   end
 
-  # A DB-selected deltabadger provider with no credentials behind it is the stale-hosted-DB
-  # case: a container database carried over to a self-hosted install, still claiming a feed it
-  # can no longer reach. Reporting it as configured sends every caller into a Result::Failure
-  # instead of the CoinGecko setup step.
+  # A database can name the deltabadger provider with no URL or token behind it — a database
+  # copied from an install that had credentials to one that does not. Calling that configured
+  # sends every caller into a Result::Failure instead of offering the CoinGecko setup step.
   #
-  # Scoped to the non-ENV path on purpose. When MARKET_DATA_URL is injected the container is
-  # hosted and this is not a question worth re-deciding — widening the check there would flip
-  # a token-less tenant from "401s from the feed" to "back through the setup wizard", which is
-  # a fleet-wide behavior change this does not need to make.
+  # Only when the provider comes from the database. MARKET_DATA_URL in the environment is a
+  # deliberate choice by whoever started the process, and second-guessing it here would send an
+  # install with a URL but no token back through the setup wizard.
   def self.configured?
     return deltabadger_url.present? && deltabadger_token.present? if db_selected_deltabadger?
 
@@ -54,13 +52,9 @@ class MarketDataSettings
       (AppConfig.platform_connected? && deltabadger_url.present? && deltabadger_token.present?)
   end
 
-  # Docker-internal network-alias launchpad's hosted deploy passes as MARKET_DATA_URL (see
-  # deltabadger-launchpad's config/deploy.yml) — fast for server-to-server calls but never
-  # browser-reachable. data-api's own public host (Kamal-proxied, Cloudflare-proxied) serves the
-  # same instance's static assets (e.g. /logos/*) directly to browsers. Serving those images is the
-  # ONLY thing that host does for us — every API call goes over the Docker network — which is why
-  # fronting it with Cloudflare is right rather than a misconfiguration. Any other configured
-  # MARKET_DATA_URL (self-hosted/BYO market data providers) is already public and used as-is.
+  # MARKET_DATA_URL may be a Docker network alias, which is reachable from this process but not
+  # from a browser. Asset URLs handed to the browser (e.g. /logos/*) are rewritten to the public
+  # host instead. Any other configured URL is already public and used as-is.
   DELTABADGER_DOCKER_HOST = 'data-api'
   DELTABADGER_PUBLIC_URL = 'https://data.deltabadger.com'
 

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -9,11 +9,10 @@
 # behind by this task, and the resulting tagged commit can ship broken
 # code that references files which don't exist in the image.
 #
-# Past incident (v2.11.0): a model file added `include Bot::Startable`
+# This has happened (v2.11.0): a model file added `include Bot::Startable`
 # but the new `app/models/bot/startable.rb` was untracked when the
-# release commit was made. The Docker image built fine but crashed on
-# boot with `uninitialized constant Bot::Startable`, taking out every
-# container the launchpad's update rolled to that version.
+# release commit was made. The Docker image built fine and then crashed on
+# boot with `uninitialized constant Bot::Startable`.
 
 RELEASE_VERSION_FILES = {
   'src-tauri/Cargo.toml' => /^(version = ")[\d.]+(")/,

--- a/test/helpers/bot_helper_test.rb
+++ b/test/helpers/bot_helper_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BotHelperTest < ActionView::TestCase
   test 'whitelist ip comes from the claimed exchange proxy' do
-    AppConfig.set('proxy_binance', 'http://user:secret@claimed-proxy.test:8101')
+    AppConfig.set('proxy_binance', 'http://user:secret@claimed-proxy.test:9000')
 
     assert_equal 'claimed-proxy.test', whitelist_ip_for('binance')
   end

--- a/test/models/bot/exchange_user_placement_test.rb
+++ b/test/models/bot/exchange_user_placement_test.rb
@@ -84,8 +84,8 @@ class Bot::ExchangeUserPlacementTest < ActiveSupport::TestCase
   # --- failures that provably happened BEFORE the request was sent stay retryable ------------
   # Ambiguity is the whole justification for refusing the retry. A connection that was never
   # established carries no ambiguity: nothing reached the exchange, so retrying cannot double-buy.
-  # Converting those too would cost a bot a full interval — up to a month — every time the AWS
-  # exchange proxy is down, which is a documented recurring outage (Errno::ECONNREFUSED on :8100).
+  # Converting those too would cost a bot a full interval — up to a month — every time a
+  # configured exchange proxy refuses the connection.
 
   test 'a connect timeout during placement stays retryable' do
     @bot.exchange.stubs(:market_buy).raises(
@@ -100,7 +100,7 @@ class Bot::ExchangeUserPlacementTest < ActiveSupport::TestCase
 
   test 'a refused connection during placement stays retryable' do
     @bot.exchange.stubs(:market_buy).raises(
-      Client::TransientNetworkError.new('Faraday::ConnectionFailed: connection refused: 18.132.181.159:8100',
+      Client::TransientNetworkError.new('Faraday::ConnectionFailed: connection refused: 203.0.113.10:9100',
                                         original_class: 'Errno::ECONNREFUSED')
     )
 
@@ -242,7 +242,7 @@ class Bot::ExchangeUserPlacementTest < ActiveSupport::TestCase
           raise Errno::ECONNREFUSED, 'connection refused'
         rescue StandardError
           # net_http_persistent's wrapper, which Faraday then wraps again.
-          raise Faraday::ConnectionFailed, RuntimeError.new('connection refused: 1.2.3.4:8100')
+          raise Faraday::ConnectionFailed, RuntimeError.new('connection refused: 203.0.113.11:9100')
         end
       end
     end.new
@@ -254,7 +254,7 @@ class Bot::ExchangeUserPlacementTest < ActiveSupport::TestCase
 
   test 'a bare adapter connection refusal during placement stays retryable' do
     @bot.exchange.stubs(:market_buy).raises(
-      Client::TransientNetworkError.new('Faraday::ConnectionFailed: connection refused: 18.132.181.159:8100',
+      Client::TransientNetworkError.new('Faraday::ConnectionFailed: connection refused: 203.0.113.10:9100',
                                         original_class: 'Net::HTTP::Persistent::Error')
     )
 

--- a/test/models/exchange_fetch_withdrawal_fees_test.rb
+++ b/test/models/exchange_fetch_withdrawal_fees_test.rb
@@ -66,8 +66,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
     exchange, asset, ea = build_exchange(:binance_exchange)
     FeeApiKey.create!(exchange: exchange, key: 'fee_key', secret: 'fee_secret')
 
-    with_env('PROXY_BINANCE', 'http://uk-proxy.test:8100') do
-      stub_fee_client('binance', 'http://uk-proxy.test:8100', :get_all_coins_information,
+    with_env('PROXY_BINANCE', 'http://proxy.test:9100') do
+      stub_fee_client('binance', 'http://proxy.test:9100', :get_all_coins_information,
                       Result::Success.new(binance_style_payload(asset.symbol)))
 
       result = exchange.fetch_withdrawal_fees!
@@ -87,8 +87,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
     FeeApiKey.create!(exchange: exchange, key: 'fee_key', secret: 'fee_secret')
     failure = Result::Failure.new('boom')
 
-    with_env('PROXY_BINANCE', 'http://uk-proxy.test:8100') do
-      stub_fee_client('binance', 'http://uk-proxy.test:8100', :get_all_coins_information, failure)
+    with_env('PROXY_BINANCE', 'http://proxy.test:9100') do
+      stub_fee_client('binance', 'http://proxy.test:9100', :get_all_coins_information, failure)
 
       result = exchange.fetch_withdrawal_fees!
 
@@ -105,8 +105,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
     FeeApiKey.create!(exchange: exchange, key: 'fee_key', secret: 'fee_secret')
     ea.update!(withdrawal_chains: [{ 'name' => 'OLD', 'fee' => '1', 'is_default' => true }])
 
-    with_env('PROXY_BINANCE_US', 'http://uk-proxy.test:8100') do
-      stub_fee_client('binance_us', 'http://uk-proxy.test:8100', :get_all_coins_information,
+    with_env('PROXY_BINANCE_US', 'http://proxy.test:9100') do
+      stub_fee_client('binance_us', 'http://proxy.test:9100', :get_all_coins_information,
                       Result::Success.new(binance_style_payload(asset.symbol)))
 
       result = exchange.fetch_withdrawal_fees!
@@ -126,8 +126,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
     FeeApiKey.create!(exchange: exchange, key: 'fee_key', secret: 'fee_secret')
     payload = { 'data' => binance_style_payload(asset.symbol) }
 
-    with_env('PROXY_BINGX', 'http://uk-proxy.test:8100') do
-      stub_fee_client('bingx', 'http://uk-proxy.test:8100', :get_all_coins_info,
+    with_env('PROXY_BINGX', 'http://proxy.test:9100') do
+      stub_fee_client('bingx', 'http://proxy.test:9100', :get_all_coins_info,
                       Result::Success.new(payload))
 
       result = exchange.fetch_withdrawal_fees!
@@ -145,8 +145,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
     exchange, asset, ea = build_exchange(:bitrue_exchange)
     FeeApiKey.create!(exchange: exchange, key: 'fee_key', secret: 'fee_secret')
 
-    with_env('PROXY_BITRUE', 'http://uk-proxy.test:8100') do
-      stub_fee_client('bitrue', 'http://uk-proxy.test:8100', :get_all_coins_information,
+    with_env('PROXY_BITRUE', 'http://proxy.test:9100') do
+      stub_fee_client('bitrue', 'http://proxy.test:9100', :get_all_coins_information,
                       Result::Success.new(binance_style_payload(asset.symbol)))
 
       result = exchange.fetch_withdrawal_fees!
@@ -177,8 +177,8 @@ class ExchangeFetchWithdrawalFeesTest < ActiveSupport::TestCase
       }
     }
 
-    with_env('PROXY_BYBIT', 'http://uk-proxy.test:8100') do
-      stub_fee_client('bybit', 'http://uk-proxy.test:8100', :get_coin_query_info,
+    with_env('PROXY_BYBIT', 'http://proxy.test:9100') do
+      stub_fee_client('bybit', 'http://proxy.test:9100', :get_coin_query_info,
                       Result::Success.new(payload))
 
       result = exchange.fetch_withdrawal_fees!

--- a/test/models/exchange_proxy_test.rb
+++ b/test/models/exchange_proxy_test.rb
@@ -10,18 +10,18 @@ class ExchangeProxyTest < ActiveSupport::TestCase
   end
 
   test 'AppConfig proxy wins over ENV' do
-    AppConfig.set('proxy_binance', 'http://claimed-proxy.test:8101')
+    AppConfig.set('proxy_binance', 'http://claimed-proxy.test:9000')
 
-    with_env('PROXY_BINANCE', 'http://fleet-proxy.test:8100') do
-      assert_equal 'http://claimed-proxy.test:8101', ExchangeProxy.for('binance')
+    with_env('PROXY_BINANCE', 'http://env-proxy.test:9100') do
+      assert_equal 'http://claimed-proxy.test:9000', ExchangeProxy.for('binance')
     end
   end
 
   test 'blank AppConfig proxy falls through to ENV' do
     AppConfig.set('proxy_binance', '')
 
-    with_env('PROXY_BINANCE', 'http://fleet-proxy.test:8100') do
-      assert_equal 'http://fleet-proxy.test:8100', ExchangeProxy.for(:binance)
+    with_env('PROXY_BINANCE', 'http://env-proxy.test:9100') do
+      assert_equal 'http://env-proxy.test:9100', ExchangeProxy.for(:binance)
     end
   end
 
@@ -43,16 +43,16 @@ class ExchangeProxyTest < ActiveSupport::TestCase
     env_client = mock('env_client')
     claimed_client = mock('claimed_client')
 
-    with_env('PROXY_BINANCE', 'http://fleet-proxy.test:8100') do
+    with_env('PROXY_BINANCE', 'http://env-proxy.test:9100') do
       Honeymaker.expects(:client)
-                .with('binance', api_key: nil, api_secret: nil, proxy: 'http://fleet-proxy.test:8100')
+                .with('binance', api_key: nil, api_secret: nil, proxy: 'http://env-proxy.test:9100')
                 .returns(env_client)
       assert_same env_client, build(:binance_exchange).send(:client)
 
-      AppConfig.set('proxy_binance', 'http://claimed-proxy.test:8101')
+      AppConfig.set('proxy_binance', 'http://claimed-proxy.test:9000')
 
       Honeymaker.expects(:client)
-                .with('binance', api_key: nil, api_secret: nil, proxy: 'http://claimed-proxy.test:8101')
+                .with('binance', api_key: nil, api_secret: nil, proxy: 'http://claimed-proxy.test:9000')
                 .returns(claimed_client)
       assert_same claimed_client, build(:binance_exchange).send(:client)
     end

--- a/test/models/exchange_transient_retry_test.rb
+++ b/test/models/exchange_transient_retry_test.rb
@@ -86,28 +86,28 @@ class ExchangeTransientRetryTest < ActiveSupport::TestCase
   # proxy then failed loudly (red execution_failed + "your bot failed" email) instead of taking
   # the gray, self-healing transient path.
   test 'transient_error? matches a dead HTTP proxy (bare connection refused)' do
-    assert @exchange.transient_error?(['connection refused: 18.132.181.159:8100'])
+    assert @exchange.transient_error?(['connection refused: 203.0.113.10:9100'])
     assert @exchange.transient_error?(['Errno::ECONNREFUSED: Connection refused - connect(2)'])
     assert @exchange.transient_error?(
-      ['Failed to open TCP connection to 18.132.181.159:8100 (Connection refused - connect(2))']
+      ['Failed to open TCP connection to 203.0.113.10:9100 (Connection refused - connect(2))']
     )
   end
 
   test 'transient_error? matches a dead proxy for an exchange with its own :transient set' do
     kraken = create(:kraken_exchange)
-    assert kraken.transient_error?(['connection refused: 18.132.181.159:8100'])
+    assert kraken.transient_error?(['connection refused: 203.0.113.10:9100'])
   end
 
   # The order-fetch job wraps the whole failure list in its own sentence; the predicate must still
   # match on substring, because that is exactly the string the job hands it.
   test 'transient_error? matches connection refused inside a wrapped error list' do
-    assert @exchange.transient_error?(['Failed to fetch orders OMFR74-QGU2N-FCQUKL. Result: ["connection refused: 18.132.181.159:8100"]'])
+    assert @exchange.transient_error?(['Failed to fetch orders OMFR74-QGU2N-FCQUKL. Result: ["connection refused: 203.0.113.10:9100"]'])
   end
 
   # Double-order safety: a refused TCP connect never reached the matching engine, but placement
   # stays keyed to PLACEMENT_SAFE_TRANSIENT_ERRORS. Widening the READ patterns must not leak here.
   test 'placement_transient_error? NEVER matches a dead proxy (double-order safety)' do
-    refute @exchange.placement_transient_error?(['connection refused: 18.132.181.159:8100'])
+    refute @exchange.placement_transient_error?(['connection refused: 203.0.113.10:9100'])
     refute @exchange.placement_transient_error?(['Errno::ECONNREFUSED: Connection refused - connect(2)'])
   end
 

--- a/test/models/exchanges/hyperliquid_test.rb
+++ b/test/models/exchanges/hyperliquid_test.rb
@@ -648,14 +648,14 @@ class Exchanges::HyperliquidTest < ActiveSupport::TestCase
 
   test 'get_ledger builds its client with the exchange proxy' do
     api_key = create(:api_key, exchange: @exchange, raw_key: VALID_WALLET, raw_secret: VALID_AGENT_KEY)
-    AppConfig.set('proxy_hyperliquid', 'http://claimed-proxy.test:8101')
+    AppConfig.set('proxy_hyperliquid', 'http://claimed-proxy.test:9000')
     hm_client = mock('honeymaker_client')
     hm_client.expects(:user_fills).returns(Result::Success.new([]))
     Honeymaker.expects(:client).with(
       'hyperliquid',
       api_key: api_key.key,
       api_secret: api_key.secret,
-      proxy: 'http://claimed-proxy.test:8101'
+      proxy: 'http://claimed-proxy.test:9000'
     ).returns(hm_client)
 
     result = @exchange.get_ledger(api_key: api_key)

--- a/test/services/api_key_validator_test.rb
+++ b/test/services/api_key_validator_test.rb
@@ -79,14 +79,14 @@ class ApiKeyValidatorTest < ActiveSupport::TestCase
   end
 
   test 'uses the exchange proxy when validating an api key' do
-    AppConfig.set('proxy_binance', 'http://claimed-proxy.test:8101')
+    AppConfig.set('proxy_binance', 'http://claimed-proxy.test:9000')
     mock_client = mock('honeymaker_client')
     mock_client.expects(:validate).with(:trading).returns(Honeymaker::Result::Success.new(true))
     Honeymaker.expects(:client).with(
       'binance',
       api_key: @api_key.key,
       api_secret: @api_key.secret,
-      proxy: 'http://claimed-proxy.test:8101'
+      proxy: 'http://claimed-proxy.test:9000'
     ).returns(mock_client)
 
     result = ApiKeyValidator.call(@api_key.id)


### PR DESCRIPTION
Several comments in the proxy and market-data paths explained how a particular deployment behaves — which process gets which environment variable, and what that implies for installs I run myself — rather than what the method decides. The decision is the useful part, and the only part that stays true.

The proxy tests carried real addresses as fixture data. They were only ever placeholders, so they now use the address range reserved for documentation (RFC 5737) and ports that correspond to nothing. A fixture naming a real machine invites a copy-paste, and quietly becomes wrong the day that machine moves.

No behaviour changes. 3559 tests green.