### PR TITLE
Warm metrics caches only while the app is in use

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :redirect_to_setup_if_needed
   before_action :set_no_cache, if: :user_signed_in?
   around_action :switch_locale
+  # after_action, so signing in counts as activity straight away.
+  after_action :mark_web_activity, if: :user_signed_in?
 
   helper_method :single_bot_mode?
 
@@ -32,6 +34,14 @@ class ApplicationController < ActionController::Base
 
   def set_no_cache
     response.headers['Cache-Control'] = 'no-store'
+  end
+
+  # Lets the recurring metrics warm-up follow real use instead of running around the clock.
+  # Signed-in only: the sign-in page is reachable by anyone, and a crawler hitting it must
+  # not hold the window open forever. Liveness probes never reach here — they deliberately
+  # bypass ApplicationController.
+  def mark_web_activity
+    Bot::WarmMetricsCachesJob.mark_activity!
   end
 
   def user_signing_out?

--- a/app/jobs/bot/warm_metrics_caches_job.rb
+++ b/app/jobs/bot/warm_metrics_caches_job.rb
@@ -10,10 +10,26 @@ class Bot::WarmMetricsCachesJob < ApplicationJob
     Bots::Signal
   ].freeze
 
+  # Warming is a page-load optimisation, so it follows actual use: every signed-in request
+  # opens this window, and outside it the job does nothing. Ungated it is a live price call
+  # per exchange every five minutes, around the clock, to fill a cache no one will read.
+  # Closing the window breaks nothing — a cold metrics cache renders a placeholder that the
+  # page fills live on connect, exactly as the first visit after an idle stretch does.
+  ACTIVITY_KEY = 'recent_web_activity'.freeze
+  ACTIVITY_WINDOW = 30.minutes
+
+  # Called from every signed-in request. A plain cache write, so it also self-disables where
+  # caching is off — there is nothing to warm there either.
+  def self.mark_activity!
+    Rails.cache.write(ACTIVITY_KEY, true, expires_in: ACTIVITY_WINDOW)
+  end
+
   # Keeps the current-price caches hot so the /bots index (cache-only global PnL) and the
   # per-bot PnL broadcasts read warm caches instead of doing live exchange roundtrips.
   # Price-only on purpose: the heavier candle path stays lazy (warmed on actual view).
   def perform
+    return unless Rails.cache.exist?(ACTIVITY_KEY)
+
     fiat_currencies = Set.new
 
     measurable_bots_with_history.each do |bot|
@@ -28,10 +44,12 @@ class Bot::WarmMetricsCachesJob < ApplicationJob
 
   private
 
+  # Correlated EXISTS, not `id: Transaction.submitted.select(:bot_id)`: the transactions index
+  # leads with bot_id, so only the correlated form seeks it (and stops at the first match)
+  # instead of scanning every submitted row in the account's whole history.
   def measurable_bots_with_history
-    Bot.not_deleted.where(type: MEASURABLE_TYPES).select do |bot|
-      bot.transactions.submitted.exists?
-    end
+    history = Transaction.submitted.where('transactions.bot_id = bots.id')
+    Bot.not_deleted.where(type: MEASURABLE_TYPES).where(history.arel.exists)
   end
 
   def warm_prices(bot)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -63,6 +63,8 @@ production:
 
   # Keeps current-price + FX caches warm so the /bots index (cache-only global PnL) and
   # per-bot PnL broadcasts read warm caches instead of doing live exchange roundtrips.
+  # The tick is unconditional but the job is not: it warms only inside the activity window
+  # a signed-in request opens, so an unused instance makes no exchange calls at all.
   warm_metrics_caches_job:
     class: Bot::WarmMetricsCachesJob
     schedule: "*/5 * * * *"  # Every 5 minutes, matching the price-cache 5-minute cut
@@ -127,6 +129,8 @@ development:
 
   # Keeps current-price + FX caches warm so the /bots index (cache-only global PnL) and
   # per-bot PnL broadcasts read warm caches instead of doing live exchange roundtrips.
+  # The tick is unconditional but the job is not: it warms only inside the activity window
+  # a signed-in request opens, so an unused instance makes no exchange calls at all.
   warm_metrics_caches_job:
     class: Bot::WarmMetricsCachesJob
     schedule: "*/5 * * * *"  # Every 5 minutes, matching the price-cache 5-minute cut

--- a/test/controllers/bots/show_metrics_loading_test.rb
+++ b/test/controllers/bots/show_metrics_loading_test.rb
@@ -3,8 +3,9 @@
 require 'test_helper'
 
 # When the combined (candles) cache is cold but the prices cache is warm — the common
-# case, since Bot::WarmMetricsCachesJob warms prices every 5 minutes — the balances
-# table must render real values immediately; only the chart shows the loading state.
+# case, since Bot::WarmMetricsCachesJob warms prices every 5 minutes while the app is in
+# use — the balances table must render real values immediately; only the chart shows the
+# loading state.
 class Bots::ShowMetricsLoadingTest < ActionDispatch::IntegrationTest
   setup do
     create(:user, admin: true, setup_completed: true) # satisfies the onboarding gate

--- a/test/controllers/warm_metrics_activity_window_test.rb
+++ b/test/controllers/warm_metrics_activity_window_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Bot::WarmMetricsCachesJob only warms inside an activity window, and requests are what
+# open it — without this the recurring job would never run again.
+class WarmMetricsActivityWindowTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true) # satisfies the onboarding gate
+    @user = create(:user)
+    @store = ActiveSupport::Cache::MemoryStore.new
+    Rails.stubs(:cache).returns(@store)
+  end
+
+  test 'a signed-in request opens the window' do
+    sign_in @user
+
+    get bots_path
+
+    assert_response :success
+    assert Rails.cache.exist?(Bot::WarmMetricsCachesJob::ACTIVITY_KEY)
+  end
+
+  test 'an anonymous request does not open the window' do
+    get new_user_session_path
+
+    assert_response :success
+    assert_not Rails.cache.exist?(Bot::WarmMetricsCachesJob::ACTIVITY_KEY)
+  end
+end

--- a/test/jobs/bot/warm_metrics_caches_job_test.rb
+++ b/test/jobs/bot/warm_metrics_caches_job_test.rb
@@ -8,7 +8,19 @@ require 'test_helper'
 # It refreshes metrics_with_current_prices(force: true) for measurable, non-deleted bots
 # that HAVE submitted transactions (matching global_pnl's inclusion set), and pre-warms
 # the FX rates those bots need. It does NOT warm the heavier candle path.
+#
+# Warming a cache nobody will read is a live exchange call for nothing, so the job only
+# runs inside the activity window a signed-in request opens. The test env is :null_store,
+# where that window can never open, so these tests swap in a real store.
 class Bot::WarmMetricsCachesJobTest < ActiveJob::TestCase
+  setup do
+    @previous_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Bot::WarmMetricsCachesJob.mark_activity!
+  end
+
+  teardown { Rails.cache = @previous_cache }
+
   test 'warms current-price metrics only for measurable bots with submitted transactions' do
     user = create(:user)
     exchange = create(:binance_exchange)
@@ -51,5 +63,30 @@ class Bot::WarmMetricsCachesJobTest < ActiveJob::TestCase
     Utilities::Currency.expects(:exchange_rate).with(from: 'EUR', to: 'USD').at_least_once
 
     Bot::WarmMetricsCachesJob.perform_now
+  end
+
+  test 'does nothing when nobody has used the app recently' do
+    user = create(:user)
+    bot = create(:dca_single_asset, user: user)
+    create(:transaction, bot: bot)
+
+    Rails.cache.clear # no signed-in request has opened the window
+
+    Bots::DcaSingleAsset.any_instance.expects(:metrics_with_current_prices).never
+    Utilities::Currency.expects(:exchange_rate).never
+
+    Bot::WarmMetricsCachesJob.perform_now
+  end
+
+  test 'the activity window a request opens expires' do
+    user = create(:user)
+    bot = create(:dca_single_asset, user: user)
+    create(:transaction, bot: bot)
+
+    Bots::DcaSingleAsset.any_instance.expects(:metrics_with_current_prices).never
+
+    travel Bot::WarmMetricsCachesJob::ACTIVITY_WINDOW + 1.minute do
+      Bot::WarmMetricsCachesJob.perform_now
+    end
   end
 end


### PR DESCRIPTION
## Problem

`Bot::WarmMetricsCachesJob` refreshed `metrics_with_current_prices(force: true)` for every
measurable bot with trade history, every five minutes, around the clock. `force: true`
bypasses the metrics cache by design, so each tick is a real price call per connected
exchange — and every one of those pulls the exchange's whole ticker list to read a handful
of prices.

None of it is conditional on anyone being there to see the result. An instance nobody has
opened in months warms with exactly the same diligence as one being actively used.

## What warming is actually for

It is a page-load optimisation, nothing more. A cold metrics cache is not a broken page:
`/bots` renders the PnL placeholders, `broadcast--on-connect` fires
`global_pnl_update` / `pnl_update`, and the values fill in live. That is already what the
first visit after an idle stretch does, and what every visit did before the job existed.

Nothing else reads these caches — an open dashboard has no polling that re-reads them, so
warming only ever pays off for a page load that happens while the cache is still warm.

## Change

The job now runs only inside a 30-minute window that any signed-in request opens, and
returns immediately outside it.

- `ApplicationController` marks activity in an `after_action`, so signing in counts
  straight away.
- Signed-in only on purpose: the sign-in page is reachable by anyone, and a crawler hitting
  it must not hold the window open indefinitely.
- The marker is a plain cache write, so the job self-disables wherever caching is off —
  there is nothing to warm there either.
- Liveness probes never reach it; they deliberately bypass `ApplicationController`.

The five-minute cadence is unchanged. It is tied to the price cache's five-minute cut, so
stretching it would leave an active user's dashboard cold most of the time — the window is
the right lever, not the interval.

Also swaps the per-bot `exists?` probe for one correlated `EXISTS`, which seeks
`index_transactions_on_bot_id_and_status_and_created_at` instead of issuing a query per bot.

## Not changed, and why

Deduplicating the price fetch per market was the obvious other candidate, but on the crypto
exchanges it is already deduplicated: `get_tickers_prices` caches per exchange for one
minute and the warm path does not force it, so every bot on a given exchange shares one
fetch per tick. The exception is Alpaca, which keys its price cache by symbol set and so
does fan out per bot — worth its own change, not folded in here.

## Tests

- Job does nothing when no request has opened the window, and after the window expires.
- A signed-in request opens the window; an anonymous one does not.
- Existing coverage (inclusion set, price-only, FX pre-warm) kept, adapted to a real cache
  store since the test env is `:null_store`.

3563 runs, 0 failures. Rubocop clean.
