### PR TITLE
Stop the dashboard doing N bots' work per bot

### DIFF
--- a/app/javascript/controllers/broadcast/on_connect_controller.js
+++ b/app/javascript/controllers/broadcast/on_connect_controller.js
@@ -8,8 +8,11 @@ export default class extends Controller {
     method: String,
     methodArgs: Object,
     retryWhile: String,
-    retryAfter: { type: Number, default: 8000 },
-    retryFor: { type: Number, default: 90000 },
+    retryAfter: { type: Number, default: 15000 },
+    // Must OUTLAST the job's own concurrency lock (10 minutes). While a pass is in flight every
+    // retry is discarded server-side, so a horizon shorter than the lock would run out before the
+    // pass could even fail — and a pass that fails after the last retry leaves the loader forever.
+    retryFor: { type: Number, default: 660000 },
   };
 
   connect() {

--- a/app/javascript/controllers/broadcast/on_connect_controller.js
+++ b/app/javascript/controllers/broadcast/on_connect_controller.js
@@ -9,11 +9,11 @@ export default class extends Controller {
     methodArgs: Object,
     retryWhile: String,
     retryAfter: { type: Number, default: 8000 },
-    retryLimit: { type: Number, default: 3 },
+    retryFor: { type: Number, default: 90000 },
   };
 
   connect() {
-    this.attempts = 0;
+    this.deadline = Date.now() + this.retryForValue;
     this.checkConnectionInterval = setInterval(() => {
       if (this.#isConnectedToTurboStreamsChannel()) {
         this.#triggerBroadcast();
@@ -31,8 +31,14 @@ export default class extends Controller {
   // none of which this page would otherwise notice. Until this existed, the only thing clearing
   // a stuck spinner was one of the N per-bot jobs broadcasting the total as a side effect, which
   // is precisely the work that made a large dashboard quadratic.
+  //
+  // Bounded by a DEADLINE, not by a count of attempts: on a cold eighty-bot account the first
+  // pass can outlast several checks, and those checks are discarded server-side by the job's
+  // per-user concurrency lock — counting them would spend the whole budget waiting for a pass
+  // that is still running, leaving nothing for the failure the retry exists to cover. A discarded
+  // request is cheap; a stuck spinner is not.
   #scheduleRetry() {
-    if (!this.hasRetryWhileValue || this.attempts >= this.retryLimitValue) return;
+    if (!this.hasRetryWhileValue || Date.now() >= this.deadline) return;
 
     this.retryTimeout = setTimeout(() => {
       if (!document.querySelector(this.retryWhileValue)) return; // the answer arrived
@@ -42,7 +48,6 @@ export default class extends Controller {
   }
 
   #triggerBroadcast() {
-    this.attempts += 1;
     this.#scheduleRetry();
     fetch(`/${this.#getLocaleFromUrl()}/broadcasts/${this.methodValue}`, {
       method: "POST",

--- a/app/javascript/controllers/broadcast/on_connect_controller.js
+++ b/app/javascript/controllers/broadcast/on_connect_controller.js
@@ -2,22 +2,48 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="broadcast--on-connect"
 export default class extends Controller {
-  static values = { method: String, methodArgs: Object };
+  // retryWhile: a selector that is present ONLY while the answer has not arrived (the global
+  // PnL's spinner). Opt-in, because this controller also drives broadcasts that must fire once.
+  static values = {
+    method: String,
+    methodArgs: Object,
+    retryWhile: String,
+    retryAfter: { type: Number, default: 8000 },
+    retryLimit: { type: Number, default: 3 },
+  };
 
   connect() {
-    // console.log("broadcast--on-connect controller connected");
+    this.attempts = 0;
     this.checkConnectionInterval = setInterval(() => {
       if (this.#isConnectedToTurboStreamsChannel()) {
         this.#triggerBroadcast();
         clearInterval(this.checkConnectionInterval);
-      } else {
-        // console.log("Client is not connected to Turbo::StreamsChannel");
       }
     }, 100);
   }
 
+  disconnect() {
+    clearInterval(this.checkConnectionInterval);
+    clearTimeout(this.retryTimeout);
+  }
+
+  // The request can fail, the job can error, and a broadcast can land during a disconnect —
+  // none of which this page would otherwise notice. Until this existed, the only thing clearing
+  // a stuck spinner was one of the N per-bot jobs broadcasting the total as a side effect, which
+  // is precisely the work that made a large dashboard quadratic.
+  #scheduleRetry() {
+    if (!this.hasRetryWhileValue || this.attempts >= this.retryLimitValue) return;
+
+    this.retryTimeout = setTimeout(() => {
+      if (!document.querySelector(this.retryWhileValue)) return; // the answer arrived
+
+      this.#triggerBroadcast();
+    }, this.retryAfterValue);
+  }
+
   #triggerBroadcast() {
-    // console.log("triggerBroadcast", this.methodValue);
+    this.attempts += 1;
+    this.#scheduleRetry();
     fetch(`/${this.#getLocaleFromUrl()}/broadcasts/${this.methodValue}`, {
       method: "POST",
       headers: {

--- a/app/jobs/user/broadcast_global_pnl_update_job.rb
+++ b/app/jobs/user/broadcast_global_pnl_update_job.rb
@@ -1,5 +1,10 @@
 class User::BroadcastGlobalPnlUpdateJob < ApplicationJob
   queue_as :default
+  # One live pass per user at a time. The dashboard retries this when the figure does not
+  # arrive, and at eighty bots a pass can outlast the retry delay — without this, the retry
+  # would start a second full-account pass instead of waiting for the first. A job that has
+  # already failed is no longer in flight, so a genuine retry still gets through.
+  limits_concurrency to: 1, key: ->(user) { "global_pnl_user_#{user.id}" }, on_conflict: :discard
 
   # Computes the global PnL live (warming the per-bot + FX caches as a side effect) and
   # broadcasts the refreshed `global-pnl` target. Triggered by the /bots index on-connect

--- a/app/jobs/user/broadcast_global_pnl_update_job.rb
+++ b/app/jobs/user/broadcast_global_pnl_update_job.rb
@@ -4,7 +4,11 @@ class User::BroadcastGlobalPnlUpdateJob < ApplicationJob
   # arrive, and at eighty bots a pass can outlast the retry delay — without this, the retry
   # would start a second full-account pass instead of waiting for the first. A job that has
   # already failed is no longer in flight, so a genuine retry still gets through.
-  limits_concurrency to: 1, key: ->(user) { "global_pnl_user_#{user.id}" }, on_conflict: :discard
+  # duration must outlast the worst pass: Solid Queue's maintenance can delete a semaphore once
+  # its duration elapses, even while the job that holds it is still running, which would let a
+  # reload start a second full-account pass.
+  limits_concurrency to: 1, key: ->(user) { "global_pnl_user_#{user.id}" },
+                     on_conflict: :discard, duration: 10.minutes
 
   # Computes the global PnL live (warming the per-bot + FX caches as a side effect) and
   # broadcasts the refreshed `global-pnl` target. Triggered by the /bots index on-connect

--- a/app/models/bots/dca_dual_asset/measurable.rb
+++ b/app/models/bots/dca_dual_asset/measurable.rb
@@ -154,8 +154,11 @@ module Bots::DcaDualAsset::Measurable
       partial: 'bots/bot_tile/bot_tile_pnl',
       locals: { bot: self, pnl: metrics_data[:pnl] || '', loading: false }
     )
-
-    user.broadcast_global_pnl_update
+    # NOT the account total. `User#global_pnl` walks every bot the user owns, and the dashboard
+    # fires one of these jobs per bot — N bots did N x N bots' worth of work, ending in two live
+    # FX conversions each (17.7s warm / 158s cold for fifteen bots). The total is owned by
+    # User::BroadcastGlobalPnlUpdateJob, which the page requests once and which does not depend
+    # on these jobs having run.
   end
 
   def metrics_with_current_prices_from_cache

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -164,12 +164,11 @@ class Bots::DcaIndex < Bot
     @quote_asset ||= Asset.find_by(id: quote_asset_id)
   end
 
+  # Memoized WHOLE, guard included: `tickers` is an unloaded relation, so `any?` is an EXISTS
+  # query every call — and the chart reads this once per data point, which turned one render
+  # into 1457 identical queries.
   def decimals
-    return {} unless tickers.any?
-
-    @decimals ||= {
-      quote: tickers.pluck(:quote_decimals).compact.min
-    }
+    @decimals ||= tickers.any? ? { quote: tickers.pluck(:quote_decimals).compact.min } : {}
   end
 
   # Returns the highest minimum_quote_size among all index tickers.

--- a/app/models/bots/dca_index/measurable.rb
+++ b/app/models/bots/dca_index/measurable.rb
@@ -180,8 +180,11 @@ module Bots::DcaIndex::Measurable
       partial: 'bots/bot_tile/bot_tile_pnl',
       locals: { bot: self, pnl: metrics_data[:pnl] || '', loading: false }
     )
-
-    user.broadcast_global_pnl_update
+    # NOT the account total. `User#global_pnl` walks every bot the user owns, and the dashboard
+    # fires one of these jobs per bot — N bots did N x N bots' worth of work, ending in two live
+    # FX conversions each (17.7s warm / 158s cold for fifteen bots). The total is owned by
+    # User::BroadcastGlobalPnlUpdateJob, which the page requests once and which does not depend
+    # on these jobs having run.
   end
 
   def metrics_with_current_prices_from_cache

--- a/app/models/bots/dca_single_asset/measurable.rb
+++ b/app/models/bots/dca_single_asset/measurable.rb
@@ -154,8 +154,11 @@ module Bots::DcaSingleAsset::Measurable
       partial: 'bots/bot_tile/bot_tile_pnl',
       locals: { bot: self, pnl: metrics_data[:pnl] || '', loading: false }
     )
-
-    user.broadcast_global_pnl_update
+    # NOT the account total. `User#global_pnl` walks every bot the user owns, and the dashboard
+    # fires one of these jobs per bot — N bots did N x N bots' worth of work, ending in two live
+    # FX conversions each (17.7s warm / 158s cold for fifteen bots). The total is owned by
+    # User::BroadcastGlobalPnlUpdateJob, which the page requests once and which does not depend
+    # on these jobs having run.
   end
 
   def metrics_with_current_prices_from_cache

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -7,8 +7,12 @@
   <% end %>
   <%= render partial: 'bots/new_menu_start' %>
 <% else %>
+  <%# The total is asked for ONCE per page load, and asked again only while its spinner is still
+      there — a lost request, a failed job or a broadcast that landed during a disconnect. The
+      per-bot tile jobs no longer broadcast it as a side effect. %>
   <%= tag.section class: 'dash-intro', data: @global_pnl_loading ? { controller: "broadcast--on-connect",
-                                                                     broadcast__on_connect_method_value: "global_pnl_update" } : {} do %>
+                                                                     broadcast__on_connect_method_value: "global_pnl_update",
+                                                                     broadcast__on_connect_retry_while_value: "#global-pnl .loader--small" } : {} do %>
     <%= render partial: 'bots/global_pnl', locals: { global_pnl: @global_pnl, loading: @global_pnl_loading } %>
   <% end %>
   

--- a/test/models/bots/index_decimals_queries_test.rb
+++ b/test/models/bots/index_decimals_queries_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# `decimals` is read per data point while the chart serializes its series, so anything it does
+# per call is multiplied by the length of the history. DcaIndex guarded its memoized body with
+# `tickers.any?` — an EXISTS query on an unloaded relation, so the guard ran every time even
+# though the answer it guarded was computed once: 1457 of the 1463 queries behind one chart
+# render were that single check.
+class Bots::IndexDecimalsQueriesTest < ActiveSupport::TestCase
+  test 'reading decimals repeatedly costs one lookup, not one per read' do
+    bot = create(:dca_index, user: create(:user))
+    # An unloaded relation is the live shape: `tickers` is built as
+    # `exchange.tickers.where(...)` and answers `any?` with an EXISTS query every time.
+    bot.stubs(:tickers).returns(Ticker.where(exchange_id: bot.exchange_id))
+    bot.decimals # first read may look the tickers up
+
+    assert_no_queries do
+      50.times { bot.decimals[:quote] }
+    end
+  end
+
+  test 'a bot with no tickers still answers, and still only asks once' do
+    bot = create(:dca_index, user: create(:user))
+    bot.stubs(:tickers).returns(Ticker.none)
+
+    assert_equal({}, bot.decimals)
+    assert_no_queries { 10.times { bot.decimals } }
+  end
+end

--- a/test/models/bots/pnl_broadcast_scope_test.rb
+++ b/test/models/bots/pnl_broadcast_scope_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# One tile's PnL job must cost one bot, not the whole account.
+#
+# `broadcast_pnl_update` used to end with `user.broadcast_global_pnl_update`, and `User#global_pnl`
+# walks every bot the user owns, computing `metrics_with_current_prices` for any whose cache is
+# cold and finishing with two live FX conversions. The dashboard fires one of these jobs PER BOT,
+# so N bots did N × N bots' worth of work — measured at 17.7s warm and 158s cold for fifteen bots,
+# and it is the accounts with eighty bots that open that page.
+#
+# The global figure is owned by User::BroadcastGlobalPnlUpdateJob, which the page requests once.
+class Bots::PnlBroadcastScopeTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @bot = create(:dca_single_asset, user: @user)
+    @sibling = create(:dca_single_asset, user: @user, exchange: @bot.exchange,
+                                         base_asset: @bot.base_asset, quote_asset: @bot.quote_asset)
+  end
+
+  test 'a tile broadcast never reaches another bot' do
+    @bot.stubs(:metrics_with_current_prices).returns(@bot.metrics)
+    @sibling.expects(:metrics_with_current_prices).never
+    @bot.broadcast_pnl_update
+  end
+
+  test 'a tile broadcast does not recompute the account total' do
+    @bot.stubs(:metrics_with_current_prices).returns(@bot.metrics)
+    User.any_instance.expects(:global_pnl).never
+    User.any_instance.expects(:broadcast_global_pnl_update).never
+
+    @bot.broadcast_pnl_update
+  end
+
+  test 'the account total is still produced by its own job, without any tile job running' do
+    User.any_instance.expects(:broadcast_global_pnl_update).once
+
+    User::BroadcastGlobalPnlUpdateJob.perform_now(@user)
+  end
+
+  # A retry arriving while a pass is still running must not start a second full-account pass.
+  test 'the global job is limited to one in flight per user' do
+    job = User::BroadcastGlobalPnlUpdateJob
+
+    assert_equal 1, job.concurrency_limit
+    assert_equal :discard, job.concurrency_on_conflict
+    assert_equal 'global_pnl_user_7', job.concurrency_key.call(User.new(id: 7))
+  end
+end

--- a/test/models/bots/pnl_broadcast_scope_test.rb
+++ b/test/models/bots/pnl_broadcast_scope_test.rb
@@ -46,5 +46,8 @@ class Bots::PnlBroadcastScopeTest < ActiveSupport::TestCase
     assert_equal 1, job.concurrency_limit
     assert_equal :discard, job.concurrency_on_conflict
     assert_equal 'global_pnl_user_7', job.concurrency_key.call(User.new(id: 7))
+    # Long enough to outlast a cold pass over a large account — Solid Queue can drop a semaphore
+    # whose duration has elapsed while its holder is still running.
+    assert_operator job.concurrency_duration, :>=, 5.minutes
   end
 end


### PR DESCRIPTION
Opening `/bots` fires one `Bot::BroadcastPnlUpdateJob` per bot, and each of those ended with `user.broadcast_global_pnl_update`. `User#global_pnl` walks **every** bot the account owns — computing `metrics_with_current_prices` for any whose cache is cold, then two live FX conversions — so **N bots did N × N bots' worth of work**, for a figure that is identical every time.

Measured on a 15-bot account:

| | warm caches | cold caches |
|---|---|---|
| one `global_pnl` | 1.18s | 10.5s |
| × once per bot | **17.7s** | **158s** |

The accounts with eighty bots are exactly the ones that open that page, and there it is 80 × 80.

## What changed

**The per-bot job broadcasts its own tile and nothing else.** The total is already owned by `User::BroadcastGlobalPnlUpdateJob`, which the page requests once on connect and which does not depend on the per-bot jobs — `global_pnl` computes what it cannot read. Work per dashboard load goes from *N jobs × N bots* to *N jobs of one bot each, plus one pass over N*.

**Those N broadcasts were also an accidental retry.** If the one request failed, the job errored, or a broadcast landed during a Cable disconnect, another job used to clear the spinner. That is now explicit: the on-connect controller re-requests while the target still shows its loader, opt-in per element so the other broadcasts still fire exactly once, and the timer is cleared on disconnect. It is bounded by a **deadline rather than an attempt count** — while a pass is in flight every retry is discarded server-side, so counting them would spend the budget waiting for a pass that is still running, and the horizon deliberately outlasts the job's lock.

**The job takes a per-user concurrency limit** (`on_conflict: :discard`) so a retry arriving mid-pass is dropped instead of starting a second full-account pass, with a duration that outlasts the worst case — Solid Queue can otherwise delete a semaphore while its holder is still running.

**`DcaIndex#decimals` memoized its body but not its guard.** `tickers` is an unloaded relation, so `tickers.any?` ran an EXISTS query on every call — and the chart reads `decimals` once per data point. One chart render was 1463 queries, **1457 of them that single check**. Single-asset and dual-asset bots memoize their ticker and were never affected.

## Result

| | before | after |
|---|---|---|
| `/bots` tile fan-out (15 bots, warm) | 1.83s | **0.10s** |
| one index-bot chart render | 1462 queries | **6** |

The fan-out is now linear, so the gap widens with bot count rather than scaling with it.

## Deliberately not in this PR

- **The candle cache is keyed by `since`**, which comes from each bot's first transaction, so two bots holding the same ticker never share a series: 1320 series fetched where 795 would do. Re-keying on `(ticker, timeframe)` is a range-coverage problem, not a key change — backward coverage checked before the freshness return, head and tail merged rather than overwritten, every path sliced to the caller's `since`, and the earliest *covered* point stored separately from `candles.first` so a limited-history venue does not retry an impossible extension forever. Own branch.
- **The bot tile costs ~5.7 queries per bot** (~456 on an eighty-bot page): one API-key lookup and one `AppConfig` read per bot, plus `invalid?(:start)`, `next_action_job_at` hitting Solid Queue, and a last-transaction query on retrying tiles. The fix is to prepare the collection's rows once, not to sprinkle `includes` — `Bot#assets` and `#tickers` are scoped methods, not associations.
- **An already-open dashboard still does not refresh a tile after a trade.** `UpdateMetricsJob` broadcasts only the show page's targets. Pre-existing; a coalesced enqueue from the transaction path is its own change.
- The 1-minute per-exchange price cache has no lock, so jobs starting together on a cold cache can each pull the whole market. This PR removes most of that pressure by removing the N× global recompute.

Plan reviewed with Codex across four rounds, the code across three.
