### PR TITLE
Say why one release starts three workflow runs

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -81,6 +81,12 @@ namespace :release do
     system("git add #{files}") || abort('git add failed')
     system("git commit -m 'Bump version to #{version}'") || abort('git commit failed')
     system('git push origin main') || abort('git push failed')
+    # Fast-forwards nightly onto the release so the :nightly image never sits BEHIND stable —
+    # anyone running image_tag: "nightly" would otherwise be on older code than a stable user.
+    # The cost is that one release starts three workflow runs: this push builds the nightly image,
+    # the tag below builds the same commit again as :latest, and the desktop release also watches
+    # v* tags. The two Docker builds are the same commit under different tags, about three minutes
+    # each, and the registry dedupes the layers — cheaper than special-casing either workflow.
     system('git push origin main:nightly') || abort('git push to nightly failed')
     system("git tag -s v#{version} -m 'v#{version}'") || abort('git tag failed')
     system("git push origin v#{version}") || abort('git tag push failed')


### PR DESCRIPTION
A version bump produces three runs, which reads like something is misconfigured:

```
git push origin main            → nothing
git push origin main:nightly    → Build and Push Nightly Docker Image
git push origin v2.27.2         → Build and Push Docker Image  +  Desktop Release
```

`main` and `nightly` are the same commit at that moment, so two of those build identical content under different tags — about three minutes each, with the registry deduping the layers.

Documenting rather than changing it. The nightly push has been there since 2026-04-04 and earns its place: without it the `:nightly` image drifts behind stable, and anyone running `image_tag: "nightly"` ends up on older code than a stable user. Every alternative costs more than it saves — either the tag build has to also push `:nightly`, or the nightly workflow needs to detect that its commit is already tagged.

Comment only, no behaviour change.