### PR TITLE
Sell for a fixed quote amount, not just a fixed base amount

### DIFF
--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -121,8 +121,8 @@ class BotsController < ApplicationController
     end
   end
 
-  # Manual ⇄ flip: turn a single-asset DCA bot around to sell (or back to buy). Reversing
-  # only changes direction + reschedules; flip_direction! owns the Accountable guard and the
+  # Manual ⇄ rotation: buy → sell N base → sell for N quote → buy. Rotating only changes the
+  # direction/denomination + reschedules; flip_direction! owns the Accountable guard and the
   # reschedule. Deferred (with a notice, no error) while the bot is mid-execution or a job is
   # claimed — flip_direction!'s cancellation cannot reach an already-claimed job.
   def reverse
@@ -131,7 +131,7 @@ class BotsController < ApplicationController
     if @bot.executing? || @bot.flip_blocked_by_inflight_job?
       flash.now[:notice] = t('bot.reverse_in_progress')
     else
-      @bot.flip_direction!
+      @bot.rotate_direction!
     end
     render :reverse
   end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -73,6 +73,17 @@ class Bot < ApplicationRecord
     false
   end
 
+  # How a sell tick is sized. Both false for buy-only types, so Bot::SmartIntervalable and the
+  # settings partials it shares with DcaDualAsset / DcaIndex can read them unguarded, exactly like
+  # selling? above. Bot::Reversible overrides them.
+  def sells_base_amount?
+    false
+  end
+
+  def sells_quote_amount?
+    false
+  end
+
   # Only Bot::Reversible (DcaSingleAsset) can flip direction. Trigger concerns are shared with
   # buy-only bot types, so the flip action and the ⇄ control must be gated on this.
   def reversible?

--- a/app/models/bot/reversible.rb
+++ b/app/models/bot/reversible.rb
@@ -2,14 +2,19 @@ module Bot::Reversible
   extend ActiveSupport::Concern
 
   DIRECTIONS = %w[buying selling].freeze
+  # How a sell tick is sized: a fixed amount of base ("Sell 0.01 BTC / Day to USD") or a fixed
+  # amount of quote ("Sell BTC for 100 USD / Day").
+  SELL_DENOMINATIONS = %w[base quote].freeze
 
   included do
-    store_accessor :settings, :direction, :sell_amount, :sell_interval
+    store_accessor :settings, :direction, :sell_amount, :sell_interval, :sell_denomination, :sell_quote_amount
 
     validates :direction, inclusion: { in: DIRECTIONS }, allow_nil: true
+    validates :sell_denomination, inclusion: { in: SELL_DENOMINATIONS }, allow_nil: true
     # Blank stays valid (sell sentence not filled yet — a no-op skip); reject negative/garbage so a
     # bad value can't silently disable selling.
     validates :sell_amount, numericality: { greater_than: 0 }, allow_nil: true
+    validates :sell_quote_amount, numericality: { greater_than: 0 }, allow_nil: true
     # The reader falls back to a valid buy interval, so this validates the effective value and
     # rejects only a corrupted stored value (which would crash scheduling on the flip).
     validates :sell_interval, inclusion: { in: Automation::Schedulable::INTERVALS.keys }
@@ -24,7 +29,12 @@ module Bot::Reversible
         return super unless selling?
 
         base_duration = Automation::Schedulable::INTERVALS[sell_interval] || super
-        if smart_intervaled? && smart_interval_base_amount.present? && sell_amount.present? && sell_amount.positive?
+        # ponytail: Smart Intervals only subdivides a BASE-denominated sell. Quote-denominated
+        # selling would need its own quote split (the buy-side one belongs to the buy sentence and
+        # is validated against it), so the rule is simply not offered in that mode — see the
+        # settings partial. Add a dedicated smart_interval_sell_quote_amount if it's ever wanted.
+        if sells_base_amount? && smart_intervaled? && smart_interval_base_amount.present? &&
+           sell_amount.present? && sell_amount.positive?
           # .seconds re-conversion required (see SmartIntervalable) so Time + duration keeps working.
           return (base_duration / (sell_amount / smart_interval_base_amount.to_f)).seconds
         end
@@ -38,7 +48,10 @@ module Bot::Reversible
       # did not submit the field leaves it untouched.
       def parse_params(params)
         result = super
-        result[:sell_amount] = params[:sell_amount].presence&.to_f if params.respond_to?(:key?) && params.key?(:sell_amount)
+        return result unless params.respond_to?(:key?)
+
+        result[:sell_amount] = params[:sell_amount].presence&.to_f if params.key?(:sell_amount)
+        result[:sell_quote_amount] = params[:sell_quote_amount].presence&.to_f if params.key?(:sell_quote_amount)
         result
       end
     end)
@@ -65,6 +78,27 @@ module Bot::Reversible
     value.presence&.to_d
   end
 
+  # Same reader-fallback rule as `direction`: an existing row has no key, and reading the default
+  # must not dirty settings.
+  def sell_denomination
+    super.presence || 'base'
+  end
+
+  # The quote-denominated sell size ("Sell BTC for N USD"). Blank until the user fills that
+  # sentence, exactly like sell_amount.
+  def sell_quote_amount
+    value = super
+    value.presence&.to_d
+  end
+
+  def sells_base_amount?
+    selling? && sell_denomination == 'base'
+  end
+
+  def sells_quote_amount?
+    selling? && sell_denomination == 'quote'
+  end
+
   def buying?
     direction == 'buying'
   end
@@ -75,6 +109,23 @@ module Bot::Reversible
 
   def reversible?
     true
+  end
+
+  # The manual ⇄ control rotates through THREE states rather than flipping between two:
+  #   buying → selling (N base) → selling (for N quote) → buying
+  # Only the controller calls this. Trigger flips call flip_direction! directly, which leaves
+  # sell_denomination alone so an automated flip preserves the sell mode the user configured.
+  # Returning to buying resets the denomination so the cycle is fully determined by the icon.
+  def rotate_direction!
+    if buying?
+      flip_direction!(to_direction: 'selling', to_denomination: 'base')
+    elsif sells_base_amount?
+      # Not a direction change, but the open sell was sized under the old basis — run the full
+      # mechanism so it is cancelled and the cadence re-anchored.
+      flip_direction!(to_direction: 'selling', to_denomination: 'quote')
+    else
+      flip_direction!(to_direction: 'buying', to_denomination: 'base')
+    end
   end
 
   # The single choke point for both the manual ⇄ flip and (later) the trigger flips.
@@ -94,7 +145,10 @@ module Bot::Reversible
   #   3. Re-broadcast via Bot::BroadcastAfterScheduledActionJob.
   # Pure mechanism — the manual path (controller) gates on flip_blocked_by_inflight_job? first;
   # trigger flips (M5) call this directly from inside the running (working) ActionJob.
-  def flip_direction!
+  #
+  # to_direction / to_denomination let the manual rotation name its target explicitly; both nil
+  # (the trigger path) means "flip the direction, leave the denomination alone".
+  def flip_direction!(to_direction: nil, to_denomination: nil)
     leaving_buy_side = buying?
     set_missed_quote_amount
     cancelled_buy_reserve = cancel_unfilled_orders
@@ -104,15 +158,17 @@ module Bot::Reversible
     if leaving_buy_side && cancelled_buy_reserve.positive?
       self.missed_quote_amount = [missed_quote_amount + cancelled_buy_reserve, effective_quote_amount].min
     end
-    flipped = (selling? ? 'buying' : 'selling')
+    clamp_smart_interval_splits
+    attrs = { direction: to_direction || (selling? ? 'buying' : 'selling') }
+    attrs[:sell_denomination] = to_denomination if to_denomination
 
     unless working?
-      update!(direction: flipped)
+      update!(**attrs)
       reset_trigger_condition_timestamps
       return
     end
 
-    update!(direction: flipped, status: :scheduled, started_at: Time.current)
+    update!(**attrs, status: :scheduled, started_at: Time.current)
     cancel_scheduled_action_jobs
     cancel_scheduled_limit_check_jobs
     reset_trigger_condition_timestamps
@@ -167,6 +223,25 @@ module Bot::Reversible
                    level: :warning, details: { order_id: order.external_id })
     end
     cancelled_buy_reserve
+  end
+
+  # Each smart-interval split is validated only while ITS side is active (the quote split while
+  # buying, the base split while selling), so the inactive one can drift below its minimum — raise
+  # the buy amount through the API while the bot sells and the stored quote split is suddenly too
+  # small. Entering that side would then make the update! above raise RecordInvalid and 500 the
+  # flip, so clamp instead. Runs after set_missed_quote_amount, which satisfies the Accountable
+  # guard for the settings write. .to_f because a BigDecimal serialises into the JSON settings
+  # column as a String, which breaks the Float division in effective_interval_duration.
+  def clamp_smart_interval_splits
+    return unless smart_intervaled?
+
+    minimum_quote = minimum_smart_interval_quote_amount.to_d
+    self.smart_interval_quote_amount = minimum_quote.to_f if smart_interval_quote_amount.to_d < minimum_quote
+
+    minimum_base = minimum_smart_interval_base_amount.to_d
+    return unless sell_amount.present? && smart_interval_base_amount.to_d < minimum_base
+
+    self.smart_interval_base_amount = minimum_base.to_f
   end
 
   # Parity with validate_unchangeable_interval: the sell cadence is fixed while it is the

--- a/app/models/bot/smart_intervalable.rb
+++ b/app/models/bot/smart_intervalable.rb
@@ -11,18 +11,20 @@ module Bot::SmartIntervalable
     # The sell base split can't be seeded at load when sell_amount is still blank (e.g. just after a
     # flip). Seed it the moment a sell amount exists — before validation — so entering the sell amount
     # in the main sentence never trips the base-split presence check.
-    before_validation :seed_smart_interval_base_amount, if: -> { smart_intervaled? && selling? }
+    before_validation :seed_smart_interval_base_amount, if: -> { smart_intervaled? && sells_base_amount? }
 
     validates :smart_intervaled, inclusion: { in: [true, false] }
-    # Quote split governs buying; base split governs selling. Direction-gate so a selling bot is never
-    # blocked by a missing quote amount (and vice versa). The base check additionally waits for a sell
-    # amount, so flipping a smart-on bot with no sell sentence yet can't fail validation.
+    # Quote split governs buying; base split governs BASE-denominated selling. Direction-gate so a
+    # selling bot is never blocked by a missing quote amount (and vice versa). The base check
+    # additionally waits for a sell amount, so flipping a smart-on bot with no sell sentence yet
+    # can't fail validation. A quote-denominated sell validates NEITHER split — the rule is not
+    # offered in that mode (see Bot::Reversible#effective_interval_duration).
     validates :smart_interval_quote_amount,
               numericality: { greater_than_or_equal_to: :minimum_smart_interval_quote_amount },
               if: -> { smart_intervaled? && !selling? }
     validates :smart_interval_base_amount,
               numericality: { greater_than_or_equal_to: :minimum_smart_interval_base_amount },
-              if: -> { smart_intervaled? && selling? && try(:sell_amount).present? }
+              if: -> { smart_intervaled? && sells_base_amount? && sell_amount.present? }
 
     decorators = Module.new do
       def parse_params(params)

--- a/app/models/bots/dca_single_asset/order_setter.rb
+++ b/app/models/bots/dca_single_asset/order_setter.rb
@@ -15,15 +15,28 @@ module Bots::DcaSingleAsset::OrderSetter
     )
 
     if side == :sell
-      sellable = sellable_base_amount
+      # A quote-denominated sell is sized in quote, so it needs the price BEFORE it can know how much
+      # base to sell — and it must be the same price the order is placed at, or "sell for 100 USD"
+      # would not deliver 100 USD (most visibly for limit orders, priced off the last trade rather
+      # than the bid). Base-denominated sells keep the original shape: an unconfigured amount or an
+      # exhausted cap still makes no exchange call at all.
+      price = nil
+      if sells_quote_amount? && effective_sell_quote_amount.positive?
+        price_result = fetch_order_price(:sell)
+        return price_result if price_result.failure?
+
+        price = price_result.data
+      end
+
+      sellable = sellable_base_amount(price: price)
       if sellable.zero?
         # Genuinely nothing to sell (a balance-read FAILURE raises instead of reaching here). Log the
         # reason so a permanently-idle selling bot is greppable in healthcheck-logs.
-        Rails.logger.info("set_order bot=#{id} event=sell_skipped reason=#{sell_skip_reason}")
+        Rails.logger.info("set_order bot=#{id} event=sell_skipped reason=#{sell_skip_reason(price: price)}")
         return Result::Success.new # nothing to sell yet — skip, keep running
       end
 
-      result = get_order_data(side: :sell, base_amount: sellable)
+      result = get_order_data(side: :sell, base_amount: sellable, price: price)
     else
       validate_order_amount!(order_amount_in_quote)
       return Result::Success.new if order_amount_in_quote.zero?
@@ -78,7 +91,27 @@ module Bots::DcaSingleAsset::OrderSetter
     raise 'Order quote_amount must be positive' if order_amount_in_quote.negative?
   end
 
-  def get_order_data(side:, order_amount_in_quote: nil, base_amount: nil)
+  def get_order_data(side:, order_amount_in_quote: nil, base_amount: nil, price: nil)
+    if price.nil?
+      result = fetch_order_price(side)
+      return result if result.failure?
+
+      price = result.data
+    end
+
+    order_data = calculate_order_data(
+      side: side,
+      price: price,
+      order_amount_in_quote: order_amount_in_quote,
+      base_amount: base_amount,
+      order_type: limit_ordered? ? :limit_order : :market_order
+    )
+    Result::Success.new(order_data)
+  end
+
+  # The price the order will actually be placed at: the reference price plus the limit-order
+  # adjustment. Extracted so a quote-denominated sell can size itself off the very same value.
+  def fetch_order_price(side)
     result = reference_price(side)
     if result.failure?
       # A transient/throttle price read must retry via Bot::ActionJob's typed-error chain, not leave
@@ -92,14 +125,7 @@ module Bots::DcaSingleAsset::OrderSetter
       return result
     end
 
-    order_data = calculate_order_data(
-      side: side,
-      price: order_price(side, result.data),
-      order_amount_in_quote: order_amount_in_quote,
-      base_amount: base_amount,
-      order_type: limit_ordered? ? :limit_order : :market_order
-    )
-    Result::Success.new(order_data)
+    Result::Success.new(order_price(side, result.data))
   end
 
   # Market price tracks the side of the spread we cross: buys take the ask, sells take the bid.
@@ -141,8 +167,8 @@ module Bots::DcaSingleAsset::OrderSetter
   # The bot only sells what it accumulated and only as much as is actually free on the exchange:
   # min(per-tick desired, net executed holdings, live free base balance, remaining cap allowance).
   # Below the exchange minimum it flows through the existing below-minimum skip path. Never oversell.
-  def sellable_base_amount
-    desired = effective_base_amount
+  def sellable_base_amount(price: nil)
+    desired = effective_base_amount(price: price)
     return 0.to_d if desired <= 0
 
     # A selling bot may liquidate the WHOLE wallet, not just what it accumulated, so net holdings
@@ -157,12 +183,30 @@ module Bots::DcaSingleAsset::OrderSetter
     [cap, live_free_base_balance].min
   end
 
-  # The per-tick sell size: while Smart Intervals is on, the base split; otherwise the full
+  # The per-tick sell size in BASE. Quote-denominated: the configured quote amount converted at the
+  # order price. Base-denominated: the base split while Smart Intervals is on, else the full
   # configured sell amount. (Quote-side splitting is the buy-only effective_quote_amount.)
-  def effective_base_amount
-    return smart_interval_base_amount.to_d if selling? && smart_intervaled? && smart_interval_base_amount.present?
+  def effective_base_amount(price: nil)
+    if sells_quote_amount?
+      return 0.to_d if price.nil? || price <= 0
+
+      return effective_sell_quote_amount / price
+    end
+
+    # The split only subdivides a sell amount that still exists — without the sell_amount guard a
+    # bot whose sell sentence was cleared would keep selling the stale split.
+    if sells_base_amount? && smart_intervaled? && smart_interval_base_amount.present? &&
+       sell_amount.present? && sell_amount.positive?
+      return smart_interval_base_amount.to_d
+    end
 
     sell_amount || 0
+  end
+
+  # The per-tick sell size in QUOTE. No smart split: Smart Intervals is not offered in this mode
+  # (see Bot::Reversible#effective_interval_duration).
+  def effective_sell_quote_amount
+    sell_quote_amount || 0
   end
 
   # The live free base balance. A failed read must NOT be coerced to 0 — that would make a transient
@@ -183,8 +227,8 @@ module Bots::DcaSingleAsset::OrderSetter
 
   # Why a sell tick found nothing to sell — for healthcheck-logs observability (NOT a balance failure,
   # which raises before we get here).
-  def sell_skip_reason
-    return 'unconfigured_sell_amount' if effective_base_amount <= 0
+  def sell_skip_reason(price: nil)
+    return 'unconfigured_sell_amount' if effective_base_amount(price: price) <= 0
     return 'cap_reached' if base_amount_limited? && base_amount_available_before_limit_reached <= 0
 
     'no_holdings'

--- a/app/views/bots/dca_single_assets/_settings.html.erb
+++ b/app/views/bots/dca_single_assets/_settings.html.erb
@@ -3,7 +3,12 @@
 
 <div id="settings" class="column gap-1">
   <%= render partial: "bots/dca_single_assets/settings/main", locals: { bot: bot, method: method, path: path } %>
-  <%= render partial: "bots/settings/smart_intervals", locals: { bot: bot, method: method, path: path } %>
+  <%# Smart Intervals subdivides a base-denominated sell (or a buy); it has no quote-sell form yet,
+      so the rule is not offered while the bot sells for a fixed quote amount. The stored setting is
+      untouched and comes back with the other two states. %>
+  <% unless bot.sells_quote_amount? %>
+    <%= render partial: "bots/settings/smart_intervals", locals: { bot: bot, method: method, path: path } %>
+  <% end %>
   <%= render partial: "bots/settings/limit_orders", locals: { bot: bot, method: method, path: path } %>
   <%= render partial: "bots/settings/starting_time", locals: { bot: bot, method: method, path: path } %>
   <%= render partial: "bots/settings/price_limit", locals: { bot: bot, method: method, path: path } %>

--- a/app/views/bots/dca_single_assets/settings/_main.html.erb
+++ b/app/views/bots/dca_single_assets/settings/_main.html.erb
@@ -12,7 +12,27 @@
                 turbo_stream: true,
                 controller: "form--submit form--submit-after-delay form--move-cursor-to-end form--html5-validations"
               } do |f| %>
-  <% if bot.selling? %>
+  <% if bot.sells_quote_amount? %>
+    <%# DCA-out, quote-denominated: "Sell [base] for …[quote] / [period]" — the tick is sized by the
+        quote amount to receive, not by the base amount to sell. %>
+    <div class="conversational flex-justify-center">
+      <%= t('bot.conversational.sell') %>
+      <%= tag.div base, class: "ticker", data: ticker_data(bot.base_asset) %>
+      <%= t('bot.for') %>
+      <div class="ticker-input ticker-input--autoscale">
+        <% sell_quote_value = bot.sell_quote_amount.present? ? bot.sell_quote_amount.to_d.to_s('F').sub(/([0-9]\d*)\.0$/, '\1') : nil %>
+        <%= f.number_field :sell_quote_amount, value: sell_quote_value, class: 'numeric-input', step: :any, size: 2, placeholder: "0", data: { controller: "autowidth-input", action: "input->form--submit-after-delay#submit input->autowidth-input#resize", form__move_cursor_to_end_target: "input" }, autofocus: bot.sell_quote_amount.blank? %>
+
+        <%= tag.div quote, class: "ticker", data: ticker_data(bot.quote_asset) %>
+      </div>
+      /
+      <div class="sinput sinput--select <%= 'sinput--disabled' if bot.working? %>">
+        <%= t("bot.#{bot.sell_interval}") %>
+        <%= f.select :sell_interval, bot_intervals_select_options, { selected: bot.sell_interval }, data: { action: "change->form--submit#submit" }, disabled: bot.working? %>
+      </div>
+      <%= render 'bots/settings/reverse_toggle', bot: bot %>
+    </div>
+  <% elsif bot.selling? %>
     <%# DCA-out sentence: "Sell …[base] / [period] to [quote]" — base and quote swapped vs buy. %>
     <div class="conversational flex-justify-center">
       <%= t('bot.conversational.sell') %>

--- a/app/views/bots/settings/_smart_intervals.html.erb
+++ b/app/views/bots/settings/_smart_intervals.html.erb
@@ -16,7 +16,7 @@
     <div class="toggle-group__info">
       <div class="toggle-group__info__label">
         <%= f.label :smart_intervaled, class: "conversational conversational--small conversational--disabled" do %>
-          <% if bot.selling? %>
+          <% if bot.sells_base_amount? %>
             <%# Selling splits the SELL amount into base units (issue #5), the mirror of the buy split. %>
             <% amount_html = content_tag(:div) do %>
               <% min_amount = bot.send(:minimum_smart_interval_base_amount) %>

--- a/app/views/bots/settings/_smart_intervals_info.html.erb
+++ b/app/views/bots/settings/_smart_intervals_info.html.erb
@@ -1,4 +1,4 @@
-<% if bot.selling? %>
+<% if bot.sells_base_amount? %>
   <% if bot.smart_intervaled? && bot.smart_interval_base_amount&.to_d&.positive? && bot.sell_amount&.positive? %>
     <small id="<%= bot.new_record? ? "new-settings-smart-intervals-info" : "settings-smart-intervals-info" %>" class="small-info">
       <%= t("bot.settings.smart_intervals.sell_info",

--- a/test/controllers/bots/reverse_controller_test.rb
+++ b/test/controllers/bots/reverse_controller_test.rb
@@ -34,13 +34,18 @@ class Bots::ReverseControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/⇄/, response.body)
   end
 
-  test 'POST reverse flips a selling bot back to buying' do
+  test 'POST reverse moves a base-selling bot on to quote-selling, then back to buying' do
+    # The manual control rotates through three states, so a selling bot needs two POSTs to return
+    # to buying (a TRIGGER flip is still a straight two-state flip — see Bot::RotationTest).
     bot = create(:dca_single_asset, :started, user: @user)
     bot.flip_direction!
-    assert_predicate bot.reload, :selling?
+    assert_predicate bot.reload, :sells_base_amount?
 
     post reverse_bot_path(id: bot.id), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
+    assert_response :success
+    assert_predicate bot.reload, :sells_quote_amount?
 
+    post reverse_bot_path(id: bot.id), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
     assert_response :success
     assert_predicate bot.reload, :buying?
   end
@@ -97,5 +102,30 @@ class Bots::ReverseControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match reverse_bot_path(id: bot.id), response.body
     assert_no_match I18n.t('bot.reverse_confirm'), response.body
+  end
+
+  # == three-state rotation (buy → sell N base → sell for N quote → buy) ==
+
+  test 'three POSTs rotate the sentence through all three states' do
+    bot = create(:dca_single_asset, :stopped, user: @user)
+
+    post reverse_bot_path(id: bot.id), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
+    assert_response :success
+    assert_match 'bots_dca_single_asset[sell_amount]', response.body
+    assert_no_match 'bots_dca_single_asset[sell_quote_amount]', response.body
+
+    post reverse_bot_path(id: bot.id), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
+    assert_response :success
+    assert_predicate bot.reload, :sells_quote_amount?
+    assert_match 'bots_dca_single_asset[sell_quote_amount]', response.body
+    assert_no_match 'bots_dca_single_asset[sell_amount]"', response.body
+    # Smart Intervals has no quote-sell form yet, so the rule is not offered in that mode
+    assert_no_match 'bots_dca_single_asset[smart_intervaled]', response.body
+
+    post reverse_bot_path(id: bot.id), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
+    assert_response :success
+    assert_predicate bot.reload, :buying?
+    assert_match 'bots_dca_single_asset[quote_amount]', response.body
+    assert_match 'bots_dca_single_asset[smart_intervaled]', response.body
   end
 end

--- a/test/models/bot/rotation_test.rb
+++ b/test/models/bot/rotation_test.rb
@@ -1,0 +1,189 @@
+require 'test_helper'
+
+# The manual ⇄ control rotates through THREE states instead of flipping between two:
+#   buy → sell N base → sell BASE for N quote → buy
+# `direction` stays two-valued; `sell_denomination` is the new axis (how a sell tick is sized).
+class Bot::RotationTest < ActiveSupport::TestCase
+  # == sell_denomination defaults & validation ==
+
+  test 'a bot sells base-denominated by default' do
+    bot = build(:dca_single_asset)
+    assert_equal 'base', bot.sell_denomination
+  end
+
+  test 'the base default is never written into settings (existing-row safe)' do
+    bot = create(:dca_single_asset)
+    assert_not bot.settings.key?('sell_denomination')
+
+    bot.reload
+    assert_equal 'base', bot.sell_denomination
+    assert_not bot.settings.key?('sell_denomination'),
+               'reading the default must not write "sell_denomination" into settings'
+  end
+
+  test 'rejects an unknown denomination' do
+    bot = build(:dca_single_asset)
+    bot.sell_denomination = 'sideways'
+    assert_not_predicate bot, :valid?
+    assert bot.errors[:sell_denomination].present?
+  end
+
+  test 'the denomination predicates are false while buying' do
+    bot = build(:dca_single_asset)
+    assert_not_predicate bot, :sells_base_amount?
+    assert_not_predicate bot, :sells_quote_amount?
+  end
+
+  test 'the denomination predicates follow direction + denomination' do
+    bot = build(:dca_single_asset)
+    bot.direction = 'selling'
+    assert_predicate bot, :sells_base_amount?
+    assert_not_predicate bot, :sells_quote_amount?
+
+    bot.sell_denomination = 'quote'
+    assert_not_predicate bot, :sells_base_amount?
+    assert_predicate bot, :sells_quote_amount?
+  end
+
+  test 'non-reversible bot types answer both predicates with false' do
+    # SmartIntervalable and its partials are shared with these types, which never include Reversible.
+    bot = build(:dca_dual_asset)
+    assert_not_predicate bot, :sells_base_amount?
+    assert_not_predicate bot, :sells_quote_amount?
+  end
+
+  # == sell_quote_amount ==
+
+  test 'sell_quote_amount is blank by default and rejects a non-positive value' do
+    bot = build(:dca_single_asset)
+    assert_nil bot.sell_quote_amount
+
+    bot.sell_quote_amount = -5
+    assert_not_predicate bot, :valid?
+    assert bot.errors[:sell_quote_amount].present?
+  end
+
+  test 'sell_quote_amount reads back as a BigDecimal' do
+    bot = create(:dca_single_asset)
+    bot.sell_quote_amount = 25.5
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 25.5.to_d, bot.reload.sell_quote_amount
+  end
+
+  test 'a submitted blank sell_quote_amount clears it' do
+    bot = create(:dca_single_asset)
+    bot.sell_quote_amount = 25
+    bot.set_missed_quote_amount
+    bot.save!
+
+    parsed = bot.parse_params(ActionController::Parameters.new(sell_quote_amount: '').permit!)
+    assert parsed.key?(:sell_quote_amount)
+    assert_nil parsed[:sell_quote_amount]
+  end
+
+  test 'a form that does not submit sell_quote_amount leaves it untouched' do
+    bot = create(:dca_single_asset)
+    parsed = bot.parse_params(ActionController::Parameters.new(interval: 'week').permit!)
+    assert_not parsed.key?(:sell_quote_amount)
+  end
+
+  # == The rotation itself ==
+
+  test 'rotate_direction! cycles buy → sell base → sell quote → buy' do
+    bot = create(:dca_single_asset)
+    assert_predicate bot, :buying?
+
+    bot.rotate_direction!
+    assert_predicate bot, :sells_base_amount?
+
+    bot.rotate_direction!
+    assert_predicate bot, :sells_quote_amount?
+
+    bot.rotate_direction!
+    assert_predicate bot, :buying?
+    assert_equal 'base', bot.sell_denomination, 'returning to buying resets the denomination'
+  end
+
+  test 'the rotation survives a reload (it is persisted, not in-memory)' do
+    bot = create(:dca_single_asset)
+    bot.rotate_direction!
+    bot.rotate_direction!
+
+    assert_predicate bot.reload, :sells_quote_amount?
+  end
+
+  test 'a trigger flip never touches the chosen sell denomination' do
+    # flip_direction! is the trigger path (start_selling / start_buying) — it must preserve the
+    # sell mode the user configured, unlike the manual rotation.
+    bot = create(:dca_single_asset)
+    bot.rotate_direction!
+    bot.rotate_direction!
+    assert_predicate bot, :sells_quote_amount?
+
+    bot.flip_direction!
+    assert_predicate bot, :buying?
+    assert_equal 'quote', bot.sell_denomination
+
+    bot.flip_direction!
+    assert_predicate bot, :sells_quote_amount?
+  end
+
+  test 'the base → quote step still cancels open orders and reschedules' do
+    # It is not a direction change, but the open sell was sized under the old basis.
+    bot = create(:dca_single_asset, :started)
+    bot.rotate_direction!
+    assert_predicate bot.reload, :sells_base_amount?
+
+    order = create(:transaction, bot: bot, side: :sell, status: :submitted, external_status: :open)
+    Transaction.any_instance.expects(:cancel).at_least_once.returns(Result::Success.new)
+
+    bot.rotate_direction!
+
+    assert_predicate bot.reload, :sells_quote_amount?
+    assert order.present?
+  end
+
+  # == Clamping the inactive smart-interval split (pre-existing 500) ==
+
+  test 'entering the buy side clamps a smart quote split that drifted below its minimum' do
+    # Only the ACTIVE side's split is validated, so the buy amount can be raised through the API
+    # while selling and leave the stored quote split below its (now higher) minimum. Entering the
+    # buy side would then raise RecordInvalid and 500 the flip.
+    bot = create(:dca_single_asset)
+    bot.settings['smart_intervaled'] = true
+    bot.settings['smart_interval_quote_amount'] = 10.0
+    bot.set_missed_quote_amount
+    bot.save!
+
+    bot.rotate_direction!
+    assert_predicate bot, :sells_base_amount?
+
+    bot.settings['quote_amount'] = 1_000_000.0 # minimum split now far above 10
+    bot.set_missed_quote_amount
+    bot.save!(validate: false)
+
+    assert_nothing_raised { bot.rotate_direction! } # → sell/quote
+    assert_nothing_raised { bot.rotate_direction! } # → buying, where the split is validated again
+    assert_predicate bot, :buying?
+    assert_operator bot.smart_interval_quote_amount.to_d, :>=,
+                    bot.send(:minimum_smart_interval_quote_amount).to_d
+  end
+
+  test 'the clamped split is stored as a number, not a BigDecimal string' do
+    # A BigDecimal serialises into the JSON settings column as a String, which breaks the Float
+    # division in effective_interval_duration on the next load.
+    bot = create(:dca_single_asset)
+    bot.settings['smart_intervaled'] = true
+    bot.settings['smart_interval_quote_amount'] = 0.01
+    bot.settings['quote_amount'] = 1_000_000.0
+    bot.set_missed_quote_amount
+    bot.save!(validate: false)
+
+    bot.flip_direction!
+    bot.flip_direction!
+
+    assert_kind_of Numeric, bot.reload.settings['smart_interval_quote_amount']
+  end
+end

--- a/test/models/bots/dca_single_asset/quote_denominated_selling_test.rb
+++ b/test/models/bots/dca_single_asset/quote_denominated_selling_test.rb
@@ -1,0 +1,153 @@
+require 'test_helper'
+
+# The third sentence: "Sell BTC for 100 USD / Day". The tick is sized in QUOTE and converted to base
+# at the same price the order is placed at; every existing sell ceiling still applies.
+class Bots::DcaSingleAsset::QuoteDenominatedSellingTest < ActiveSupport::TestCase
+  def quote_selling_bot(sell_quote_amount: 100, free_base: 10.0, limit: false)
+    bot = create(:dca_single_asset, :started)
+    bot.settings['limit_ordered'] = limit
+    bot.direction = 'selling'
+    bot.sell_denomination = 'quote'
+    bot.sell_quote_amount = sell_quote_amount
+    bot.set_missed_quote_amount
+    bot.save!
+    bot.exchange.stubs(:get_balance).returns(Result::Success.new({ free: free_base.to_d, total: free_base.to_d }))
+    bot
+  end
+
+  test 'a quote-denominated market sell sizes the base amount as quote / bid price' do
+    bot = quote_selling_bot(sell_quote_amount: 100)
+    bot.ticker.stubs(:get_bid_price).returns(Result::Success.new(200.to_d))
+    bot.exchange.expects(:market_sell).with(has_entries(amount_type: :base))
+       .returns(Result::Success.new({ order_id: 'q-1' }))
+
+    result = bot.set_order(side: :sell)
+
+    assert_predicate result, :success?
+    txn = bot.transactions.order(:created_at).last
+    assert_predicate txn, :sell?
+    assert_in_delta 0.5, txn.amount.to_f, 1e-6 # 100 / 200
+    assert_in_delta 100, txn.quote_amount.to_f, 1e-6
+  end
+
+  test 'a quote-denominated limit sell sizes at the LIMIT price, not the last trade' do
+    # The whole point of fetching the price once: sizing at the bid and placing at last*(1+distance)
+    # would not deliver the quote amount the sentence promises.
+    bot = quote_selling_bot(sell_quote_amount: 100_100, limit: true)
+    bot.ticker.stubs(:get_last_price).returns(Result::Success.new(100_000.to_d))
+    bot.ticker.expects(:get_bid_price).never
+    captured = nil
+    bot.exchange.stubs(:limit_sell).with do |args|
+      captured = args
+      true
+    end.returns(Result::Success.new({ order_id: 'q-l1' }))
+
+    bot.set_order(side: :sell)
+
+    assert_in_delta 100_100, captured[:price].to_f, 1e-6
+    assert_in_delta 1.0, captured[:amount].to_f, 1e-6 # 100_100 / 100_100, not 100_100 / 100_000
+  end
+
+  test 'the live free base balance still caps a quote-denominated sell' do
+    bot = quote_selling_bot(sell_quote_amount: 1000, free_base: 0.25)
+    bot.ticker.stubs(:get_bid_price).returns(Result::Success.new(100.to_d))
+    bot.exchange.stubs(:market_sell).returns(Result::Success.new({ order_id: 'q-2' }))
+
+    bot.set_order(side: :sell)
+
+    assert_in_delta 0.25, bot.transactions.order(:created_at).last.amount.to_f, 1e-6
+  end
+
+  test 'the base cap still caps a quote-denominated sell' do
+    bot = quote_selling_bot(sell_quote_amount: 1000, free_base: 10.0)
+    bot.settings['base_amount_limited'] = true
+    bot.settings['base_amount_limit'] = 0.4
+    bot.set_missed_quote_amount
+    bot.save!
+    bot.ticker.stubs(:get_bid_price).returns(Result::Success.new(100.to_d))
+    bot.exchange.stubs(:market_sell).returns(Result::Success.new({ order_id: 'q-3' }))
+
+    bot.set_order(side: :sell)
+
+    assert_in_delta 0.4, bot.transactions.order(:created_at).last.amount.to_f, 1e-6
+  end
+
+  test 'a blank sell_quote_amount skips the tick without touching the exchange' do
+    bot = quote_selling_bot(sell_quote_amount: nil)
+    bot.ticker.expects(:get_bid_price).never
+    bot.ticker.expects(:get_last_price).never
+    bot.exchange.expects(:get_balance).never
+    bot.exchange.expects(:market_sell).never
+
+    assert_predicate bot.set_order(side: :sell), :success?
+    assert_equal 'unconfigured_sell_amount', bot.send(:sell_skip_reason)
+  end
+
+  test 'a base-denominated sell makes no early price call (the base path is unchanged)' do
+    bot = create(:dca_single_asset, :started)
+    bot.direction = 'selling'
+    bot.sell_amount = 0.3
+    bot.set_missed_quote_amount
+    bot.save!
+    bot.exchange.stubs(:get_balance).returns(Result::Success.new({ free: 1.to_d, total: 1.to_d }))
+    bot.ticker.expects(:get_bid_price).once.returns(Result::Success.new(100.to_d))
+    bot.exchange.stubs(:market_sell).returns(Result::Success.new({ order_id: 'b-1' }))
+
+    bot.set_order(side: :sell)
+  end
+
+  test 'a non-transient price failure returns before the balance is read' do
+    bot = quote_selling_bot(sell_quote_amount: 100)
+    bot.ticker.stubs(:get_bid_price).returns(Result::Failure.new(['Symbol not found']))
+    bot.exchange.expects(:get_balance).never
+    bot.exchange.expects(:market_sell).never
+
+    assert_predicate bot.set_order(side: :sell), :failure?
+    assert_predicate bot.transactions.order(:created_at).last, :failed?
+  end
+
+  test 'a throttled price read raises the typed error Bot::ActionJob retries on' do
+    bot = quote_selling_bot(sell_quote_amount: 100)
+    bot.ticker.stubs(:get_bid_price).returns(Result::Failure.new(['Too many requests']))
+    bot.exchange.stubs(:throttled_error?).returns(true)
+
+    assert_raises(Client::RateLimitedError) { bot.set_order(side: :sell) }
+  end
+
+  # == Smart Intervals is inert in quote mode ==
+
+  test 'a smart-intervalled quote sell ignores the split and sells the full quote amount' do
+    bot = quote_selling_bot(sell_quote_amount: 100)
+    bot.settings['smart_intervaled'] = true
+    bot.settings['smart_interval_quote_amount'] = 10.0
+    bot.set_missed_quote_amount
+    bot.save!
+    bot.ticker.stubs(:get_bid_price).returns(Result::Success.new(100.to_d))
+    bot.exchange.stubs(:market_sell).returns(Result::Success.new({ order_id: 'q-4' }))
+
+    bot.set_order(side: :sell)
+
+    assert_in_delta 1.0, bot.transactions.order(:created_at).last.amount.to_f, 1e-6
+    assert_equal Automation::Schedulable::INTERVALS[bot.sell_interval], bot.effective_interval_duration
+  end
+
+  # == Pre-existing hole closed on the base side ==
+
+  test 'a smart base sell with a cleared sell_amount no longer sells the stale split' do
+    bot = create(:dca_single_asset, :started)
+    bot.direction = 'selling'
+    bot.sell_amount = 1.0
+    bot.settings['smart_intervaled'] = true
+    bot.settings['smart_interval_base_amount'] = 0.1
+    bot.set_missed_quote_amount
+    bot.save!
+
+    bot.sell_amount = nil
+    bot.set_missed_quote_amount
+    bot.save!
+
+    bot.ticker.expects(:get_bid_price).never
+    bot.exchange.expects(:market_sell).never
+    assert_predicate bot.set_order(side: :sell), :success?
+  end
+end


### PR DESCRIPTION
The ⇄ control at the end of the single-asset sentence rotates through three states instead of flipping between two:

```
Invest 100 USD / Day into BTC
Sell 0.01 BTC / Day to USD
Sell BTC for 100 USD / Day     ← new
```

`direction` stays two-valued (`buying` / `selling`); the new axis is `sell_denomination` — how a sell tick is sized. `flip_direction!` is still a straight two-state flip and never touches the denomination, so a trigger flip (`start_selling` / `start_buying`) preserves the sell mode the user picked. Only the manual control rotates, and returning to buying resets the denomination so the cycle is fully determined by the icon.

### Sizing

A quote-denominated sell needs the price before it knows how much base to sell, and it has to be the *same* price the order is placed at. Sizing off the bid and then placing a limit order at `last * (1 + distance)` would not deliver the amount the sentence promises. So the reference-price read plus its limit adjustment is extracted into `fetch_order_price`, and the sell branch passes one price to both the sizing and the order data.

The base-denominated path keeps its exact shape: an unconfigured amount or a spent cap still makes no exchange call at all. Every existing ceiling — the "don't sell more than N base" cap and the live free balance — still clamps the result, so quote mode can never oversell.

### Fixed on the way

- Each smart-interval split is validated only while its side is active, so the inactive one could drift below its minimum (raise the buy amount while the bot sells) and make the *next* flip raise `RecordInvalid` and 500. `flip_direction!` now clamps both splits before saving.
- A base sell whose `sell_amount` had been cleared kept selling the stale smart split.

### Smart Intervals

Not offered while selling for a fixed quote amount. It would need its own quote split — the buy-side one belongs to the buy sentence and is validated against it, and a shared field couples the two sides. The rule is hidden in that mode, the stored setting is untouched, and it comes back with the other two states. An upgrade path (`smart_interval_sell_quote_amount`) is recorded in the code.

### Tests

`test/models/bot/rotation_test.rb` and `test/models/bots/dca_single_asset/quote_denominated_selling_test.rb`, plus the rotation in `test/controllers/bots/reverse_controller_test.rb`. 3653 runs, 0 failures.
