### PR TITLE
Let a bot switch exchange before its first start

### DIFF
--- a/app/views/bots/_exchange_select.html.erb
+++ b/app/views/bots/_exchange_select.html.erb
@@ -1,10 +1,14 @@
 <%= form_with model: bot, url: bot_path(bot), method: :patch, id: "exchange_select", class: "flex-row", data: { controller: "form--submit" } do |f| %>
+  <%# Not-working, not stopped: a bot that has never been started is `created`, and that is exactly
+      where a user lands after the wizard or after a key is rejected. Gating on stopped? left them
+      unable to move off the venue they could not connect to. %>
+  <% switchable = !bot.working? %>
   <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="dropdown-wrapper">
-    <div class="sbutton sbutton--exchange sbutton--exchange--<%= bot.exchange.name_id %> <%= 'sinput--disabled' unless bot.stopped? %>">
+    <div class="sbutton sbutton--exchange sbutton--exchange--<%= bot.exchange.name_id %> <%= 'sinput--disabled' unless switchable %>">
       <%= render "svg/exchange-#{bot.exchange.name_id}", title: bot.exchange.name %>
       <span class="hide-on-mobile"><%= bot.exchange&.name || t('bot.pick_exchange') %></span>
     </div>
-    <% if bot.stopped? %>
+    <% if switchable %>
       <% other_exchanges = bot.available_exchanges_for_current_settings.where.not(id: bot.exchange_id) %>
       <%# A retired venue can never be reconnected — offering "reconnect" would send the user into a
           key wizard that only refuses them. The list of other exchanges is what they need here. %>

--- a/test/controllers/bots/exchange_switcher_test.rb
+++ b/test/controllers/bots/exchange_switcher_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+# The exchange switcher was gated on `stopped?`, so a bot that had never been started — the exact
+# state a bot sits in right after the wizard, and the state a user lands in with a rejected key —
+# got no dropdown at all. Not-working is the gate: `created` and `stopped` both switch freely.
+class ExchangeSwitcherTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, admin: true, setup_completed: true)
+    sign_in @user
+
+    @base = create(:asset, :bitcoin)
+    @quote = create(:asset, :usd)
+    @kraken = create(:kraken_exchange)
+    create(:ticker, exchange: @kraken, base_asset: @base, quote_asset: @quote)
+  end
+
+  def bot_with(status:, with_api_key:)
+    create(:dca_single_asset, status, user: @user, base_asset: @base, quote_asset: @quote,
+                                      with_api_key:)
+  end
+
+  test 'a never-started bot with a disconnected key can still be switched to another exchange' do
+    bot = create(:dca_single_asset, user: @user, base_asset: @base, quote_asset: @quote,
+                                    with_api_key: false)
+
+    get bot_path(id: bot.id)
+
+    assert_response :success
+    assert_match 'dropdown--exchanges', response.body
+    assert_match @kraken.name, response.body
+  end
+
+  test 'a working bot offers no switcher' do
+    bot = bot_with(status: :started, with_api_key: true)
+
+    get bot_path(id: bot.id)
+
+    assert_response :success
+    refute_match 'dropdown--exchanges', response.body
+  end
+end


### PR DESCRIPTION
The exchange switcher on the bot page was gated on `stopped?`. A bot that has never been started is `created`, not `stopped` — which is where every bot sits straight out of the wizard, and where a user lands when the exchange's API key is rejected. In that state the dropdown was not rendered at all, so the only apparent way to move off a venue was to first connect a key to the venue you were trying to leave.

The gate is now `!working?`, matching what `_status_button.html.erb` already does, and the same local drives the `sinput--disabled` class so the button stops reading as dead.

View-only: `validate_bot_exchange` and `validate_unchangeable_exchange` already permit the switch for a `created` bot and block it while orders are open.

Tests: a `created` bot with a disconnected key offers the other venues that carry its pair; a working bot offers no switcher.
