### PR TITLE
Stop reporting a rejected API key as something else

### DIFF
--- a/app/jobs/bot/repair_orphaned_bots_job.rb
+++ b/app/jobs/bot/repair_orphaned_bots_job.rb
@@ -38,9 +38,14 @@ class Bot::RepairOrphanedBotsJob < ApplicationJob
     end
   end
 
+  # `pending_action_job?`, not `next_action_job_at.nil?`: only a SCHEDULED execution carries a
+  # scheduled_at, so a bot whose ActionJob is running right now (claimed), due now (ready), or
+  # queued behind the per-exchange concurrency semaphore (blocked) read as orphaned — and got a
+  # SECOND job for the same tick, since cancel_scheduled_action_jobs cannot cancel a claimed one.
+  # The duplicate then died on ActionJob's "already has an action job scheduled" guard.
   def find_orphaned_bots
     Bot.where(status: %i[scheduled retrying]).select do |bot|
-      bot.exchange.present? && bot.next_action_job_at.nil?
+      bot.exchange.present? && !bot.pending_action_job?
     end
   end
 

--- a/app/mcp/tools/list_open_orders_tool.rb
+++ b/app/mcp/tools/list_open_orders_tool.rb
@@ -11,7 +11,7 @@ class ListOpenOrdersTool < ApplicationMCPTool
     result = BotApi::Orders::ListOpen.call(user: current_user, exchange_name: exchange_name)
     return render(text: result.error_message) unless result.success?
 
-    if result.data[:count].zero?
+    if result.data[:count].zero? && result.data[:unavailable].blank?
       render text: 'No open orders found.'
       return
     end
@@ -25,7 +25,15 @@ class ListOpenOrdersTool < ApplicationMCPTool
     lines = data[:orders].map do |order|
       order[:source] == 'db' ? db_line(order) : exchange_line(order)
     end
-    "Open orders (#{data[:count]}):\n#{lines.join("\n")}"
+    header = data[:count].zero? ? 'No open orders found on the exchanges that answered.' : "Open orders (#{data[:count]}):"
+    ([header] + lines + unavailable_lines(data)).join("\n")
+  end
+
+  # Never silently. An exchange we could not ask is not an exchange with nothing on it.
+  def unavailable_lines(data)
+    Array(data[:unavailable]).map do |entry|
+      "! #{entry[:exchange]}: could not be checked (#{entry[:error]}) — open orders there are not listed"
+    end
   end
 
   def db_line(order)

--- a/app/models/automation/schedulable.rb
+++ b/app/models/automation/schedulable.rb
@@ -45,6 +45,16 @@ module Automation::Schedulable
     )
   end
 
+  # Does a live ActionJob exist for this record in ANY active Solid Queue state?
+  #
+  # Broader than `next_action_job_at`, which only ever sees a SCHEDULED execution: a job that is due
+  # now (ready), one a worker has already claimed, and one blocked on the per-exchange concurrency
+  # semaphore all report nil there while being very much alive. Bot::RepairOrphanedBotsJob asks this
+  # instead, so it stops "repairing" bots that are mid-tick and enqueueing a second job for the tick.
+  def pending_action_job?
+    active_job?(job_class: action_job_config[:class], record: self)
+  end
+
   def next_interval_checkpoint_at
     return Time.current if effective_interval_duration.zero?
 
@@ -149,8 +159,8 @@ module Automation::Schedulable
 
   # True if a job of job_class for `record` exists in ANY active Solid Queue execution state
   # (Scheduled / Ready / Claimed / Blocked). Excludes FailedExecution by design — a dead-lettered
-  # job is NOT a live chain. Used by limit-check recovery to avoid double-enqueuing.
-  def active_limit_check_job?(job_class:, record:)
+  # job is NOT a live chain. Used by limit-check and orphan recovery to avoid double-enqueuing.
+  def active_job?(job_class:, record:)
     return false unless defined?(SolidQueue)
 
     global_id = record.to_global_id.to_s

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -40,6 +40,16 @@ class Bot < ApplicationRecord
     []
   end
 
+  # Mark a metrics payload that had to fall back to the last executed transaction price because the
+  # live read failed. Every bot type does that fallback — it is better than a blank page — but the
+  # view then renders a carried-over number as "Portfolio value" with nothing to distinguish it from
+  # a live one, and with a rejected key it simply stops moving for weeks. The flag drives the
+  # already-translated `bot.details.stats.exchange_unavailable_html` notice.
+  def stale(metrics_data)
+    metrics_data[:prices_stale] = true
+    metrics_data
+  end
+
   def last_transaction
     transactions.where(transaction_type: 'REGULAR').order(created_at: :desc).limit(1).last
   end

--- a/app/models/bot/indicator_limitable.rb
+++ b/app/models/bot/indicator_limitable.rb
@@ -296,8 +296,7 @@ module Bot::IndicatorLimitable
   end
 
   def indicator_limit_condition_currently_met?
-    result = get_indicator_limit_condition_met?
-    result.success? && result.data
+    limit_condition_met?(get_indicator_limit_condition_met?)
   end
 
   # Side-suffixed so a flip never renders the buy-side reading from a stale cache entry.

--- a/app/models/bot/limit_checkable.rb
+++ b/app/models/bot/limit_checkable.rb
@@ -20,6 +20,18 @@ module Bot::LimitCheckable
                     ->(bot) { Time.now.utc + Utilities::Time.seconds_to_current_candle_close(bot.indicator_limit_in_timeframe_duration) }]
   }.freeze
 
+  # A failed condition read is NOT "the condition is not met". Every gate below used to flatten a
+  # Result::Failure to false, which reads as "the market has not reached your price" — so a bot whose
+  # key the venue rejects parks itself, tells the user it is waiting for a price, polls forever and
+  # never trades again, with no error and no email. A credential rejection is the same answer on
+  # every tick, so it must escape; every other failure keeps the old conservative behaviour (wait —
+  # never trade on a read we could not make), which the check jobs already reschedule.
+  def limit_condition_met?(result)
+    exchange.raise_on_invalid_key!(result)
+
+    result.success? && result.data
+  end
+
   # The limit type CURRENTLY pausing this bot, or nil. "Currently" — not "ever": a bot keeps its
   # limit_paused logs forever, so we must distinguish a bot resting on a live limit pause from one
   # that limit-paused in the past but has since run a normal cycle. Signal: the latest limit_paused

--- a/app/models/bot/limit_checkable.rb
+++ b/app/models/bot/limit_checkable.rb
@@ -54,7 +54,7 @@ module Bot::LimitCheckable
     klass = live_limit_check_job_class
     return false unless klass
 
-    active_limit_check_job?(job_class: klass.name, record: self)
+    active_job?(job_class: klass.name, record: self)
   end
 
   # Re-enqueue the live check job at its type-specific next check time. No-op if no paused type.

--- a/app/models/bot/moving_average_limitable.rb
+++ b/app/models/bot/moving_average_limitable.rb
@@ -273,8 +273,7 @@ module Bot::MovingAverageLimitable
   end
 
   def moving_average_limit_condition_currently_met?
-    result = get_moving_average_limit_condition_met?
-    result.success? && result.data
+    limit_condition_met?(get_moving_average_limit_condition_met?)
   end
 
   # Side-suffixed so a flip never renders the buy-side reading from a stale cache entry.

--- a/app/models/bot/price_drop_limitable.rb
+++ b/app/models/bot/price_drop_limitable.rb
@@ -285,8 +285,7 @@ module Bot::PriceDropLimitable
   end
 
   def price_drop_limit_condition_currently_met?
-    result = get_price_drop_limit_condition_met?
-    result.success? && result.data
+    limit_condition_met?(get_price_drop_limit_condition_met?)
   end
 
   # Side-suffixed so a flip never renders the buy-side high as the sell-side low (or vice versa)

--- a/app/models/bot/price_limitable.rb
+++ b/app/models/bot/price_limitable.rb
@@ -261,8 +261,7 @@ module Bot::PriceLimitable
   end
 
   def price_limit_condition_currently_met?
-    result = get_price_limit_condition_met?
-    result.success? && result.data
+    limit_condition_met?(get_price_limit_condition_met?)
   end
 
   # Side-suffixed so a flip never renders the buy-side condition state from a stale cache entry.

--- a/app/models/bot/reversible.rb
+++ b/app/models/bot/reversible.rb
@@ -126,7 +126,7 @@ module Bot::Reversible
   #       stale state — this catches the window where the worker has claimed the job but not
   #       yet flipped status to :executing, which a status-only check would miss;
   #   (b) a claimed Bot::*LimitCheckJob could enqueue an ActionJob that races the fresh one.
-  # Claimed-only (narrower than active_limit_check_job?, which also counts merely-scheduled
+  # Claimed-only (narrower than active_job?, which also counts merely-scheduled
   # jobs and would over-block the common limit-paused case).
   def flip_blocked_by_inflight_job?
     return false unless defined?(SolidQueue)

--- a/app/models/bots/dca_dual_asset/measurable.rb
+++ b/app/models/bots/dca_dual_asset/measurable.rb
@@ -78,11 +78,11 @@ module Bots::DcaDualAsset::Measurable
       return metrics_data if metrics_data[:chart][:labels].empty? || ticker0.nil? || ticker1.nil?
 
       result = exchange.get_tickers_prices(symbols: [ticker0.ticker, ticker1.ticker])
-      return metrics_data if result.failure?
+      return stale(metrics_data) if result.failure?
 
       price0 = result.data[ticker0.ticker]
       price1 = result.data[ticker1.ticker]
-      return metrics_data unless price0.present? && price1.present?
+      return stale(metrics_data) unless price0.present? && price1.present?
 
       metrics_data[:total_base0_amount_value_in_quote] = metrics_data[:total_base0_amount] * price0
       metrics_data[:total_base1_amount_value_in_quote] = metrics_data[:total_base1_amount] * price1

--- a/app/models/bots/dca_index/measurable.rb
+++ b/app/models/bots/dca_index/measurable.rb
@@ -78,7 +78,7 @@ module Bots::DcaIndex::Measurable
       return metrics_data if metrics_data[:chart][:labels].empty?
 
       result = exchange.get_tickers_prices(symbols: tickers.map(&:ticker))
-      return metrics_data if result.failure?
+      return stale(metrics_data) if result.failure?
 
       ticker_prices = result.data
       total_value = 0

--- a/app/models/bots/dca_single_asset/measurable.rb
+++ b/app/models/bots/dca_single_asset/measurable.rb
@@ -84,10 +84,10 @@ module Bots::DcaSingleAsset::Measurable
       return metrics_data if metrics_data[:chart][:labels].empty? || ticker.nil?
 
       result = exchange.get_tickers_prices(symbols: [ticker.ticker])
-      return metrics_data if result.failure?
+      return stale(metrics_data) if result.failure?
 
       price = result.data[ticker.ticker]
-      return metrics_data unless price.present?
+      return stale(metrics_data) unless price.present?
 
       metrics_data[:total_amount_value_in_quote] =
         (metrics_data[:total_realized_proceeds] || 0) + (metrics_data[:total_base_amount] * price)

--- a/app/models/concerns/api_key_failure_handling.rb
+++ b/app/models/concerns/api_key_failure_handling.rb
@@ -23,7 +23,7 @@ module ApiKeyFailureHandling
 
     Rails.logger.warn("[SyncKeyFailure] #{exchange.name} api_key=#{api_key.id}: #{message}")
 
-    reason = failure_reason(exchange, errors, status: exchange.http_status(result))
+    reason = failure_reason(exchange, errors)
     api_key.update!(status: :incorrect) if reason == :invalid
 
     # Both the wrapper copy and humanize_error resolve I18n immediately, so both belong inside
@@ -42,9 +42,11 @@ module ApiKeyFailureHandling
 
   private
 
-  def failure_reason(exchange, errors, status: nil)
+  # The status is deliberately NOT consulted here — only #condemning_invalid_key_error? decides what
+  # may flip a key to :incorrect, and it wants the venue's own words. See Exchange#invalid_key_error?.
+  def failure_reason(exchange, errors)
     return :permission if exchange.permission_error?(errors)
-    return :invalid if exchange.invalid_key_error?(errors, status: status)
+    return :invalid if exchange.condemning_invalid_key_error?(errors)
     return :transient if exchange.transient_error?(errors)
 
     :failed

--- a/app/models/concerns/api_key_failure_handling.rb
+++ b/app/models/concerns/api_key_failure_handling.rb
@@ -23,7 +23,7 @@ module ApiKeyFailureHandling
 
     Rails.logger.warn("[SyncKeyFailure] #{exchange.name} api_key=#{api_key.id}: #{message}")
 
-    reason = failure_reason(exchange, errors)
+    reason = failure_reason(exchange, errors, status: exchange.http_status(result))
     api_key.update!(status: :incorrect) if reason == :invalid
 
     # Both the wrapper copy and humanize_error resolve I18n immediately, so both belong inside
@@ -42,9 +42,9 @@ module ApiKeyFailureHandling
 
   private
 
-  def failure_reason(exchange, errors)
+  def failure_reason(exchange, errors, status: nil)
     return :permission if exchange.permission_error?(errors)
-    return :invalid if exchange.invalid_key_error?(errors)
+    return :invalid if exchange.invalid_key_error?(errors, status: status)
     return :transient if exchange.transient_error?(errors)
 
     :failed

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -3,8 +3,9 @@ class Exchange < ApplicationRecord
   # lookback over daily candles is only a handful of windows) so a misbehaving API or an
   # advance bug can never spin forever.
   MAX_CANDLE_PAGES = 1000
-  # "We do not accept these credentials", in the one status every venue agrees on. See
-  # #invalid_key_error?; Exchanges::Ibkr opts out via #ambiguous_unauthorized?.
+  # "We do not accept these credentials", in the one status every venue agrees on. It SURFACES a
+  # credential failure (#invalid_key_error?) but never condemns a stored key on its own
+  # (#condemning_invalid_key_error?). Exchanges::Ibkr opts out entirely via #ambiguous_unauthorized?.
   UNAUTHORIZED_STATUS = 401
 
   STABLE_TYPES = %w[Exchanges::Binance Exchanges::BinanceUs Exchanges::Coinbase Exchanges::Kraken].freeze
@@ -245,12 +246,19 @@ class Exchange < ApplicationRecord
   # Used by sync jobs to decide whether to flip an API key's status to :incorrect
   # when a live call (get_balances, get_ledger, etc.) fails.
   def invalid_key_error?(errors, status: nil)
-    # HTTP 401 is the one vocabulary every venue shares for "these credentials are not accepted",
-    # and it is what makes this classifiable WITHOUT inventing message substrings. Alpaca and
-    # Coinbase carry no usable string at all, so their revoked keys could never be condemned — the
-    # status closes that for all of them at once. Honeymaker::Client#with_rescue and Clients::Alpaca
-    # both already attach it; venues that answer over HTTP 200 (Kraken's EAPI:Invalid key) still
-    # need the strings below, which is why this is an addition and not a replacement.
+    # HTTP 401 is the one vocabulary every venue shares for "these credentials are not accepted", and
+    # it is the only signal some venues give: Coinbase carries no usable message string at all, so
+    # without it a rejected Coinbase key produces a domain-shaped lie downstream and nothing else.
+    # Honeymaker::Client#with_rescue and Clients::Alpaca both attach it; venues that reject over
+    # HTTP 200 (Kraken's EAPI:Invalid key) still need the strings below, so this is an addition.
+    #
+    # SURFACING ONLY. A bare 401 is deliberately NOT enough to condemn a stored key — see
+    # #condemning_invalid_key_error?. Coinbase signs each request with a two-minute JWT built from
+    # local time, so clock skew rejects a perfectly good key; our own authenticated exchange proxy
+    # answers a wrong password with 401 as well. Saying "the venue rejected our credentials" in a bot
+    # error is reversible and self-correcting when either of those is the real cause. Flipping the
+    # key to :incorrect is not: it drops the key from every :correct-scoped sync until the user
+    # pastes new credentials that were never the problem.
     return true if status == UNAUTHORIZED_STATUS && !ambiguous_unauthorized?
 
     invalid_messages = (known_errors[:invalid_key] || []).map(&:to_s)
@@ -281,6 +289,15 @@ class Exchange < ApplicationRecord
   # or an error we raised ourselves.
   def http_status(result)
     result.data[:status] if result.data.is_a?(Hash)
+  end
+
+  # Enough to CONDEMN the stored key — persistent, and only the user can undo it. Deliberately
+  # narrower than #invalid_key_error?: the venue's own words, never a bare status. Every 401 we
+  # cannot attribute (Coinbase's JWT clock skew, a proxy rejecting its own credential, a WAF) would
+  # otherwise strand a user whose key is fine, and "replace your API key" is advice they cannot act
+  # on. Alpaca's two observed rejection bodies are listed as strings for exactly this reason.
+  def condemning_invalid_key_error?(errors)
+    invalid_key_error?(errors)
   end
 
   # Does a 401 from this venue mean anything OTHER than "your key is no longer valid"? Only where

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -251,6 +251,18 @@ class Exchange < ApplicationRecord
     end
   end
 
+  # Raise on a credential rejection, wherever a failed call would otherwise be flattened into a
+  # benign answer — "no price", "market state unknown". Those flattenings are right for a pair with
+  # no liquidity or a clock blip; for a rejected key they are a lie that hides the one thing the
+  # user has to act on, and they hid it for six weeks. Single phrase, single place: the venue's own
+  # text can be as bare as "HTTP 401", so the exchange is named here. The localized, actionable copy
+  # stays the tracker's sync-key banner, which the same classification drives.
+  def raise_on_invalid_key!(errors)
+    return unless invalid_key_error?(errors)
+
+    raise "#{name} rejected the API key: #{Array(errors).to_sentence}"
+  end
+
   # Heuristic: do the given errors say the credentials are fine but lack a SCOPE the call needed
   # (e.g. Kraken's "EGeneral:Permission denied" on Ledgers when the key has no Query Ledger
   # Entries)? Deliberately separate from invalid_key_error?: the key is valid and may be trading

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -3,6 +3,9 @@ class Exchange < ApplicationRecord
   # lookback over daily candles is only a handful of windows) so a misbehaving API or an
   # advance bug can never spin forever.
   MAX_CANDLE_PAGES = 1000
+  # "We do not accept these credentials", in the one status every venue agrees on. See
+  # #invalid_key_error?; Exchanges::Ibkr opts out via #ambiguous_unauthorized?.
+  UNAUTHORIZED_STATUS = 401
 
   STABLE_TYPES = %w[Exchanges::Binance Exchanges::BinanceUs Exchanges::Coinbase Exchanges::Kraken].freeze
 
@@ -241,7 +244,15 @@ class Exchange < ApplicationRecord
   # Heuristic: does the given errors array look like an invalid-key / auth error?
   # Used by sync jobs to decide whether to flip an API key's status to :incorrect
   # when a live call (get_balances, get_ledger, etc.) fails.
-  def invalid_key_error?(errors)
+  def invalid_key_error?(errors, status: nil)
+    # HTTP 401 is the one vocabulary every venue shares for "these credentials are not accepted",
+    # and it is what makes this classifiable WITHOUT inventing message substrings. Alpaca and
+    # Coinbase carry no usable string at all, so their revoked keys could never be condemned — the
+    # status closes that for all of them at once. Honeymaker::Client#with_rescue and Clients::Alpaca
+    # both already attach it; venues that answer over HTTP 200 (Kraken's EAPI:Invalid key) still
+    # need the strings below, which is why this is an addition and not a replacement.
+    return true if status == UNAUTHORIZED_STATUS && !ambiguous_unauthorized?
+
     invalid_messages = (known_errors[:invalid_key] || []).map(&:to_s)
     return false if invalid_messages.empty?
 
@@ -252,15 +263,31 @@ class Exchange < ApplicationRecord
   end
 
   # Raise on a credential rejection, wherever a failed call would otherwise be flattened into a
-  # benign answer — "no price", "market state unknown". Those flattenings are right for a pair with
-  # no liquidity or a clock blip; for a rejected key they are a lie that hides the one thing the
-  # user has to act on, and they hid it for six weeks. Single phrase, single place: the venue's own
-  # text can be as bare as "HTTP 401", so the exchange is named here. The localized, actionable copy
-  # stays the tracker's sync-key banner, which the same classification drives.
-  def raise_on_invalid_key!(errors)
-    return unless invalid_key_error?(errors)
+  # benign answer — "no price", "market state unknown", "condition not met". Those flattenings are
+  # right for a pair with no liquidity, a clock blip or a price that simply has not moved; for a
+  # rejected key they are a lie that hides the one thing the user has to act on, and they hid it for
+  # six weeks. Single phrase, single place: the venue's own text can be as bare as "HTTP 401", so
+  # the exchange is named here. The localized, actionable copy stays the tracker's sync-key banner,
+  # which the same classification drives.
+  def raise_on_invalid_key!(result)
+    return if result.success?
+    return unless invalid_key_error?(result.errors, status: http_status(result))
 
-    raise "#{name} rejected the API key: #{Array(errors).to_sentence}"
+    raise "#{name} rejected the API key: #{Array(result.errors).to_sentence}"
+  end
+
+  # The venue's HTTP status when the client attached one (both honeymaker and the app's own clients
+  # carry it as data: { status: }), nil when the failure never had one — a Kraken HTTP-200 rejection
+  # or an error we raised ourselves.
+  def http_status(result)
+    result.data[:status] if result.data.is_a?(Hash)
+  end
+
+  # Does a 401 from this venue mean anything OTHER than "your key is no longer valid"? Only where
+  # it does may a venue refuse the status rule — see Exchanges::Ibkr, whose competing-login and
+  # not-yet-activated sessions 401 exactly like a revoked key.
+  def ambiguous_unauthorized?
+    false
   end
 
   # Heuristic: do the given errors say the credentials are fine but lack a SCOPE the call needed

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -1,6 +1,13 @@
 class Exchanges::Alpaca < Exchange
   ERRORS = {
-    insufficient_funds: ['insufficient buying power']
+    insufficient_funds: ['insufficient buying power'],
+    # A rejected key arrives in two shapes: the trading host's JSON body {"message":"unauthorized."}
+    # and, when the market-data host answers with an HTML error page, Clients::Alpaca's "HTTP 401"
+    # fallback. Both had to be listed for the key to be condemnable at all — Exchange#invalid_key_error?
+    # returns false on an empty :invalid_key list, so before this a revoked key kept reading `correct`
+    # in the tracker while every call on it 401'd. Matched as substrings, so the trailing period on
+    # Alpaca's message is not load-bearing.
+    invalid_key: ['unauthorized', 'HTTP 401']
   }.freeze
 
   # Alpaca's tradable crypto universe (30+ assets as of 2026-07, growing) mapped to the

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -1,13 +1,19 @@
 class Exchanges::Alpaca < Exchange
   ERRORS = {
     insufficient_funds: ['insufficient buying power'],
-    # A rejected key arrives in two shapes: the trading host's JSON body {"message":"unauthorized."}
-    # and, when the market-data host answers with an HTML error page, Clients::Alpaca's "HTTP 401"
-    # fallback. Both had to be listed for the key to be condemnable at all — Exchange#invalid_key_error?
-    # returns false on an empty :invalid_key list, so before this a revoked key kept reading `correct`
-    # in the tracker while every call on it 401'd. Matched as substrings, so the trailing period on
-    # Alpaca's message is not load-bearing.
-    invalid_key: ['unauthorized', 'HTTP 401']
+    # Alpaca's OWN word for a rejected key, from the trading host's JSON body
+    # {"message":"unauthorized."} — this is the string production recorded in ApiKey#last_sync_error
+    # while the key still read `correct`, because the list used to be empty and
+    # Exchange#invalid_key_error? returns false on an empty one. Matched as a substring, so the
+    # trailing period is not load-bearing.
+    #
+    # Clients::Alpaca's "HTTP 401" fallback (its HTML-body case, which is how the same rejection
+    # arrives from the market-data host) is deliberately NOT listed: that string is synthesised from
+    # the status by our own client, so a WAF or edge 401 would produce it just as readily, and
+    # condemning on it would be the bare-status rule wearing a costume. It still SURFACES through
+    # Exchange#invalid_key_error?(status:) — the bot error stays truthful either way; only the
+    # persistent :incorrect flip waits for Alpaca to say it.
+    invalid_key: ['unauthorized']
   }.freeze
 
   # Alpaca's tradable crypto universe (30+ assets as of 2026-07, growing) mapped to the

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -539,7 +539,7 @@ class Exchanges::Alpaca < Exchange
     Rails.cache.fetch("exchange_#{id}_clock", expires_in: 1.minute) do
       result = client.get_clock
       if result.failure?
-        raise_on_invalid_key!(result.errors)
+        raise_on_invalid_key!(result)
         return nil
       end
 

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -530,10 +530,18 @@ class Exchanges::Alpaca < Exchange
     api_key.passphrase != 'live'
   end
 
+  # nil means "could not ask", which #market_open? deliberately reads as open — a clock blip must not
+  # pause everyone's trading. A rejected key is NOT that: it fails every tick forever, so fail-open
+  # turned a dead key into "the market is open" at 04:00 UTC and sent the bot on to work that could
+  # only fail. Raise it here, at the first call the job makes, instead of somewhere downstream that
+  # cannot tell why nothing has a price. Nothing is cached on either path.
   def get_clock_cached
     Rails.cache.fetch("exchange_#{id}_clock", expires_in: 1.minute) do
       result = client.get_clock
-      return nil if result.failure?
+      if result.failure?
+        raise_on_invalid_key!(result.errors)
+        return nil
+      end
 
       result.data
     end

--- a/app/models/exchanges/ibkr.rb
+++ b/app/models/exchanges/ibkr.rb
@@ -54,6 +54,14 @@ class Exchanges::Ibkr < Exchange
     ERRORS
   end
 
+  # The same reasoning as the empty :invalid_key list above, applied to the status rule every other
+  # venue now follows: IBKR answers a competing login, an expired live session token and a key still
+  # awaiting activation with the SAME 401 as a revoked one. Condemning on the status would strand
+  # users whose credentials are fine, so IBKR keeps classifying by its own prose (:transient).
+  def ambiguous_unauthorized?
+    true
+  end
+
   def set_client(api_key: nil)
     @api_key = api_key
     @account_id = nil
@@ -130,6 +138,7 @@ class Exchanges::Ibkr < Exchange
 
   def cancel_order(order_id:)
     acct = account_id
+    return acct if acct.is_a?(Result)
     return Result::Failure.new('No IBKR account available') if acct.blank?
 
     result = client.cancel_order(account_id: acct, order_id: order_id)
@@ -142,6 +151,7 @@ class Exchanges::Ibkr < Exchange
 
   def get_balances(asset_ids: nil)
     acct = account_id
+    return acct if acct.is_a?(Result)
     return Result::Failure.new('No IBKR account available') if acct.blank?
 
     ledger = client.ledger(account_id: acct)
@@ -187,7 +197,16 @@ class Exchanges::Ibkr < Exchange
 
   def get_api_key_validity(api_key:)
     result = Clients::Ibkr.new(api_key: api_key).accounts
-    return Result::Success.new(:pending_activation) if result.failure? # registered but not yet usable
+    # A 401 here IS genuinely ambiguous — a key still awaiting activation and a revoked one answer
+    # identically — so it keeps meaning "registered, not yet usable". Anything else is not ambiguous
+    # at all: a 500 or a lock timeout used to tell the user IBKR was activating their key and reset
+    # the 14-day activation clock (ApiKey#activation_stalled?) over a blip.
+    if result.failure?
+      return Result::Success.new(:pending_activation) if http_status(result).nil? ||
+                                                         http_status(result) == UNAUTHORIZED_STATUS
+
+      return result
+    end
 
     Result::Success.new(extract_accounts(result.data).any? || :pending_activation)
   rescue Client::TransientNetworkError => e
@@ -203,13 +222,19 @@ class Exchanges::Ibkr < Exchange
 
   private
 
+  # Returns the account id, or the FAILED RESULT when discovery itself failed — the same
+  # `is_a?(Result)` shape resolve_conid uses, and callers branch on it the same way. It used to
+  # return a bare nil, so all three callers reported 'No IBKR account available': the user was told
+  # their brokerage account was gone when IBKR had actually said "competing live session", and that
+  # rewrite also hid the text from Exchange#transient_error?, which classifies on exactly those
+  # strings. Reserve the 'no account' message for a SUCCESSFUL call that lists none.
   def account_id
     return @account_id if defined?(@account_id) && @account_id
 
     result = client.accounts
     if result.failure?
       Rails.logger.warn("[IBKR] account discovery failed: #{result.errors.to_sentence}")
-      return nil
+      return result
     end
     @account_id = extract_accounts(result.data).first
   end
@@ -240,6 +265,7 @@ class Exchanges::Ibkr < Exchange
     return conid if conid.is_a?(Result) # search_contract failure
 
     acct = account_id
+    return acct if acct.is_a?(Result)
     return Result::Failure.new('No IBKR account available') if acct.blank?
 
     result = client.place_order(

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -40,13 +40,7 @@ class Ticker < ApplicationRecord
     # lie — "No matching coins found on Alpaca for the index" — while the real fault is the key.
     # One such bot failed that way on every tick for six weeks. Escapes like a transient error
     # does, and for the same reason: the caller must be able to tell the difference.
-    if result.failure? && exchange.invalid_key_error?(result.errors)
-      # Named, because the venue's own text can be as bare as "HTTP 401" and this string is what
-      # lands in the bot's activity feed. English like its neighbours (see IndexAllocatable) — the
-      # localized, actionable copy is the tracker's sync-key banner, which the same classification
-      # now triggers.
-      raise "#{exchange.name} rejected the API key: #{result.errors.to_sentence}"
-    end
+    exchange.raise_on_invalid_key!(result.errors) if result.failure?
 
     result.success? && result.data.to_d.positive?
   end

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -23,9 +23,8 @@ class Ticker < ApplicationRecord
              else raise ArgumentError, "Unsupported price_type: #{price_type.inspect}"
              end
 
-    begin
-      result = public_send(method, force: force)
-      result.success? && result.data.to_d.positive?
+    result = begin
+      public_send(method, force: force)
     rescue Client::TransientNetworkError
       raise
     rescue StandardError => e
@@ -33,8 +32,23 @@ class Ticker < ApplicationRecord
       # not an error — keep at debug so it doesn't trip the log exception scanner.
       Rails.logger.debug("Ticker#priced? false for ticker=#{id} (#{ticker}) " \
                          "type=#{price_type}: #{e.class}: #{e.message}")
-      false
+      return false
     end
+
+    # Rejected credentials are NOT "this pair has no live price": they make every ticker on the
+    # exchange look unpriced at once, so a caller that only sees `false` reports a domain-shaped
+    # lie — "No matching coins found on Alpaca for the index" — while the real fault is the key.
+    # One such bot failed that way on every tick for six weeks. Escapes like a transient error
+    # does, and for the same reason: the caller must be able to tell the difference.
+    if result.failure? && exchange.invalid_key_error?(result.errors)
+      # Named, because the venue's own text can be as bare as "HTTP 401" and this string is what
+      # lands in the bot's activity feed. English like its neighbours (see IndexAllocatable) — the
+      # localized, actionable copy is the tracker's sync-key banner, which the same classification
+      # now triggers.
+      raise "#{exchange.name} rejected the API key: #{result.errors.to_sentence}"
+    end
+
+    result.success? && result.data.to_d.positive?
   end
 
   # Whether the pair can actually be traded for the given order side right now:

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -40,7 +40,7 @@ class Ticker < ApplicationRecord
     # lie — "No matching coins found on Alpaca for the index" — while the real fault is the key.
     # One such bot failed that way on every tick for six weeks. Escapes like a transient error
     # does, and for the same reason: the caller must be able to tell the difference.
-    exchange.raise_on_invalid_key!(result.errors) if result.failure?
+    exchange.raise_on_invalid_key!(result)
 
     result.success? && result.data.to_d.positive?
   end

--- a/app/services/bot_api/orders/list_open.rb
+++ b/app/services/bot_api/orders/list_open.rb
@@ -27,7 +27,11 @@ module BotApi
         exchange_rows = exchange_orders(db_external_ids)
         rows = db_rows + exchange_rows
 
-        Result.success({ count: rows.size, orders: rows })
+        # `unavailable` is what stops "no open orders" from being asserted about an exchange we could
+        # not reach. Orders placed through this API have no local row, so for them this listing is
+        # the only source — silently dropping a 401'd exchange told the user their money was where it
+        # was not.
+        Result.success({ count: rows.size, orders: rows, unavailable: @unavailable.to_a })
       end
 
       private
@@ -56,15 +60,22 @@ module BotApi
       end
 
       def exchange_orders(db_external_ids)
+        @unavailable = []
         exchanges_to_query.flat_map do |ex|
           next [] unless ex.respond_to?(:list_open_orders)
 
           api_key = Lookup.find_api_key(@user, ex)
-          next [] unless api_key
+          if api_key.nil?
+            @unavailable << { exchange: ex.name, error: 'no usable trading key' }
+            next []
+          end
 
           ex.set_client(api_key: api_key)
           result = ex.list_open_orders
-          next [] if result.failure?
+          if result.failure?
+            @unavailable << { exchange: ex.name, error: result.errors.to_sentence }
+            next []
+          end
 
           map_exchange_rows(ex, result.data, db_external_ids)
         end

--- a/app/views/bots/dca_dual_assets/_metrics.html.erb
+++ b/app/views/bots/dca_dual_assets/_metrics.html.erb
@@ -1,4 +1,9 @@
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
+  <% if metrics[:prices_stale] %>
+    <p class="status-button__hint" role="status">
+      <%= t('bot.details.stats.exchange_unavailable_html') %>
+    </p>
+  <% end %>
   <div class="widget data-grid data-grid--two-columns">
     <%= render partial: "bots/dca_dual_assets/metrics_item", locals: {
       label: t('data_labels.invested'),

--- a/app/views/bots/dca_indexes/_metrics.html.erb
+++ b/app/views/bots/dca_indexes/_metrics.html.erb
@@ -1,4 +1,9 @@
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
+  <% if metrics[:prices_stale] %>
+    <p class="status-button__hint" role="status">
+      <%= t('bot.details.stats.exchange_unavailable_html') %>
+    </p>
+  <% end %>
   <div class="widget data-grid data-grid--two-columns">
     <div class="data-grid__item" data-controller="tooltip">
       <div class="label"><%= t('bot.details.stats.total_invested') %></div>

--- a/app/views/bots/dca_single_assets/_metrics.html.erb
+++ b/app/views/bots/dca_single_assets/_metrics.html.erb
@@ -1,4 +1,9 @@
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
+  <% if metrics[:prices_stale] %>
+    <p class="status-button__hint" role="status">
+      <%= t('bot.details.stats.exchange_unavailable_html') %>
+    </p>
+  <% end %>
   <div class="widget data-grid data-grid--two-columns">
     <%= render partial: "bots/dca_single_assets/metrics_item", locals: {
       label: t('data_labels.invested'),

--- a/test/jobs/bot/repair_orphaned_bots_job_test.rb
+++ b/test/jobs/bot/repair_orphaned_bots_job_test.rb
@@ -23,7 +23,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       id: 1,
       class: Bots::DcaSingleAsset,
       exchange: exchange,
-      next_action_job_at: nil,
+      pending_action_job?: false,
       next_interval_checkpoint_at: 1.hour.from_now,
       cancel_scheduled_action_jobs: true
     )
@@ -44,7 +44,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       id: 1,
       class: Bots::DcaSingleAsset,
       exchange: exchange,
-      next_action_job_at: nil,
+      pending_action_job?: false,
       next_interval_checkpoint_at: 1.hour.from_now,
       cancel_scheduled_action_jobs: true
     )
@@ -68,7 +68,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       id: 1,
       class: Bots::DcaSingleAsset,
       exchange: exchange,
-      next_action_job_at: nil,
+      pending_action_job?: false,
       next_interval_checkpoint_at: 1.hour.from_now
     )
     job_setter = stub('ConfiguredJob', perform_later: true)
@@ -87,7 +87,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       'Bots::DcaSingleAsset',
       id: 1,
       exchange: exchange,
-      next_action_job_at: 1.hour.from_now
+      pending_action_job?: true
     )
 
     Bot.stubs(:where).with(status: %i[scheduled retrying]).returns([bot])
@@ -116,7 +116,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       id: 1,
       class: Bots::DcaSingleAsset,
       exchange: exchange,
-      next_action_job_at: nil,
+      pending_action_job?: false,
       next_interval_checkpoint_at: 1.hour.from_now
     )
     bot2 = stub(
@@ -124,7 +124,7 @@ class Bot::RepairOrphanedBotsJobTest < ActiveSupport::TestCase
       id: 2,
       class: Bots::DcaSingleAsset,
       exchange: exchange,
-      next_action_job_at: nil,
+      pending_action_job?: false,
       next_interval_checkpoint_at: 2.hours.from_now,
       cancel_scheduled_action_jobs: true
     )
@@ -189,6 +189,39 @@ class Bot::RepairOrphanedBotsJobIntegrationTest < ActiveSupport::TestCase
   test 'does not repair single asset bot that already has a scheduled job' do
     bot = create(:dca_single_asset, :started, status: :scheduled)
     Bot::ActionJob.set(wait_until: 1.hour.from_now).perform_later(bot)
+    initial_job_count = SolidQueue::Job.where(class_name: 'Bot::ActionJob').count
+
+    Bot::RepairOrphanedBotsJob.perform_now
+
+    assert_equal initial_job_count, SolidQueue::Job.where(class_name: 'Bot::ActionJob').count
+  end
+
+  # Only a SCHEDULED execution carries a scheduled_at, so `next_action_job_at` reads nil for a job
+  # that is due now and waiting for a worker, one a worker has already claimed, and one blocked on
+  # the per-exchange concurrency semaphore. None of those bots is orphaned: each already owns a live
+  # job, and enqueueing a second one puts two ActionJobs on the same tick — the duplicate then dies
+  # on ActionJob's "already has an action job scheduled" guard.
+  test 'does not repair a bot whose ActionJob is queued and waiting for a worker' do
+    bot = create(:dca_single_asset, :started, status: :scheduled)
+    Bot::ActionJob.perform_later(bot)
+    assert_nil bot.next_action_job_at, 'a ready job has no scheduled_at — that is the trap'
+    live_job = SolidQueue::Job.find_by!(class_name: 'Bot::ActionJob')
+
+    Bot::RepairOrphanedBotsJob.perform_now
+
+    assert SolidQueue::Job.exists?(live_job.id),
+           'the due job was cancelled and replaced, delaying a tick that was about to run'
+    assert_equal 1, SolidQueue::Job.where(class_name: 'Bot::ActionJob').count
+  end
+
+  test 'does not repair a bot whose ActionJob a worker has already claimed' do
+    bot = create(:dca_single_asset, :started, status: :scheduled)
+    Bot::ActionJob.perform_later(bot)
+    process = SolidQueue::Process.create!(kind: 'Worker', pid: 42, name: 'test-worker',
+                                          last_heartbeat_at: Time.current)
+    SolidQueue::ReadyExecution.claim('*', 10, process.id)
+    assert_equal 1, SolidQueue::ClaimedExecution.count, 'test setup: the job must be claimed'
+    assert_nil bot.next_action_job_at
     initial_job_count = SolidQueue::Job.where(class_name: 'Bot::ActionJob').count
 
     Bot::RepairOrphanedBotsJob.perform_now

--- a/test/mcp/tools/list_open_orders_tool_test.rb
+++ b/test/mcp/tools/list_open_orders_tool_test.rb
@@ -31,6 +31,24 @@ class ListOpenOrdersToolTest < ActiveSupport::TestCase
     assert_match(/order-123/, text)
   end
 
+  # "No open orders found." is a statement of fact about the user's money. When the exchange call
+  # fails — a rejected key, a venue outage — we do not know that, and MCP-placed limit orders have no
+  # local row, so this listing is their only source.
+  test 'does not claim there are no open orders when an exchange could not be reached' do
+    alpaca = create(:alpaca_exchange)
+    create(:api_key, user: @user, exchange: alpaca, key_type: :trading, status: :correct)
+    Exchanges::Alpaca.any_instance.stubs(:list_open_orders)
+                     .returns(Result::Failure.new('unauthorized.', data: { status: 401 }))
+
+    response = ListOpenOrdersTool.new.execute
+    text = response.contents.first.text
+
+    assert_no_match(/\ANo open orders found\.\z/, text,
+                    'the bare claim asserts a fact about money we could not check')
+    assert_match(/could not be checked/, text)
+    assert_match(/Alpaca/, text)
+  end
+
   test 'lists open orders from exchange API' do
     alpaca = create(:alpaca_exchange)
     create(:api_key, user: @user, exchange: alpaca, key_type: :trading, status: :correct)

--- a/test/models/bot/limit_checkable_test.rb
+++ b/test/models/bot/limit_checkable_test.rb
@@ -134,4 +134,26 @@ class Bot::LimitCheckableTest < ActiveSupport::TestCase
     Bot::PriceLimitCheckJob.expects(:set).never
     @bot.enqueue_limit_check_job
   end
+
+  # == limit_condition_met? ==
+  #
+  # A failed condition read is NOT "the condition is not met". With a rejected key it is the same
+  # answer on every tick, so the bot parks itself and the feed says "Paused: price limit not met" —
+  # the market simply has not reached your price — while the truth is that we cannot ask at all. It
+  # then polls forever and never trades again, with no error and no email.
+  test 'limit_condition_met? raises when the read failed because the key was rejected' do
+    result = Result::Failure.new('Invalid API-key, IP, or permissions for action.')
+
+    error = assert_raises(RuntimeError) { @bot.limit_condition_met?(result) }
+    assert_match 'rejected the API key', error.message
+  end
+
+  test 'limit_condition_met? still reads any other failure as not-met, so a blip only waits' do
+    assert_not @bot.limit_condition_met?(Result::Failure.new('connection reset'))
+  end
+
+  test 'limit_condition_met? passes a successful condition through' do
+    assert @bot.limit_condition_met?(Result::Success.new(true))
+    assert_not @bot.limit_condition_met?(Result::Success.new(false))
+  end
 end

--- a/test/models/bots/stale_prices_flag_test.rb
+++ b/test/models/bots/stale_prices_flag_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+# When the live price read fails, every bot type falls back to valuing holdings at the last
+# executed transaction price — and renders that as "Portfolio value" with nothing to say it is not
+# live. With a rejected key the number simply stops moving, for weeks, while the page keeps
+# presenting it as current. The fallback itself is right (a stale number beats a blank one); saying
+# nothing about it is not.
+class Bots::StalePricesFlagTest < ActiveSupport::TestCase
+  FACTORIES = %i[dca_single_asset dca_dual_asset dca_index].freeze
+
+  FACTORIES.each do |factory|
+    test "#{factory}: metrics are marked stale when the price read fails" do
+      bot = create(factory, user: create(:user))
+      bot.stubs(:metrics).returns(minimal_metrics)
+      bot.exchange.stubs(:get_tickers_prices).returns(Result::Failure.new('unauthorized.'))
+
+      data = bot.metrics_with_current_prices(force: true)
+
+      assert data[:prices_stale], 'a value carried over from the last trade must say so'
+    end
+
+    test "#{factory}: metrics are not marked stale when prices come back" do
+      bot = create(factory, user: create(:user))
+      bot.stubs(:metrics).returns(minimal_metrics)
+      prices = bot.tickers.to_a.index_by(&:ticker).transform_values { 100.to_d }
+      bot.exchange.stubs(:get_tickers_prices).returns(Result::Success.new(prices))
+
+      data = bot.metrics_with_current_prices(force: true)
+
+      assert_not data[:prices_stale]
+    end
+  end
+
+  private
+
+  # Only the keys the fallback path reads before returning: a non-empty chart (an empty one returns
+  # earlier, before any price call) plus the accumulators each type touches on the way through.
+  def minimal_metrics
+    {
+      chart: { labels: [Time.current], series: [[1.0], [1.0]] },
+      asset_breakdown: {},
+      total_base_amount: 1.to_d,
+      total_base0_amount: 1.to_d,
+      total_base1_amount: 1.to_d,
+      total_quote_amount_invested: 100.to_d,
+      base0_total_quote_amount_invested: 50.to_d,
+      base1_total_quote_amount_invested: 50.to_d,
+      total_realized_proceeds: 0.to_d
+    }
+  end
+end

--- a/test/models/concerns/api_key_failure_handling_test.rb
+++ b/test/models/concerns/api_key_failure_handling_test.rb
@@ -72,6 +72,45 @@ class ApiKeyFailureHandlingTest < ActiveSupport::TestCase
     assert_equal :en, I18n.locale, 'the wrapper must not leak the user locale into the caller'
   end
 
+  # Alpaca and Coinbase carry no usable invalid-key STRING, and invalid_key_error? returns false on
+  # an empty list — so a revoked key on either could never be condemned and kept reading `correct`
+  # while every call 401'd. HTTP 401 is the one vocabulary every venue shares, and both
+  # Honeymaker::Client#with_rescue and Clients::Alpaca already attach it to every failure.
+  test 'a 401 condemns the key on a venue that has no invalid-key strings' do
+    coinbase = create(:coinbase_exchange)
+    key = create(:api_key, user: @user, exchange: coinbase)
+    Turbo::StreamsChannel.stubs(:broadcast_append_to)
+
+    @host.handle_api_key_failure(key, Result::Failure.new('Unauthorized', data: { status: 401 }),
+                                 capability: :balances)
+
+    assert_equal 'incorrect', key.reload.status
+  end
+
+  test 'a 403 is a permission problem, not a rejected key, and leaves the key usable' do
+    coinbase = create(:coinbase_exchange)
+    key = create(:api_key, user: @user, exchange: coinbase)
+    Turbo::StreamsChannel.stubs(:broadcast_append_to)
+
+    @host.handle_api_key_failure(key, Result::Failure.new('Forbidden', data: { status: 403 }),
+                                 capability: :balances)
+
+    assert_equal 'correct', key.reload.status
+  end
+
+  # IBKR answers a competing login with the same 401 as a revoked key. Condemning on that would
+  # strand a user whose credentials are fine, so IBKR opts out and keeps its own transient handling.
+  test 'IBKR is exempt from the 401 rule because its 401 is ambiguous' do
+    ibkr = create(:ibkr_exchange)
+    key = create(:api_key, user: @user, exchange: ibkr)
+    Turbo::StreamsChannel.stubs(:broadcast_append_to)
+
+    @host.handle_api_key_failure(key, Result::Failure.new('not authenticated', data: { status: 401 }),
+                                 capability: :balances)
+
+    assert_equal 'correct', key.reload.status
+  end
+
   test 'nothing is broadcast for a successful result' do
     Turbo::StreamsChannel.expects(:broadcast_append_to).never
 

--- a/test/models/concerns/api_key_failure_handling_test.rb
+++ b/test/models/concerns/api_key_failure_handling_test.rb
@@ -72,11 +72,12 @@ class ApiKeyFailureHandlingTest < ActiveSupport::TestCase
     assert_equal :en, I18n.locale, 'the wrapper must not leak the user locale into the caller'
   end
 
-  # Alpaca and Coinbase carry no usable invalid-key STRING, and invalid_key_error? returns false on
-  # an empty list — so a revoked key on either could never be condemned and kept reading `correct`
-  # while every call 401'd. HTTP 401 is the one vocabulary every venue shares, and both
-  # Honeymaker::Client#with_rescue and Clients::Alpaca already attach it to every failure.
-  test 'a 401 condemns the key on a venue that has no invalid-key strings' do
+  # THE regression pin for a 401. It is enough to SAY the venue rejected us, never enough to condemn
+  # a stored key: Coinbase signs every request with a two-minute JWT built from local time, so clock
+  # skew 401s a perfectly good key, and our own authenticated exchange proxy answers a wrong password
+  # with 401 too. Condemning drops the key from every :correct-scoped sync until the user pastes new
+  # credentials that were never the problem — so condemnation wants the venue's own words.
+  test 'a bare 401 never condemns a stored key' do
     coinbase = create(:coinbase_exchange)
     key = create(:api_key, user: @user, exchange: coinbase)
     Turbo::StreamsChannel.stubs(:broadcast_append_to)
@@ -84,31 +85,20 @@ class ApiKeyFailureHandlingTest < ActiveSupport::TestCase
     @host.handle_api_key_failure(key, Result::Failure.new('Unauthorized', data: { status: 401 }),
                                  capability: :balances)
 
+    assert_equal 'correct', key.reload.status
+  end
+
+  # Alpaca's two observed rejection bodies ARE listed as strings, which is what makes its revoked key
+  # condemnable — the venue's own words, not a status.
+  test 'a venue that names the rejection still condemns the key' do
+    alpaca = create(:alpaca_exchange)
+    key = create(:api_key, user: @user, exchange: alpaca)
+    Turbo::StreamsChannel.stubs(:broadcast_append_to)
+
+    @host.handle_api_key_failure(key, Result::Failure.new('unauthorized.', data: { status: 401 }),
+                                 capability: :balances)
+
     assert_equal 'incorrect', key.reload.status
-  end
-
-  test 'a 403 is a permission problem, not a rejected key, and leaves the key usable' do
-    coinbase = create(:coinbase_exchange)
-    key = create(:api_key, user: @user, exchange: coinbase)
-    Turbo::StreamsChannel.stubs(:broadcast_append_to)
-
-    @host.handle_api_key_failure(key, Result::Failure.new('Forbidden', data: { status: 403 }),
-                                 capability: :balances)
-
-    assert_equal 'correct', key.reload.status
-  end
-
-  # IBKR answers a competing login with the same 401 as a revoked key. Condemning on that would
-  # strand a user whose credentials are fine, so IBKR opts out and keeps its own transient handling.
-  test 'IBKR is exempt from the 401 rule because its 401 is ambiguous' do
-    ibkr = create(:ibkr_exchange)
-    key = create(:api_key, user: @user, exchange: ibkr)
-    Turbo::StreamsChannel.stubs(:broadcast_append_to)
-
-    @host.handle_api_key_failure(key, Result::Failure.new('not authenticated', data: { status: 401 }),
-                                 capability: :balances)
-
-    assert_equal 'correct', key.reload.status
   end
 
   test 'nothing is broadcast for a successful result' do

--- a/test/models/exchange_test.rb
+++ b/test/models/exchange_test.rb
@@ -16,4 +16,42 @@ class ExchangeTest < ActiveSupport::TestCase
 
     assert_equal [alpaca.id, ibkr.id].sort, Exchange.stock_venues.pluck(:id).sort
   end
+  # == 401 classification ==
+  #
+  # Two different questions, deliberately answered differently. SAYING the venue rejected us is
+  # cheap and self-correcting, so a bare 401 is enough — and for Coinbase it is the ONLY signal,
+  # since it names no rejection string. CONDEMNING the stored key is not: see
+  # ApiKeyFailureHandlingTest.
+  test 'a 401 marks a credential failure even on a venue that names no rejection string' do
+    coinbase = create(:coinbase_exchange)
+
+    assert_empty Array(coinbase.known_errors[:invalid_key]), 'fixture: the venue names nothing'
+    assert coinbase.invalid_key_error?(['Unauthorized'], status: 401)
+    assert_not coinbase.condemning_invalid_key_error?(['Unauthorized'])
+  end
+
+  test 'a 401 does not mark a credential failure on IBKR, whose 401 is ambiguous' do
+    ibkr = create(:ibkr_exchange)
+
+    assert_predicate ibkr, :ambiguous_unauthorized?
+    assert_not ibkr.invalid_key_error?(['not authenticated'], status: 401)
+  end
+
+  test 'a non-401 status is classified by the venue words alone' do
+    kraken = create(:kraken_exchange)
+
+    assert_not kraken.invalid_key_error?(['EGeneral:Internal error'], status: 500)
+    assert kraken.invalid_key_error?(['EAPI:Invalid key'])
+  end
+
+  test 'raise_on_invalid_key! names the exchange and passes a success through' do
+    coinbase = create(:coinbase_exchange)
+
+    error = assert_raises(RuntimeError) do
+      coinbase.raise_on_invalid_key!(Result::Failure.new('Unauthorized', data: { status: 401 }))
+    end
+    assert_match 'Coinbase rejected the API key', error.message
+
+    assert_nil coinbase.raise_on_invalid_key!(Result::Success.new({}))
+  end
 end

--- a/test/models/exchanges/alpaca_test.rb
+++ b/test/models/exchanges/alpaca_test.rb
@@ -68,7 +68,10 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
   # not an unknown: it is a definite answer, and the bot must fail on it here, before any trading
   # work, rather than at some later call that has no idea why nothing has a price.
   test 'market_open? raises instead of failing open when the clock call is rejected as unauthorized' do
-    Clients::Alpaca.any_instance.stubs(:get_clock).returns(Result::Failure.new('HTTP 401'))
+    # Shaped like the real client: Clients::Alpaca#with_rescue attaches the status to every failure,
+    # and the HTML body of Alpaca's 401 is what becomes the bare "HTTP 401" text.
+    Clients::Alpaca.any_instance.stubs(:get_clock)
+                   .returns(Result::Failure.new('HTTP 401', data: { status: 401 }))
 
     error = assert_raises(RuntimeError) { @exchange.market_open? }
     assert_match 'rejected the API key', error.message
@@ -76,7 +79,8 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
   end
 
   test 'next_market_open_at raises on a rejected key rather than returning Time.current' do
-    Clients::Alpaca.any_instance.stubs(:get_clock).returns(Result::Failure.new('unauthorized.'))
+    Clients::Alpaca.any_instance.stubs(:get_clock)
+                   .returns(Result::Failure.new('unauthorized.', data: { status: 401 }))
 
     assert_raises(RuntimeError) { @exchange.next_market_open_at }
   end
@@ -699,8 +703,16 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
     assert @exchange.invalid_key_error?(['unauthorized.'])
   end
 
-  test 'invalid_key_error? recognises an HTML 401 from the market-data host' do
-    assert @exchange.invalid_key_error?(['HTTP 401'])
+  # The HTML-body case arrives as Clients::Alpaca's synthesised "HTTP 401". It surfaces through the
+  # status — the bot error stays truthful — but it must never condemn the key on its own: our client
+  # builds that string from the status, so a WAF or edge 401 would produce it just as readily.
+  test 'an HTML 401 surfaces as a credential failure but does not condemn on its own' do
+    assert @exchange.invalid_key_error?(['HTTP 401'], status: 401)
+    assert_not @exchange.condemning_invalid_key_error?(['HTTP 401'])
+  end
+
+  test 'the JSON unauthorized body is Alpaca own word, and does condemn' do
+    assert @exchange.condemning_invalid_key_error?(['unauthorized.'])
   end
 
   test 'invalid_key_error? ignores a failure that is not about credentials' do

--- a/test/models/exchanges/alpaca_test.rb
+++ b/test/models/exchanges/alpaca_test.rb
@@ -62,6 +62,25 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
     assert_predicate @exchange, :market_open?
   end
 
+  # The fail-open above is deliberate for a BLIP — but a rejected key fails the clock call on every
+  # tick forever, and "we could not ask" then became "the market is open", so a bot woke at 04:00
+  # UTC, ran a full index refresh against a dead key and blamed the index. A credential failure is
+  # not an unknown: it is a definite answer, and the bot must fail on it here, before any trading
+  # work, rather than at some later call that has no idea why nothing has a price.
+  test 'market_open? raises instead of failing open when the clock call is rejected as unauthorized' do
+    Clients::Alpaca.any_instance.stubs(:get_clock).returns(Result::Failure.new('HTTP 401'))
+
+    error = assert_raises(RuntimeError) { @exchange.market_open? }
+    assert_match 'rejected the API key', error.message
+    assert_match 'HTTP 401', error.message
+  end
+
+  test 'next_market_open_at raises on a rejected key rather than returning Time.current' do
+    Clients::Alpaca.any_instance.stubs(:get_clock).returns(Result::Failure.new('unauthorized.'))
+
+    assert_raises(RuntimeError) { @exchange.next_market_open_at }
+  end
+
   test 'set_client defaults to paper mode when passphrase is nil' do
     api_key = stub(key: 'test_key', secret: 'test_secret', passphrase: nil)
     @exchange.set_client(api_key: api_key)

--- a/test/models/exchanges/alpaca_test.rb
+++ b/test/models/exchanges/alpaca_test.rb
@@ -669,4 +669,22 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
 
     assert_predicate result, :failure?
   end
+
+  # == invalid-key classification ==
+  #
+  # A rejected Alpaca key arrives in two shapes: the JSON body {"message":"unauthorized."} from the
+  # trading host, and Clients::Alpaca's "HTTP <status>" fallback when the market-data host answers
+  # with an HTML error page. With no :invalid_key list at all, Exchange#invalid_key_error? early
+  # returns false, so nothing ever condemns the key and the tracker keeps showing it as correct.
+  test 'invalid_key_error? recognises the JSON unauthorized body' do
+    assert @exchange.invalid_key_error?(['unauthorized.'])
+  end
+
+  test 'invalid_key_error? recognises an HTML 401 from the market-data host' do
+    assert @exchange.invalid_key_error?(['HTTP 401'])
+  end
+
+  test 'invalid_key_error? ignores a failure that is not about credentials' do
+    assert_not @exchange.invalid_key_error?(['insufficient buying power'])
+  end
 end

--- a/test/models/exchanges/ibkr_test.rb
+++ b/test/models/exchanges/ibkr_test.rb
@@ -81,6 +81,38 @@ class Exchanges::IbkrTest < ActiveSupport::TestCase
     assert_equal :pending_activation, result.data
   end
 
+  # A 401 from IBKR really is ambiguous — an unactivated key and a revoked one look identical — so
+  # :pending_activation stays the answer there. Everything else is not: a 500 or a lock timeout told
+  # the user "IBKR is activating your key, 24h-2wk" and started a fresh 14-day activation clock over
+  # a transient blip.
+  test 'get_api_key_validity keeps :pending_activation for a 401' do
+    Clients::Ibkr.any_instance.expects(:accounts)
+                 .returns(Result::Failure.new('not authenticated', data: { status: 401 }))
+    result = @exchange.get_api_key_validity(api_key: stub(id: 1, key: 'C'))
+    assert_equal :pending_activation, result.data
+  end
+
+  test 'get_api_key_validity surfaces a server error instead of calling it pending activation' do
+    Clients::Ibkr.any_instance.expects(:accounts)
+                 .returns(Result::Failure.new('Internal Server Error', data: { status: 500 }))
+    result = @exchange.get_api_key_validity(api_key: stub(id: 1, key: 'C'))
+    assert_predicate result, :failure?
+  end
+
+  # account_id returning a bare nil made all three callers substitute "No IBKR account available" —
+  # telling the user their brokerage account is gone, and hiding the real text from
+  # Exchange#transient_error?, which classifies on exactly the strings IBKR sends here.
+  test 'a failed account discovery surfaces IBKR own error rather than "no account"' do
+    @client.expects(:accounts).returns(Result::Failure.new('competing live session'))
+
+    result = @exchange.get_balances
+
+    assert_predicate result, :failure?
+    assert_match 'competing live session', result.errors.to_sentence
+    assert @exchange.transient_error?(result.errors),
+           'the venue text must survive so the transient classifier can still see it'
+  end
+
   test 'get_api_key_validity returns true when accounts come back' do
     Clients::Ibkr.any_instance.expects(:accounts).returns(Result::Success.new({ 'accounts' => ['U1'] }))
     result = @exchange.get_api_key_validity(api_key: stub(id: 1, key: 'C'))

--- a/test/models/ticker_test.rb
+++ b/test/models/ticker_test.rb
@@ -20,6 +20,18 @@ class TickerTest < ActiveSupport::TestCase
     assert_not @ticker.priced?(:last)
   end
 
+  # A rejected API key makes EVERY ticker on the exchange look unpriced, so a caller that only sees
+  # `false` reports a domain-shaped lie ("No matching coins found for the index") while the real
+  # fault is the credentials. Auth failures must escape, the way transient ones already do.
+  test 'priced? raises when the price lookup fails because the key is rejected' do
+    @ticker.stubs(:get_last_price).returns(Result::Failure.new('EAPI:Invalid key'))
+
+    error = assert_raises(RuntimeError) { @ticker.priced?(:last) }
+    assert_match 'EAPI:Invalid key', error.message
+    assert_match 'rejected the API key', error.message,
+                 'the venue text can be as bare as "HTTP 401" — the message must name what happened'
+  end
+
   test 'priced? returns false when last price is zero' do
     stub_ticker_last_price(@ticker, price: BigDecimal('0'))
     assert_not @ticker.priced?(:last)


### PR DESCRIPTION
When a venue rejects our credentials, several layers flattened that failure into a benign
sentinel — `false`, `nil`, `[]` — and a later layer then reported a confident, domain-shaped
conclusion that was untrue. The user was told the index had no matching coins, that the market was
open, that their price limit had not been reached, that they had no open orders. Nothing said the
key had been rejected, and nothing marked the key as bad, so there was nothing to act on.

## Where it was happening

| Site | What it said | What had happened |
|---|---|---|
| `Ticker#priced?` | "No matching coins found on Alpaca for the index" | every ticker on the venue looks unpriced when the key is refused |
| `Exchanges::Alpaca#get_clock_cached` | market is open (at any hour) | the clock call was refused; `nil` was read as "open" |
| `price` / `price_drop` / `moving_average` / `indicator` limit gates | "Paused: price limit not met" — then polls forever and never trades again | the condition could not be read at all |
| `BotApi::Orders::ListOpen` → `list_open_orders` | "No open orders found." | an exchange never answered; orders placed through the API have no local row, so this listing is their only source |
| `Exchanges::Ibkr#account_id` | "No IBKR account available" | IBKR said something else — and the rewrite hid that text from `Exchange#transient_error?`, which classifies on exactly those strings |
| `Exchanges::Ibkr#get_api_key_validity` | "registered, awaiting activation", restarting the 14-day activation clock | any failure at all, including a 500 or a lock timeout |
| the three `metrics_with_current_prices` fallbacks | a live "Portfolio value" | holdings valued at the last executed transaction price |

## How a rejected key is recognised now

Two questions, deliberately answered differently, because their consequences differ:

- **Saying** the venue rejected us — `Exchange#invalid_key_error?(errors, status:)`. A bare HTTP 401
  counts. It is the one vocabulary every venue shares, and for Coinbase it is the only signal there
  is, since it names no rejection string. Both `Honeymaker::Client#with_rescue` and
  `Clients::Alpaca` already attach the status to every failure. Saying so is reversible and
  self-correcting, and it is what makes the bot's own error truthful.
- **Condemning** the stored key — `Exchange#condemning_invalid_key_error?(errors)`. Venue words
  only, never a bare status. A 401 does not prove the credentials are wrong: Coinbase signs each
  request with a two-minute JWT built from local time, so clock skew refuses a perfectly good key,
  and an authenticated exchange proxy answers a wrong password with 401 too. Flipping a key to
  `:incorrect` drops it from every `:correct`-scoped sync until the user pastes new credentials that
  were never the problem.

`Exchanges::Alpaca::ERRORS[:invalid_key]` gains `'unauthorized'`, Alpaca's own word for it, which is
what makes a refused Alpaca key condemnable at all — the list was empty, and
`Exchange#invalid_key_error?` returns false on an empty list. `Clients::Alpaca`'s `"HTTP 401"`
fallback is deliberately not listed: that string is synthesised from the status by our own client,
so an edge or WAF 401 would produce it just as readily.

`Exchanges::Ibkr#ambiguous_unauthorized?` opts IBKR out of the status rule entirely. A competing
login, an expired live session token and a key still awaiting activation all answer 401 there,
exactly like a revoked one.

`Exchange#raise_on_invalid_key!` is the single raiser, used by `Ticker#priced?`, the Alpaca clock and
the shared limit gate. `Exchanges::Alpaca#market_open?` keeps failing open for an ordinary blip — one
flaky clock call must not pause everyone's trading — but a credential rejection is a definite answer,
not an unknown, and now raises at the first call the job makes.

## Also here: a duplicate ActionJob every 15 minutes

`Bot::RepairOrphanedBotsJob` judged orphanhood by `next_action_job_at`, which only ever sees a
SCHEDULED execution. A bot whose `ActionJob` was running (claimed), due now (ready), or queued behind
the per-exchange concurrency semaphore read as orphaned, and `cancel_scheduled_action_jobs` cannot
cancel a claimed job — so the repair enqueued a second job for the same tick, which then died on
`Bot::ActionJob`'s "already has an action job scheduled" guard. It now asks whether any live
`ActionJob` exists in any active queue state (`Automation::Schedulable#pending_action_job?`). The
generic helper behind it is renamed `active_limit_check_job?` → `active_job?`, since it was never
limit-check specific.

## Notes

- The stale-metrics notice needed no new copy: `bot.details.stats.exchange_unavailable_html` already
  said exactly this in all 15 locales and had never been rendered anywhere.
- `Exchanges::Ibkr#account_id` now returns the failed `Result`, the same `is_a?(Result)` shape
  `resolve_conid` already used; all three call sites branch on it.
- Still open, and unchanged here: no email is sent when a key dies. `Bot::ActionJob#notify_retry`
  cannot fire, because `retry_on StandardError` is commented out in `ApplicationJob`, so `executions`
  stays at 1 and `estimated_retry_delay` never exceeds a minute. That needs its own change.

3626 tests, 13503 assertions, all green. Rubocop clean.
