### PR TITLE
Stop the desktop release from failing every ordinary tag

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -6,27 +6,56 @@ on:
       - 'v*'
 
 jobs:
-  validate-updater-key:
+  # Desktop releases are not configured yet, and every version tag also builds the Docker image —
+  # so a hard failure here paints every ordinary release red for a leg that has never once run.
+  # This reports what is missing and skips instead. It turns itself on: the day the keypair and the
+  # signing secrets exist, the build runs, with no workflow edit to remember.
+  preflight:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Verify updater public key
+      - name: Check the desktop release is configured
+        id: check
         shell: bash
+        env:
+          # Read as env rather than inline, so a missing secret is an empty string here instead of
+          # an empty expression in the middle of a shell script.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
+          missing=""
           pubkey=$(jq -r '.plugins.updater.pubkey // empty' src-tauri/tauri.conf.json)
           if [ -z "$pubkey" ] || [ "$pubkey" = 'REPLACE_WITH_TAURI_UPDATER_PUBLIC_KEY' ]; then
-            echo '::error file=src-tauri/tauri.conf.json::Updater public key is not configured. Run "tauri signer generate" and replace the updater pubkey with the generated public key.'
-            exit 1
+            missing="$missing updater-pubkey(tauri.conf.json)"
+          fi
+          # Signing is mandatory, not optional: createUpdaterArtifacts is v1Compatible, and Tauri
+          # reads the Apple variables with var_os — an empty secret is still *set*, so it takes the
+          # certificate-import branch and fails on a zero-byte .p12 rather than skipping signing.
+          for name in TAURI_SIGNING_PRIVATE_KEY APPLE_CERTIFICATE APPLE_ID APPLE_TEAM_ID; do
+            [ -n "${!name}" ] || missing="$missing $name"
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::notice::Desktop release skipped — not configured yet. Missing:$missing"
+            echo "::notice::Set up with 'tauri signer generate', put the public key in tauri.conf.json and the private key plus the Apple secrets in repository secrets."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:
-    needs: validate-updater-key
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -56,18 +85,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # This repository has no package-lock.json — only bun.lock, the same one the Dockerfile
+      # installs from. `npm ci` requires a lockfile it does not have and would fail on every leg,
+      # as would `cache: npm`. Bun comes first because the install now depends on it.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
       - name: Install frontend dependencies
         shell: bash
-        run: npm ci
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        run: bun install --frozen-lockfile
 
       - name: Install Rust target
         uses: dtolnay/rust-toolchain@stable

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,8 +25,9 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-updater = "2"
-cocoa = "0.26"
-objc = "0.2"
+# cocoa and objc were here unconditionally and referenced nowhere in src/, which pulled
+# core-graphics onto the Windows target for no reason. Removed rather than cfg-gated: nothing
+# uses them.
 tokio = { version = "1", features = ["process", "time", "sync"] }
 reqwest = { version = "0.12", features = ["blocking"] }
 port_check = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,12 @@ use tauri::{
     image::Image,
     menu::{MenuBuilder, MenuItemBuilder},
     tray::TrayIconBuilder,
-    ActivationPolicy, Manager, WebviewUrl, WebviewWindowBuilder,
+    Manager, WebviewUrl, WebviewWindowBuilder,
 };
+// Tauri re-exports this only for macOS, and all three call sites are already cfg-gated — an
+// unconditional import is what breaks the Windows and Linux builds.
+#[cfg(target_os = "macos")]
+use tauri::ActivationPolicy;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_updater::UpdaterExt;
 
@@ -620,20 +624,27 @@ pub fn run() {
 
                         // Create the main window pointing to Rails
                         let url = format!("http://{}:{}", RAILS_HOST, port);
-                        WebviewWindowBuilder::new(
+                        let window_builder = WebviewWindowBuilder::new(
                             app,
                             "main",
                             WebviewUrl::External(url.parse().unwrap()),
                         )
                         .title("Deltabadger")
-                        .title_bar_style(tauri::TitleBarStyle::Overlay)
-                        .hidden_title(true)
                         .inner_size(1280.0, 800.0)
                         .min_inner_size(320.0, 600.0)
                         .center()
                         .devtools(true)
-                        .initialization_script("window.__TAURI_INTERNALS__ = true; window.__IS_TAURI__ = true;")
-                        .build()?;
+                        .initialization_script("window.__TAURI_INTERNALS__ = true; window.__IS_TAURI__ = true;");
+
+                        // The overlay title bar is the macOS look; both builder methods exist only
+                        // on macOS in Tauri 2, so calling them unconditionally does not compile
+                        // anywhere else. Other platforms get their native title bar.
+                        #[cfg(target_os = "macos")]
+                        let window_builder = window_builder
+                            .title_bar_style(tauri::TitleBarStyle::Overlay)
+                            .hidden_title(true);
+
+                        window_builder.build()?;
 
                         // Set up system tray
                         let show_item = MenuItemBuilder::with_id("show", "Show Deltabadger").build(app)?;

--- a/test/config/desktop_configuration_test.rb
+++ b/test/config/desktop_configuration_test.rb
@@ -7,14 +7,41 @@ class DesktopConfigurationTest < ActiveSupport::TestCase
     assert_equal './scripts/bundle_skeleton.sh', config.dig('build', 'beforeBuildCommand')
   end
 
-  test 'desktop releases validate the updater public key before starting platform builds' do
+  # A build must never start without a real updater key and the secrets that sign with it — an
+  # unsigned or unverifiable artifact is worse than no artifact. The gate skips rather than fails,
+  # because the same tag also builds the Docker image and an unconfigured desktop pipeline must not
+  # redden an ordinary release, so what needs pinning is that the build cannot run without it.
+  test 'desktop releases cannot build without a verified updater key and signing secrets' do
     workflow = Rails.root.join('.github/workflows/desktop-release.yml').read
-    validation_job = workflow[/^  validate-updater-key:\n(?<body>.*?)(?=^  [a-z][a-z-]*:)/m, :body]
+    preflight = workflow[/^  preflight:\n(?<body>.*?)(?=^  [a-z][a-z-]*:)/m, :body]
 
-    assert validation_job, 'desktop release workflow is missing the updater-key validation job'
-    assert_includes validation_job, 'REPLACE_WITH_TAURI_UPDATER_PUBLIC_KEY'
-    assert_includes validation_job, 'tauri signer generate'
-    assert_includes validation_job, 'exit 1'
-    assert_match(/^  build:\n    needs: validate-updater-key$/, workflow)
+    assert preflight, 'desktop release workflow is missing the preflight job'
+    assert_includes preflight, 'REPLACE_WITH_TAURI_UPDATER_PUBLIC_KEY'
+    assert_includes preflight, 'tauri signer generate'
+
+    # Signing is mandatory (createUpdaterArtifacts is v1Compatible) and Tauri reads these with
+    # var_os, so an unset secret is an empty string and takes the import path rather than skipping.
+    %w[TAURI_SIGNING_PRIVATE_KEY APPLE_CERTIFICATE APPLE_ID APPLE_TEAM_ID].each do |secret|
+      assert_includes preflight, secret, "preflight does not require #{secret}"
+    end
+
+    assert_match(/^  build:\n    needs: preflight\n    if: needs\.preflight\.outputs\.ready == 'true'$/,
+                 workflow)
+  end
+
+  # The macOS-only calls broke the other platforms once already, in two places at once.
+  test 'platform-specific window APIs stay behind their platform gate' do
+    source = Rails.root.join('src-tauri/src/lib.rs').read
+    macos_only = %w[ActivationPolicy title_bar_style hidden_title]
+
+    macos_only.each do |symbol|
+      source.each_line.with_index(1) do |line, number|
+        next unless line.include?(symbol)
+
+        preceding = source.lines[[number - 6, 0].max...(number - 1)].join
+        assert_includes preceding, 'cfg(target_os = "macos")',
+                        "#{symbol} on line #{number} is not behind a macOS gate"
+      end
+    end
   end
 end


### PR DESCRIPTION
Since v2.27.0 every version tag produces one green Docker run and one red desktop run. The Docker image publishes fine; only the desktop leg fails, in about eight seconds, at the updater-key gate. That gate is doing its job — it exists to stop a build that would ship an unverifiable updater — but the pipeline it guards has never executed once, so the effect is a red mark on every ordinary release.

It now reports what is missing and skips, and it turns itself on: the day the keypair and signing secrets exist, the build runs, with no workflow edit to remember.

The gate covers the Apple secrets too, not only the updater key. Signing is mandatory here (`createUpdaterArtifacts: "v1Compatible"`), and Tauri reads those variables with `var_os` — an unset repository secret arrives as an **empty string rather than as absent**, so the action takes the certificate-import branch and runs `security import` on a zero-byte `.p12`. That fails hard rather than degrading, which is worth gating on rather than discovering after a 30-minute build.

## Three things underneath that could not have built either

- **`npm ci` and `cache: npm`** — this repository has no `package-lock.json`, only the `bun.lock` the Dockerfile installs from. Both steps fail on every leg, before anything else. Now `bun install --frozen-lockfile`, with Bun set up first since the install depends on it.
- **Windows and Linux could not compile.** `ActivationPolicy` was imported unconditionally while all three of its call sites were already `#[cfg(target_os = "macos")]`. The same bug had a second instance nobody had spotted: the window builder called `.title_bar_style()` and `.hidden_title()` unconditionally, and both exist only on macOS in Tauri 2. Other platforms now get their native title bar.
- **`cocoa` and `objc`** sat in the unconditional dependency list, referenced nowhere in `src-tauri/src`, dragging `core-graphics` onto the MSVC target. Removed rather than gated, since nothing uses them.

## What this does not do

It does not make a desktop build succeed — that still needs `tauri signer generate`, the private key, and the Apple signing and notarization secrets, none of which exist yet. This only stops an unconfigured pipeline from failing releases that have nothing to do with it, and clears the code-level blockers so the first real attempt fails on something informative rather than on `npm ci`.

`cargo check` clean on macOS. The Windows and Linux compiles are argued statically rather than executed — there is no rustup here to add a cross target, so the evidence is that every macOS-only symbol is now behind the same gate as its call sites, and that nothing references the removed crates.

3559 Ruby tests green.