### PR TITLE
Archive bots

### DIFF
--- a/app/controllers/bots/archives_controller.rb
+++ b/app/controllers/bots/archives_controller.rb
@@ -1,0 +1,30 @@
+class Bots::ArchivesController < ApplicationController
+  include Bots::Botable
+
+  before_action :authenticate_user!
+  before_action :set_bot
+
+  def edit; end
+
+  def create
+    return render_error unless @bot.archive
+
+    render :update
+  end
+
+  # Reactivating is the one transition that can move the bot off the page it was clicked on: from
+  # ?filter=archived it leaves the list (and may take the filter with it). Refresh rather than
+  # patch widgets into a tile that no longer belongs there.
+  def destroy
+    return render_error unless @bot.unarchive
+
+    render turbo_stream: turbo_stream_page_refresh
+  end
+
+  private
+
+  def render_error
+    flash.now[:alert] = @bot.errors.messages.values.flatten.to_sentence
+    render turbo_stream: turbo_stream_prepend_flash, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -16,19 +16,22 @@ class BotsController < ApplicationController
     end
 
     @filter = params[:filter] || 'all'
-    @bots = non_deleted_bots.includes(:exchange)
-    case @filter
-    when 'active'
-      @bots = @bots.working
-    when 'inactive'
-      @bots = @bots.where(status: %i[created stopped])
-    end
+    scope = non_deleted_bots.includes(:exchange)
+    @bots = case @filter
+            when 'active' then scope.working
+            when 'inactive' then scope.where(status: %i[created stopped])
+            when 'archived' then scope.archived
+            else scope.not_archived
+            end
     @bots = @bots.order(label: :asc)
 
-    @total_bots = current_user.bots.not_deleted.size
+    @total_bots = current_user.bots.not_deleted.not_archived.size
     @has_active = current_user.bots.not_deleted.working.exists?
     @has_inactive = current_user.bots.not_deleted.where(status: %i[created stopped]).exists?
-    @show_filters = @total_bots > 1 && @has_active && @has_inactive
+    @has_archived = current_user.bots.archived.exists?
+    # Archived bots are reachable through their own filter only, so its presence alone has to be
+    # enough to show the row — otherwise archiving would put a bot somewhere with no way back.
+    @show_filters = (@total_bots > 1 && @has_active && @has_inactive) || @has_archived
 
     @pnl_hash = {}
     @loading_hash = {}
@@ -64,7 +67,7 @@ class BotsController < ApplicationController
       permitted_params = params.require(:decimals).permit(*Asset.all.pluck(:symbol))
       @decimals = permitted_params.transform_values(&:to_i)
     else
-      @other_bots = current_user.bots.not_deleted.order(label: :asc).where.not(id: @bot.id).pluck(:id, :label, :type)
+      @other_bots = current_user.bots.not_deleted.not_archived.order(label: :asc).where.not(id: @bot.id).pluck(:id, :label, :type)
 
       # TODO: When transactions point to real asset ids, we can use the asset ids directly instead of symbols
       if @bot.dca_single_asset?

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -598,7 +598,7 @@ class SettingsController < ApplicationController
   end
 
   def stop_working_bots(api_key)
-    current_user.bots.not_deleted.not_stopped.each do |bot|
+    current_user.bots.working.each do |bot|
       next unless same_exchange_and_type?(bot, api_key)
 
       bot.stop

--- a/app/jobs/bot/action_job.rb
+++ b/app/jobs/bot/action_job.rb
@@ -42,12 +42,13 @@ class Bot::ActionJob < BotJob
   # A stop or delete from another process (user click, admin stock deactivation sweep) can land
   # while this job is mid-flight on a stale bot instance; Stop's cancel can't reach a Claimed
   # (running) execution, and a check-then-update! would leave a resurrection window. The
-  # conditional UPDATE closes it: the flip only happens if no stop/delete won the race, and the
-  # caller branches on the outcome. Skipped callbacks are covered on every call site: the status
+  # conditional UPDATE closes it: the flip only happens while the row is still in a working
+  # status — a stop, delete or archive that won the race leaves it out of scope — and the caller
+  # branches on the outcome. Skipped callbacks are covered on every call site: the status
   # bar is (re)broadcast by BroadcastAfterScheduledActionJob or explicitly, and the
   # button/columns-lock UI does not differ between working statuses.
   def self.transition_working_bot!(bot, status)
-    updated = Bot.where(id: bot.id).where.not(status: %w[stopped deleted])
+    updated = Bot.where(id: bot.id).working
                  .update_all(status: status, updated_at: Time.current) == 1
     # Sync the attribute without reload — reload would drop memoized associations; only the
     # status column changed, and no later save runs on these paths.

--- a/app/mcp/tools/get_portfolio_summary_tool.rb
+++ b/app/mcp/tools/get_portfolio_summary_tool.rb
@@ -24,7 +24,9 @@ class GetPortfolioSummaryTool < ApplicationMCPTool
     totals = data[:totals]
     lines << 'Portfolio Summary'
     lines << '================'
-    lines << "Total bots: #{totals[:total]} (#{totals[:working]} active, #{totals[:stopped]} stopped, #{totals[:created]} not started)"
+    buckets = ["#{totals[:working]} active", "#{totals[:stopped]} stopped", "#{totals[:created]} not started"]
+    buckets << "#{totals[:archived]} archived" if totals[:archived].to_i.positive?
+    lines << "Total bots: #{totals[:total]} (#{buckets.join(', ')})"
     lines << ''
     lines.concat(global_pnl_lines(data[:global_pnl]))
     lines << ''

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -115,7 +115,7 @@ class ApiKey < ApplicationRecord
   def stop_dependent_bots!
     return unless trading?
 
-    user.bots.not_deleted.not_stopped.each do |bot|
+    user.bots.working.each do |bot|
       bot.stop if bot.exchange_id == exchange_id
     end
   end

--- a/app/models/automation/statusable.rb
+++ b/app/models/automation/statusable.rb
@@ -2,7 +2,8 @@ module Automation::Statusable
   extend ActiveSupport::Concern
 
   included do
-    enum :status, %i[created scheduled stopped deleted executing retrying waiting]
+    # `archived` is appended, never inserted: the column stores the position.
+    enum :status, %i[created scheduled stopped deleted executing retrying waiting archived]
 
     scope :working, -> { where(status: %i[scheduled executing retrying waiting]) }
   end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -17,6 +17,10 @@ class Bot < ApplicationRecord
   belongs_to :user
   has_many :transactions, dependent: :destroy
 
+  # Every start path — the button, a stale tab, BotApi::Bots::Start — goes through valid?(:start),
+  # so one validation is the whole gate: an archived bot is reactivated first or not at all.
+  validate :not_archived, on: :start
+
   before_save :store_previous_exchange_id
   after_update_commit :broadcast_status_bar_update, if: -> { saved_change_to_status? && !@skip_status_bar_broadcast }
   after_update_commit :broadcast_status_button_update, if: :saved_change_to_status?
@@ -49,6 +53,33 @@ class Bot < ApplicationRecord
   def stale(metrics_data)
     metrics_data[:prices_stale] = true
     metrics_data
+  end
+
+  # Hidden from the list, keeps its history, trades nothing. Archiving goes through #stop so the
+  # job cancellation and the settings-dirty guard stay in one place — an archived bot must never
+  # leave a tick scheduled behind it.
+  def archive
+    stop && update(status: :archived)
+  end
+
+  # status_was, not archived?: both #start implementations assign :scheduled before they validate,
+  # so the only place the archive is still visible at validation time is the persisted value.
+  def not_archived
+    errors.add(:status, :archived, message: I18n.t('errors.bots.archived')) if status_was == 'archived'
+  end
+
+  # Always :stopped, never :created — a never-run bot renders identically either way (no
+  # last_action_job_at, so a plain fresh Start), while :created is the one status that would put
+  # the bot back under validate_bot_exchange and refuse to reactivate a delisted pair. Reading
+  # started_at to tell the two apart would not work anyway: the limit concerns decorate it.
+  #
+  # Idempotent on purpose: a stale second Reactivate (double click, retried request) must not
+  # write :stopped over a bot that has since been started again — that would halt it without
+  # cancelling its scheduled tick.
+  def unarchive
+    return true unless archived?
+
+    update(status: :stopped)
   end
 
   def last_transaction

--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -104,7 +104,7 @@ module Bot::AssetConfigurable
   end
 
   def validate_bot_exchange
-    return if stopped? || deleted?
+    return if stopped? || deleted? || archived?
     return if exchange_supports_current_assets?
 
     errors.add(:exchange, :unsupported, message: I18n.t('errors.bots.exchange_asset_mismatch', exchange_name: exchange.name))

--- a/app/models/bot/lifecycle.rb
+++ b/app/models/bot/lifecycle.rb
@@ -57,7 +57,7 @@ module Bot::Lifecycle
       # ones. A job already running cannot be cancelled, so a stop-then-restart landing inside that
       # execution window leaves the in-flight job to finish against stale in-memory state and
       # reschedule itself — re-creating the second chain this call exists to prevent.
-      # transition_working_bot! does not close it either: it excludes stopped/deleted, but a
+      # transition_working_bot! does not close it either: it requires a working status, but a
       # restart has already flipped the row back to :scheduled. Closing it properly needs an
       # execution fence (a generation counter bumped here and re-checked before the job's final
       # writes), which is a schema change and deliberately not bolted on here.
@@ -79,6 +79,10 @@ module Bot::Lifecycle
   end
 
   def stop(stop_message_key: nil)
+    # A stop that lands after archiving — a queued Bot::StopJob, a stale tab — must not write
+    # :stopped over :archived and drop the bot back into Inactive. It is already stopped.
+    return true if archived?
+
     # A freshly loaded bot can carry recomputed settings defaults (after_initialize
     # concerns), which marks settings dirty — Accountable then requires
     # set_missed_quote_amount before any save (same guard start uses above).

--- a/app/models/bots/signal.rb
+++ b/app/models/bots/signal.rb
@@ -48,6 +48,10 @@ class Bots::Signal < Bot
   end
 
   def stop(stop_message_key: nil)
+    # A stop that lands after archiving — a queued Bot::StopJob, a stale tab — must not write
+    # :stopped over :archived and drop the bot back into Inactive. It is already stopped.
+    return true if archived?
+
     if update(
       status: :stopped,
       stopped_at: Time.current,

--- a/app/services/bot_api/portfolio/summary.rb
+++ b/app/services/bot_api/portfolio/summary.rb
@@ -33,7 +33,8 @@ module BotApi
           total: bots.size,
           working: bots.count(&:working?),
           stopped: bots.where(status: :stopped).count,
-          created: bots.where(status: :created).count
+          created: bots.where(status: :created).count,
+          archived: bots.where(status: :archived).count
         }
       end
 

--- a/app/views/bots/_header.html.erb
+++ b/app/views/bots/_header.html.erb
@@ -13,13 +13,4 @@
     <% end %>
   </div>
 </div>
-<div class="flex-row">
-  <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="sbutton sbutton--link dropdown-wrapper dropdown-wrapper--right">
-    <%= render "svg/24x24_dot_menu" %>
-    <div class="dropdown">
-      <%= link_to t('utils.change_name'), edit_bot_path(bot), class: "dropdown__item", data: { turbo_frame: "modal" } %>
-      <div class="dropdown__item dropdown__item--divider"></div>
-      <%= link_to t('button.delete'), edit_bot_delete_path(bot), class: "dropdown__item dropdown__item--danger", data: { turbo_frame: "modal" } %>
-    </div>
-  </div>
-</div>
+<%= render "bots/menu", bot: bot %>

--- a/app/views/bots/_menu.html.erb
+++ b/app/views/bots/_menu.html.erb
@@ -1,0 +1,15 @@
+<%# Its own partial with its own id: archiving and reactivating swap the Archive entry in and out,
+    and the archive response replaces this along with the status widgets. %>
+<%= tag.div class: "flex-row", id: dom_id(bot, :menu) do %>
+  <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="sbutton sbutton--link dropdown-wrapper dropdown-wrapper--right">
+    <%= render "svg/24x24_dot_menu" %>
+    <div class="dropdown">
+      <%= link_to t('utils.change_name'), edit_bot_path(bot), class: "dropdown__item", data: { turbo_frame: "modal" } %>
+      <% unless bot.archived? %>
+        <%= link_to t('button.archive'), edit_bot_archive_path(bot), class: "dropdown__item", data: { turbo_frame: "modal" } %>
+      <% end %>
+      <div class="dropdown__item dropdown__item--divider"></div>
+      <%= link_to t('button.delete'), edit_bot_delete_path(bot), class: "dropdown__item dropdown__item--danger", data: { turbo_frame: "modal" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bots/archives/edit.html.erb
+++ b/app/views/bots/archives/edit.html.erb
@@ -1,0 +1,24 @@
+<%= render 'layouts/modal/base' do %>
+  <div class="modal">
+    <%= button_tag type: 'button', class: 'modal__close', data: { action: 'modal--base#animateOutCloseAndCleanUp' } do %>
+      <%= render partial: 'svg/24x24_close' %>
+    <% end %>
+    <div class="modal__header">
+      <h1 class="modal__title"><%= @bot.label %></h1>
+    </div>
+    <div class="modal__body text-center">
+      <p>
+        <%= t('bot.messages.do_you_want_to_archive') %>
+      </p>
+      <div class="buttons buttons--row--2">
+        <%= button_tag type: 'button', class: 'button button--outline button--large', data: { action: 'modal--base#animateOutCloseAndCleanUp' } do %>
+          <%= t('button.cancel') %>
+        <% end %>
+        <%# Unlike Delete this stays on the page, so the modal has to close itself on success. %>
+        <%= button_to t('button.archive'), bot_archive_path(@bot), method: :post,
+                      class: 'button button--success button--large',
+                      form: { data: { action: 'turbo:submit-end->modal--base#submitEnd' } } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bots/archives/update.turbo_stream.erb
+++ b/app/views/bots/archives/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%# Archiving and reactivating both change nothing but the two status widgets — the bot page and
+    every tile render them from the same partials. %>
+<%= turbo_stream.replace dom_id(@bot, :status_bar), partial: 'bots/status/status_bar', locals: { bot: @bot } %>
+<%= turbo_stream.replace dom_id(@bot, :status_button), partial: 'bots/status/status_button', locals: { bot: @bot } %>
+<%= turbo_stream.replace dom_id(@bot, :menu), partial: 'bots/menu', locals: { bot: @bot } %>

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -1,6 +1,7 @@
 <%= turbo_stream_from "user_#{current_user.id}", :bot_updates %>
 
-<% if @bots.empty? %>
+<%# Not @bots.empty?: a user whose bots are all archived still has bots, and needs the filter row. %>
+<% if @total_bots.zero? && !@has_archived %>
   <% if @auto_open_dca %>
     <% content_for :modal_src, new_bots_dca_single_assets_pick_buyable_asset_path(auto_open: true) %>
     <% content_for :hide_chrome, true %>
@@ -22,7 +23,7 @@
           pad the short label out of proportion. %>
       <% if @show_filters %>
         <%= render 'shared/segmented', fluid: true, label: t('bot_filters.all'),
-                   options: %w[all active inactive].map { |filter|
+                   options: (%w[all active inactive] + (@has_archived ? %w[archived] : [])).map { |filter|
                      { value: filter, label: t("bot_filters.#{filter}"),
                        href: bots_path(filter: filter), active: @filter == filter }
                    } %>

--- a/app/views/bots/status/_status_bar.html.erb
+++ b/app/views/bots/status/_status_bar.html.erb
@@ -1,5 +1,9 @@
 <div id="<%= dom_id(bot, :status_bar) %>" class="bot-control__status <%= 'active' if bot.scheduled? %>" data-controller="marquee" style="display: flex;">
-  <% if bot.executing? %>
+  <% if bot.archived? %>
+    <div class="bot-control__status__text" data-marquee-target="text">
+      <%= t('bot.status.archived') %>
+    </div>
+  <% elsif bot.executing? %>
     <div class="bot-control__status__text" data-marquee-target="text">
       <%= t('bot.status.setting_orders') %>
     </div>

--- a/app/views/bots/status/_status_button.html.erb
+++ b/app/views/bots/status/_status_button.html.erb
@@ -1,32 +1,39 @@
 <%= tag.div id: dom_id(bot, :status_button) do %>
-  <%# Fix C: a disabled start button (button_to never submits) is otherwise a silent freeze. When the
-      block is a temporarily-unavailable ticker, surface the reason right next to the button. %>
-  <% if (bot.stopped? || bot.created? || bot.restarting?) && bot.start_blocked_by_unavailable_ticker? %>
-    <p class="status-button__hint" role="status">
-      <%= t('errors.bots.exchange_asset_mismatch', exchange_name: bot.exchange&.name) %>
-    </p>
-  <% end %>
-  <% if !bot.stopped? && !bot.created? %>
-    <%= button_to bot_stop_path(bot), method: :patch, class: "sbutton sbutton--sky sbutton--outline", data: { hw_animate_out: "animate-button-to-start-shape", turbo_frame: "_top" }, aria: { label: t('button.stop') } do %>
-      <div class="animicon animicon--stop">
-        <div class="animicon__a"></div>
-        <div class="animicon__b"></div>
-      </div>
-    <% end %>
+  <% if bot.archived? %>
+    <%# The Start button's slot, reading Reactivate: one click puts the bot back where archiving
+        found it, and only then can it be started again. %>
+    <%= button_to t('button.reactivate'), bot_archive_path(bot), method: :delete,
+                  class: "sbutton sbutton--success", data: { turbo_frame: "_top" } %>
   <% else %>
-    <% if bot.restarting? %>
-      <%= button_to edit_bot_start_path(bot), method: :get, class: "sbutton sbutton--success", data: { hw_animate_out: "animate-button-to-stop-shape", turbo_frame: "modal" }, disabled: bot.invalid?(:start) || !bot.api_key.correct?, aria: { label: t('button.start') } do %>
-        <div class="animicon animicon--start">
+    <%# Fix C: a disabled start button (button_to never submits) is otherwise a silent freeze. When the
+        block is a temporarily-unavailable ticker, surface the reason right next to the button. %>
+    <% if (bot.stopped? || bot.created? || bot.restarting?) && bot.start_blocked_by_unavailable_ticker? %>
+      <p class="status-button__hint" role="status">
+        <%= t('errors.bots.exchange_asset_mismatch', exchange_name: bot.exchange&.name) %>
+      </p>
+    <% end %>
+    <% if !bot.stopped? && !bot.created? %>
+      <%= button_to bot_stop_path(bot), method: :patch, class: "sbutton sbutton--sky sbutton--outline", data: { hw_animate_out: "animate-button-to-start-shape", turbo_frame: "_top" }, aria: { label: t('button.stop') } do %>
+        <div class="animicon animicon--stop">
           <div class="animicon__a"></div>
           <div class="animicon__b"></div>
         </div>
       <% end %>
     <% else %>
-      <%= button_to bot_start_path(bot, start_fresh: true), method: :patch, class: "sbutton sbutton--success", data: { hw_animate_out: "animate-button-to-stop-shape", turbo_frame: "_top" }, disabled: bot.invalid?(:start) || !bot.api_key.correct?, aria: { label: t('button.start') } do %>
-        <div class="animicon animicon--start">
-          <div class="animicon__a"></div>
-          <div class="animicon__b"></div>
-        </div>
+      <% if bot.restarting? %>
+        <%= button_to edit_bot_start_path(bot), method: :get, class: "sbutton sbutton--success", data: { hw_animate_out: "animate-button-to-stop-shape", turbo_frame: "modal" }, disabled: bot.invalid?(:start) || !bot.api_key.correct?, aria: { label: t('button.start') } do %>
+          <div class="animicon animicon--start">
+            <div class="animicon__a"></div>
+            <div class="animicon__b"></div>
+          </div>
+        <% end %>
+      <% else %>
+        <%= button_to bot_start_path(bot, start_fresh: true), method: :patch, class: "sbutton sbutton--success", data: { hw_animate_out: "animate-button-to-stop-shape", turbo_frame: "_top" }, disabled: bot.invalid?(:start) || !bot.api_key.correct?, aria: { label: t('button.start') } do %>
+          <div class="animicon animicon--start">
+            <div class="animicon__a"></div>
+            <div class="animicon__b"></div>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -17,6 +17,8 @@ bg:
         authorize: 'Оторизирай'
         disable: 'Изключи'
         delete: 'Изтрий'
+        archive: 'Архивирай'
+        reactivate: 'Възстанови'
         duplicate: 'Дублирай'
         copy: 'Копирай'
         submit: 'Изпрати'
@@ -350,6 +352,7 @@ bg:
         all: 'Всички'
         active: 'Активни'
         inactive: 'Неактивни'
+        archived: 'Архивирани'
     rules:
         index:
             title: 'Правила'

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -17,6 +17,8 @@ cs:
         authorize: 'Autorizovat'
         disable: 'Vypnout'
         delete: 'Smazat'
+        archive: 'Archivovat'
+        reactivate: 'Obnovit'
         duplicate: 'Duplikovat'
         copy: 'Kopírovat'
         submit: 'Odeslat'
@@ -357,6 +359,7 @@ cs:
         all: 'Vše'
         active: 'Aktivní'
         inactive: 'Neaktivní'
+        archived: 'Archivované'
     rules:
         index:
             title: 'Pravidla'

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -17,6 +17,8 @@ da:
         authorize: 'Godkend'
         disable: 'Deaktivér'
         delete: 'Slet'
+        archive: 'Arkivér'
+        reactivate: 'Genaktivér'
         duplicate: 'Duplikér'
         copy: 'Kopiér'
         submit: 'Send'
@@ -350,6 +352,7 @@ da:
         all: 'Alle'
         active: 'Aktive'
         inactive: 'Inaktive'
+        archived: 'Arkiverede'
     rules:
         index:
             title: 'Regler'

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -17,6 +17,8 @@ de:
         authorize: 'Autorisieren'
         disable: 'Deaktivieren'
         delete: 'Löschen'
+        archive: 'Archivieren'
+        reactivate: 'Reaktivieren'
         duplicate: 'Duplizieren'
         copy: 'Kopieren'
         submit: 'Senden'
@@ -349,6 +351,7 @@ de:
         all: 'Alle'
         active: 'Aktiv'
         inactive: 'Inaktiv'
+        archived: 'Archiviert'
     rules:
         index:
             title: 'Regeln'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -17,6 +17,8 @@ el:
         authorize: 'Εξουσιοδότηση'
         disable: 'Απενεργοποίηση'
         delete: 'Διαγραφή'
+        archive: 'Αρχειοθέτηση'
+        reactivate: 'Επαναφορά'
         duplicate: 'Αντιγραφή'
         copy: 'Αντιγραφή'
         submit: 'Υποβολή'
@@ -350,6 +352,7 @@ el:
         all: 'Όλα'
         active: 'Ενεργά'
         inactive: 'Ανενεργά'
+        archived: 'Αρχειοθετημένα'
     rules:
         index:
             title: 'Κανόνες'

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -17,6 +17,8 @@ en:
         authorize: 'Authorize'
         disable: 'Disable'
         delete: 'Delete'
+        archive: 'Archive'
+        reactivate: 'Reactivate'
         duplicate: 'Duplicate'
         copy: 'Copy'
         submit: 'Submit'
@@ -350,6 +352,7 @@ en:
         all: 'All'
         active: 'Active'
         inactive: 'Inactive'
+        archived: 'Archived'
     rules:
         index:
             title: 'Rules'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -17,6 +17,8 @@ es:
         authorize: 'Autorizar'
         disable: 'Desactivar'
         delete: 'Eliminar'
+        archive: 'Archivar'
+        reactivate: 'Reactivar'
         duplicate: 'Duplicar'
         copy: 'Copiar'
         submit: 'Enviar'
@@ -349,6 +351,7 @@ es:
         all: 'Todos'
         active: 'Activos'
         inactive: 'Inactivos'
+        archived: 'Archivados'
     rules:
         index:
             title: 'Reglas'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -17,6 +17,8 @@ fr:
         authorize: 'Autoriser'
         disable: 'Désactiver'
         delete: 'Supprimer'
+        archive: 'Archiver'
+        reactivate: 'Réactiver'
         duplicate: 'Dupliquer'
         copy: 'Copier'
         submit: 'Soumettre'
@@ -349,6 +351,7 @@ fr:
         all: 'Tous'
         active: 'Actifs'
         inactive: 'Inactifs'
+        archived: 'Archivés'
     rules:
         index:
             title: 'Règles'

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -17,6 +17,8 @@ it:
         authorize: 'Autorizza'
         disable: 'Disabilita'
         delete: 'Elimina'
+        archive: 'Archivia'
+        reactivate: 'Riattiva'
         duplicate: 'Duplica'
         copy: 'Copia'
         submit: 'Invia'
@@ -349,6 +351,7 @@ it:
         all: 'Tutti'
         active: 'Attivi'
         inactive: 'Inattivi'
+        archived: 'Archiviati'
     rules:
         index:
             title: 'Regole'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -17,6 +17,8 @@ nl:
         authorize: 'Autoriseren'
         disable: 'Uitschakelen'
         delete: 'Verwijderen'
+        archive: 'Archiveren'
+        reactivate: 'Heractiveren'
         duplicate: 'Dupliceren'
         copy: 'Kopiëren'
         submit: 'Verzenden'
@@ -349,6 +351,7 @@ nl:
         all: 'Alle'
         active: 'Actief'
         inactive: 'Inactief'
+        archived: 'Gearchiveerd'
     rules:
         index:
             title: 'Regels'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -17,6 +17,8 @@ pl:
         authorize: 'Autoryzuj'
         disable: 'Wyłącz'
         delete: 'Usuń'
+        archive: 'Archiwizuj'
+        reactivate: 'Przywróć'
         duplicate: 'Duplikuj'
         copy: 'Kopiuj'
         submit: 'Wyślij'
@@ -351,6 +353,7 @@ pl:
         all: 'Wszystkie'
         active: 'Aktywne'
         inactive: 'Nieaktywne'
+        archived: 'Zarchiwizowane'
     rules:
         index:
             title: 'Reguły'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -17,6 +17,8 @@ pt:
         authorize: 'Autorizar'
         disable: 'Desativar'
         delete: 'Eliminar'
+        archive: 'Arquivar'
+        reactivate: 'Reativar'
         duplicate: 'Duplicar'
         copy: 'Copiar'
         submit: 'Enviar'
@@ -348,6 +350,7 @@ pt:
         all: 'Todos'
         active: 'Ativos'
         inactive: 'Inativos'
+        archived: 'Arquivados'
     rules:
         index:
             title: 'Regras'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -17,6 +17,8 @@ ru:
         authorize: 'Авторизовать'
         disable: 'Выключить'
         delete: 'Удалить'
+        archive: 'В архив'
+        reactivate: 'Восстановить'
         duplicate: 'Дублировать'
         copy: 'Копировать'
         submit: 'Отправить'
@@ -352,6 +354,7 @@ ru:
         all: 'Все'
         active: 'Активные'
         inactive: 'Неактивные'
+        archived: 'В архиве'
     rules:
         index:
             title: 'Правила'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -17,6 +17,8 @@ sk:
         authorize: 'Autorizovať'
         disable: 'Vypnúť'
         delete: 'Zmazať'
+        archive: 'Archivovať'
+        reactivate: 'Obnoviť'
         duplicate: 'Duplikovať'
         copy: 'Kopírovať'
         submit: 'Odoslať'
@@ -357,6 +359,7 @@ sk:
         all: 'Všetky'
         active: 'Aktívne'
         inactive: 'Neaktívne'
+        archived: 'Archivované'
     rules:
         index:
             title: 'Pravidlá'

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -17,6 +17,8 @@ sv:
         authorize: 'Auktorisera'
         disable: 'Inaktivera'
         delete: 'Ta bort'
+        archive: 'Arkivera'
+        reactivate: 'Återaktivera'
         duplicate: 'Duplicera'
         copy: 'Kopiera'
         submit: 'Skicka'
@@ -350,6 +352,7 @@ sv:
         all: 'Alla'
         active: 'Aktiva'
         inactive: 'Inaktiva'
+        archived: 'Arkiverade'
     rules:
         index:
             title: 'Regler'

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -64,6 +64,7 @@ bg:
             exchange_retired: 'Тази борса вече не работи — прехвърли бота към друга.'
             setting_orders: "Подаване на поръчки…"
             paused: "На пауза"
+            archived: "Архивиран"
             next_try: "Следващ опит след"
             waiting: "Изчакване за изпълнение на всички условия"
             listening: "Слушам"
@@ -172,6 +173,7 @@ bg:
         limit_sell: 'Лимитирана продажба'
         messages:
             do_you_want_to_delete: 'Искате ли да изтриете този бот?'
+            do_you_want_to_archive: 'Искате ли да архивирате този бот?'
             symbol_not_supported: "%{symbol} не се поддържа"
             specify_percentage_limit_order: "При създаване на лимитирана поръчка задайте процент"
             smart_intervals_above_minimum: "Стойността на умните интервали трябва да е по-висока от %{minimum}"

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -64,6 +64,7 @@ cs:
             exchange_retired: 'Tato burza už nefunguje — přesuň bota na jinou.'
             setting_orders: "Zadávání příkazů…"
             paused: "Pozastaveno"
+            archived: "Archivováno"
             next_try: "Další pokus za"
             waiting: "Čekání na splnění všech podmínek"
             listening: "Naslouchám"
@@ -172,6 +173,7 @@ cs:
         limit_sell: 'Limitní prodej'
         messages:
             do_you_want_to_delete: 'Chcete smazat tohoto bota?'
+            do_you_want_to_archive: 'Chcete archivovat tohoto bota?'
             symbol_not_supported: "%{symbol} není podporován"
             specify_percentage_limit_order: "Při vytváření limitního příkazu zadejte procento"
             smart_intervals_above_minimum: "Hodnota chytrých intervalů musí být vyšší než %{minimum}"

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -64,6 +64,7 @@ da:
             exchange_retired: 'Denne børs findes ikke længere — flyt botten til en anden.'
             setting_orders: "Opretter ordrer…"
             paused: "Sat på pause"
+            archived: "Arkiveret"
             next_try: "Næste forsøg om"
             waiting: "Venter på, at alle betingelser opfyldes"
             listening: "Lytter"
@@ -172,6 +173,7 @@ da:
         limit_sell: 'Limitsalg'
         messages:
             do_you_want_to_delete: 'Vil du slette denne bot?'
+            do_you_want_to_archive: 'Vil du arkivere denne bot?'
             symbol_not_supported: "%{symbol} understøttes ikke"
             specify_percentage_limit_order: "Angiv en procentdel for limitordrer"
             smart_intervals_above_minimum: "Smarte intervallers værdi skal være større end %{minimum}"

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -57,6 +57,7 @@ de:
             exchange_retired: 'Diese Börse gibt es nicht mehr — wechsle den Bot zu einer anderen.'
             setting_orders: "Orders werden erstellt…"
             paused: "Pausiert"
+            archived: "Archiviert"
             next_try: "Nächster Versuch in"
             waiting: "Warten bis alle Bedingungen erfüllt sind"
             listening: "Empfangsbereit"
@@ -156,6 +157,7 @@ de:
         limit_sell: 'Limit Verkauf'
         messages:
             do_you_want_to_delete: 'Möchtest du diesen Bot löschen?'
+            do_you_want_to_archive: 'Möchtest du diesen Bot archivieren?'
             symbol_not_supported: "%{symbol} wird nicht unterstützt"
             specify_percentage_limit_order: "Gib den Prozentsatz bei der Erstellung einer Limit-Order an"
             smart_intervals_above_minimum: "Der Wert der intelligenten Intervalle sollte größer als %{minimum} sein"

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -64,6 +64,7 @@ el:
             exchange_retired: 'Αυτό το ανταλλακτήριο δεν λειτουργεί πλέον — μετέφερε το bot σε άλλο.'
             setting_orders: "Ρύθμιση εντολών…"
             paused: "Σε παύση"
+            archived: "Αρχειοθετημένο"
             next_try: "Επόμενη προσπάθεια σε"
             waiting: "Αναμονή για πλήρωση όλων των συνθηκών"
             listening: "Σε ακρόαση"
@@ -172,6 +173,7 @@ el:
         limit_sell: 'Πώληση limit'
         messages:
             do_you_want_to_delete: 'Θέλεις να διαγράψεις αυτό το bot;'
+            do_you_want_to_archive: 'Θέλεις να αρχειοθετήσεις αυτό το bot;'
             symbol_not_supported: "Το %{symbol} δεν υποστηρίζεται"
             specify_percentage_limit_order: "Όρισε ποσοστό κατά τη δημιουργία εντολής limit"
             smart_intervals_above_minimum: "Η τιμή των έξυπνων διαστημάτων πρέπει να είναι μεγαλύτερη από %{minimum}"

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -64,6 +64,7 @@ en:
             exchange_retired: 'This exchange no longer operates — switch the bot to another one.'
             setting_orders: "Setting orders…"
             paused: "Paused"
+            archived: "Archived"
             next_try: "Next try in"
             waiting: "Waiting for all conditions to be met"
             listening: "Listening"
@@ -172,6 +173,7 @@ en:
         limit_sell: 'Limit sell'
         messages:
             do_you_want_to_delete: 'Do you want to delete this bot?'
+            do_you_want_to_archive: 'Do you want to archive this bot?'
             symbol_not_supported: "%{symbol} is not supported"
             specify_percentage_limit_order: "Specify percentage when creating a limit order"
             smart_intervals_above_minimum: "Smart intervals value should be greater than %{minimum}"

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -60,6 +60,7 @@ es:
             exchange_retired: 'Este exchange ya no opera: cambia el bot a otro.'
             setting_orders: "Configurando órdenes…"
             paused: "Pausado"
+            archived: "Archivado"
             next_try: "Próximo intento en"
             waiting: "Esperando a que se cumplan todas las condiciones"
             listening: "Escuchando"
@@ -160,6 +161,7 @@ es:
         limit_sell: 'Venta limitada'
         messages:
             do_you_want_to_delete: '¿Quieres eliminar este bot?'
+            do_you_want_to_archive: '¿Quieres archivar este bot?'
             symbol_not_supported: "%{symbol} no es compatible"
             specify_percentage_limit_order: "Especifica el porcentaje al crear una orden limitada"
             smart_intervals_above_minimum: "El valor de los intervalos inteligentes debe ser mayor que %{minimum}"

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -60,6 +60,7 @@ fr:
             exchange_retired: "Cette plateforme n'existe plus — bascule le bot vers une autre."
             setting_orders: "Configuration des commandes…"
             paused: "En pause"
+            archived: "Archivé"
             next_try: "Prochain essai dans"
             waiting: "En attente que toutes les conditions soient remplies"
             listening: "En écoute"
@@ -160,6 +161,7 @@ fr:
         limit_sell: 'Vente limitée'
         messages:
             do_you_want_to_delete: 'Voulez-vous vraiment supprimer ce bot ?'
+            do_you_want_to_archive: 'Voulez-vous vraiment archiver ce bot ?'
             symbol_not_supported: "%{symbol} n''est pas pris en charge"
             specify_percentage_limit_order: "Spécifiez le pourcentage lors de la création d''un ordre limité"
             smart_intervals_above_minimum: "La valeur des intervalles intelligents doit être supérieure à %{minimum}"

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -57,6 +57,7 @@ it:
             exchange_retired: 'Questo exchange non esiste più — sposta il bot su un altro.'
             setting_orders: "Impostazione ordini…"
             paused: "In pausa"
+            archived: "Archiviato"
             next_try: "Prossimo tentativo in"
             waiting: "In attesa che tutte le condizioni siano soddisfatte"
             listening: "In ascolto"
@@ -158,6 +159,7 @@ it:
         limit_sell: 'Vendita limite'
         messages:
             do_you_want_to_delete: 'Vuoi eliminare questo bot?'
+            do_you_want_to_archive: 'Vuoi archiviare questo bot?'
             symbol_not_supported: "%{symbol} non è supportato"
             specify_percentage_limit_order: "Specifica la percentuale quando crei un ordine limite"
             smart_intervals_above_minimum: "Il valore degli intervalli intelligenti dovrebbe essere maggiore di %{minimum}"

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -57,6 +57,7 @@ nl:
             exchange_retired: 'Deze exchange bestaat niet meer — zet de bot over naar een andere.'
             setting_orders: "Orders instellen…"
             paused: "Gepauzeerd"
+            archived: "Gearchiveerd"
             next_try: "Volgende poging in"
             waiting: "Wachten tot aan alle voorwaarden is voldaan"
             listening: "Luistert"
@@ -157,6 +158,7 @@ nl:
         limit_sell: 'Limiet verkoop'
         messages:
             do_you_want_to_delete: 'Wil je deze bot verwijderen?'
+            do_you_want_to_archive: 'Wil je deze bot archiveren?'
             symbol_not_supported: "%{symbol} wordt niet ondersteund"
             specify_percentage_limit_order: "Geef het percentage op bij het maken van een limietorder"
             smart_intervals_above_minimum: "De waarde van slimme intervallen moet groter zijn dan %{minimum}"

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -60,6 +60,7 @@ pl:
             exchange_retired: 'Ta giełda już nie działa — przenieś bota na inną.'
             setting_orders: "Ustawianie zleceń…"
             paused: "Wstrzymany"
+            archived: "Zarchiwizowany"
             next_try: "Następna próba za"
             waiting: "Oczekiwanie na spełnienie wszystkich warunków"
             listening: "Nasłuchiwanie"
@@ -160,6 +161,7 @@ pl:
         limit_sell: 'Sprzedaj z limitem'
         messages:
             do_you_want_to_delete: 'Czy chcesz usunąć tego bota?'
+            do_you_want_to_archive: 'Czy chcesz zarchiwizować tego bota?'
             symbol_not_supported: "%{symbol} nie jest obsługiwany"
             specify_percentage_limit_order: "Podaj procent przy tworzeniu zlecenia z limitem"
             smart_intervals_above_minimum: "Wartość inteligentnych interwałów powinna być większa niż %{minimum}"

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -60,6 +60,7 @@ pt:
             exchange_retired: 'Esta exchange já não opera — muda o bot para outra.'
             setting_orders: "Configurando ordens…"
             paused: "Pausado"
+            archived: "Arquivado"
             next_try: "Próxima tentativa em"
             waiting: "À espera que todas as condições sejam cumpridas"
             listening: "A escutar"
@@ -158,6 +159,7 @@ pt:
         limit_sell: 'Limitar venda'
         messages:
             do_you_want_to_delete: 'Quer eliminar este bot?'
+            do_you_want_to_archive: 'Quer arquivar este bot?'
             symbol_not_supported: "%{symbol} não é suportado"
             specify_percentage_limit_order: "Especifique a porcentagem ao criar uma ordem limitada"
             smart_intervals_above_minimum: "O valor dos intervalos inteligentes deve ser maior que %{minimum}"

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -57,6 +57,7 @@ ru:
             exchange_retired: 'Эта биржа больше не работает — переведите бота на другую.'
             setting_orders: "Настройка ордеров…"
             paused: "На паузе"
+            archived: "В архиве"
             next_try: "Следующая попытка через"
             waiting: "Ожидание выполнения всех условий"
             listening: "Ожидание сигнала"
@@ -155,6 +156,7 @@ ru:
         limit_sell: 'Лимитная продажа'
         messages:
             do_you_want_to_delete: 'Вы хотите удалить этого бота?'
+            do_you_want_to_archive: 'Вы хотите архивировать этого бота?'
             symbol_not_supported: "%{symbol} не поддерживается"
             specify_percentage_limit_order: "Укажите процент при создании лимитного ордера"
             smart_intervals_above_minimum: "Значение умных интервалов должно быть больше, чем %{minimum}"

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -64,6 +64,7 @@ sk:
             exchange_retired: 'Táto burza už nefunguje — presuň bota na inú.'
             setting_orders: "Zadávanie príkazov…"
             paused: "Pozastavené"
+            archived: "Archivované"
             next_try: "Ďalší pokus za"
             waiting: "Čakanie na splnenie všetkých podmienok"
             listening: "Počúvam"
@@ -172,6 +173,7 @@ sk:
         limit_sell: 'Limitný predaj'
         messages:
             do_you_want_to_delete: 'Chcete zmazať tohto bota?'
+            do_you_want_to_archive: 'Chcete archivovať tohto bota?'
             symbol_not_supported: "%{symbol} nie je podporovaný"
             specify_percentage_limit_order: "Pri vytváraní limitného príkazu zadajte percento"
             smart_intervals_above_minimum: "Hodnota inteligentných intervalov musí byť vyššia ako %{minimum}"

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -64,6 +64,7 @@ sv:
             exchange_retired: 'Den här börsen finns inte längre — flytta boten till en annan.'
             setting_orders: "Lägger ordrar…"
             paused: "Pausad"
+            archived: "Arkiverad"
             next_try: "Nästa försök om"
             waiting: "Väntar på att alla villkor ska uppfyllas"
             listening: "Lyssnar"
@@ -172,6 +173,7 @@ sv:
         limit_sell: 'Limitsälj'
         messages:
             do_you_want_to_delete: 'Vill du ta bort denna bot?'
+            do_you_want_to_archive: 'Vill du arkivera denna bot?'
             symbol_not_supported: "%{symbol} stöds inte"
             specify_percentage_limit_order: "Ange procentsats vid limitorder"
             smart_intervals_above_minimum: "Smarta intervall-beloppet måste vara större än %{minimum}"

--- a/config/locales/errors.bg.yml
+++ b/config/locales/errors.bg.yml
@@ -60,6 +60,7 @@ bg:
             transient_unavailable: "%{exchange} е временно недостъпна. Ботът ще опита отново автоматично."
         bots:
             exchange_asset_mismatch: "Не всички активи са налични в %{exchange_name}"
+            archived: "Възстановете този бот, преди да го стартирате"
             exchange_change_while_open_orders: "Преди смяна на борсата отменете всички отворени поръчки на този бот в %{exchange_name}"
             destroy_success: "Ботът %{bot_label} е изтрит успешно"
             api_key_success: "API ключовете са запазени успешно"

--- a/config/locales/errors.cs.yml
+++ b/config/locales/errors.cs.yml
@@ -60,6 +60,7 @@ cs:
             transient_unavailable: "%{exchange} je dočasně nedostupná. Bot to automaticky zkusí znovu."
         bots:
             exchange_asset_mismatch: "Ne všechna aktiva jsou dostupná na %{exchange_name}"
+            archived: "Než tohoto bota spustíte, obnovte ho"
             exchange_change_while_open_orders: "Před změnou burzy zrušte všechny otevřené příkazy tohoto bota na %{exchange_name}"
             destroy_success: "Bot %{bot_label} byl úspěšně smazán"
             api_key_success: "API klíče byly úspěšně uloženy"

--- a/config/locales/errors.da.yml
+++ b/config/locales/errors.da.yml
@@ -60,6 +60,7 @@ da:
             transient_unavailable: "%{exchange} er midlertidigt utilgængelig. Botten prøver automatisk igen."
         bots:
             exchange_asset_mismatch: "Ikke alle aktiverne er noteret på %{exchange_name}"
+            archived: "Genaktivér denne bot, før du starter den"
             exchange_change_while_open_orders: "Annullér alle åbne ordrer, denne bot har på %{exchange_name}, før du skifter børs"
             destroy_success: "Bot %{bot_label} er slettet"
             api_key_success: "API-nøgler gemt"

--- a/config/locales/errors.de.yml
+++ b/config/locales/errors.de.yml
@@ -67,6 +67,7 @@ de:
             transient_unavailable: "%{exchange} ist vorübergehend nicht verfügbar. Der Bot versucht es automatisch erneut."
         bots:
             exchange_asset_mismatch: "Nicht alle Vermögenswerte sind auf %{exchange_name} gelistet"
+            archived: "Reaktiviere diesen Bot, bevor du ihn startest"
             exchange_change_while_open_orders: "Alle offenen Bestellungen dieses Bots auf %{exchange_name} stornieren, bevor Sie den Exchange ändern"
             destroy_success: "Bot %{bot_label} erfolgreich gelöscht"
             api_key_success: "API-Schlüssel erfolgreich gespeichert"

--- a/config/locales/errors.el.yml
+++ b/config/locales/errors.el.yml
@@ -60,6 +60,7 @@ el:
             transient_unavailable: "Η %{exchange} είναι προσωρινά μη διαθέσιμη. Το bot θα προσπαθήσει ξανά αυτόματα."
         bots:
             exchange_asset_mismatch: "Δεν είναι όλα τα assets διαθέσιμα στο %{exchange_name}"
+            archived: "Επαναφέρετε αυτό το bot πριν το ξεκινήσετε"
             exchange_change_while_open_orders: "Ακύρωσε όλες τις ανοιχτές εντολές που έχει αυτό το bot στο %{exchange_name} πριν αλλάξεις ανταλλακτήριο"
             destroy_success: "Το bot %{bot_label} διαγράφηκε επιτυχώς"
             api_key_success: "Τα κλειδιά API αποθηκεύτηκαν επιτυχώς"

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -68,6 +68,7 @@ en:
             transient_unavailable: "%{exchange} is temporarily unavailable. The bot will retry automatically."
         bots:
             exchange_asset_mismatch: "Not all the assets are listed on %{exchange_name}"
+            archived: "Reactivate this bot before starting it"
             exchange_change_while_open_orders: "Cancel all open orders this bot has on %{exchange_name} before changing the exchange"
             destroy_success: "Bot %{bot_label} deleted successfully"
             api_key_success: "API keys saved successfully"

--- a/config/locales/errors.es.yml
+++ b/config/locales/errors.es.yml
@@ -67,6 +67,7 @@ es:
             transient_unavailable: "%{exchange} no está disponible temporalmente. El bot lo reintentará automáticamente."
         bots:
             exchange_asset_mismatch: "No todos los activos están listados en %{exchange_name}"
+            archived: "Reactiva este bot antes de iniciarlo"
             exchange_change_while_open_orders: "Cancela todas las órdenes abiertas de este bot en %{exchange_name} antes de cambiar el exchange"
             destroy_success: "Bot %{bot_label} eliminado con éxito"
             api_key_success: "claves API guardadas con éxito"

--- a/config/locales/errors.fr.yml
+++ b/config/locales/errors.fr.yml
@@ -54,6 +54,7 @@ fr:
             transient_unavailable: "%{exchange} est temporairement indisponible. Le bot réessaiera automatiquement."
         bots:
             exchange_asset_mismatch: "Tous les actifs ne sont pas répertoriés sur %{exchange_name}"
+            archived: "Réactivez ce bot avant de le démarrer"
             exchange_change_while_open_orders: "Veuillez annuler toutes les commandes ouvertes de ce bot sur %{exchange_name} avant de changer l''exchange"
             destroy_success: "Bot %{bot_label} supprimé avec succès"
             api_key_success: "Clés API enregistrées avec succès"

--- a/config/locales/errors.it.yml
+++ b/config/locales/errors.it.yml
@@ -67,6 +67,7 @@ it:
             transient_unavailable: "%{exchange} è temporaneamente non disponibile. Il bot riproverà automaticamente."
         bots:
             exchange_asset_mismatch: "Non tutte le attività sono quotate su %{exchange_name}"
+            archived: "Riattiva questo bot prima di avviarlo"
             exchange_change_while_open_orders: "Annulla tutte le ordini aperti di questo bot su %{exchange_name} prima di cambiare l'exchange"
             destroy_success: "Bot %{bot_label} eliminato con successo"
             api_key_success: "Chiavi API salvate con successo"

--- a/config/locales/errors.nl.yml
+++ b/config/locales/errors.nl.yml
@@ -67,6 +67,7 @@ nl:
             transient_unavailable: "%{exchange} is tijdelijk niet beschikbaar. De bot probeert het automatisch opnieuw."
         bots:
             exchange_asset_mismatch: "Niet alle activa staan genoteerd op %{exchange_name}"
+            archived: "Heractiveer deze bot voordat je hem start"
             exchange_change_while_open_orders: "Annuleer alle openstaande bestellingen van deze bot op %{exchange_name} voordat u de exchange wijzigt"
             destroy_success: "Bot %{bot_label} succesvol verwijderd"
             api_key_success: "API-sleutels succesvol opgeslagen"

--- a/config/locales/errors.pl.yml
+++ b/config/locales/errors.pl.yml
@@ -67,6 +67,7 @@ pl:
             transient_unavailable: "%{exchange} jest chwilowo niedostępny. Bot automatycznie ponowi próbę."
         bots:
             exchange_asset_mismatch: "Nie wszystkie aktywa są notowane na %{exchange_name}"
+            archived: "Przywróć tego bota, zanim go uruchomisz"
             exchange_change_while_open_orders: "Anuluj wszystkie otwarte zlecenia tego bot na %{exchange_name} przed zmianą exchange"
             destroy_success: "Bot %{bot_label} został pomyślnie usunięty"
             api_key_success: "Klucze API zostały pomyślnie zapisane"

--- a/config/locales/errors.pt.yml
+++ b/config/locales/errors.pt.yml
@@ -67,6 +67,7 @@ pt:
             transient_unavailable: "%{exchange} está temporariamente indisponível. O bot tentará novamente de forma automática."
         bots:
             exchange_asset_mismatch: "Nem todos os ativos estão listados em %{exchange_name}"
+            archived: "Reative este bot antes de o iniciar"
             exchange_change_while_open_orders: "Cancela todas as ordens abertas deste bot em %{exchange_name} antes de alterar o exchange"
             destroy_success: "Bot %{bot_label} excluído com sucesso"
             api_key_success: "Chaves de API salvas com sucesso"

--- a/config/locales/errors.ru.yml
+++ b/config/locales/errors.ru.yml
@@ -62,6 +62,7 @@ ru:
             transient_unavailable: "%{exchange} временно недоступен. Бот повторит попытку автоматически."
         bots:
             exchange_asset_mismatch: "Не все активы котируются на %{exchange_name}"
+            archived: "Восстановите этого бота, прежде чем запускать"
             exchange_change_while_open_orders: "Пожалуйста, отмените все открытые ордера этого бота на %{exchange_name} перед изменением биржи"
             destroy_success: "Бот %{bot_label} успешно удален"
             api_key_success: "Ключи API успешно сохранены"

--- a/config/locales/errors.sk.yml
+++ b/config/locales/errors.sk.yml
@@ -60,6 +60,7 @@ sk:
             transient_unavailable: "%{exchange} je dočasne nedostupná. Bot to automaticky skúsi znova."
         bots:
             exchange_asset_mismatch: "Nie vsetky aktiva su dostupne na %{exchange_name}"
+            archived: "Než tohto bota spustíte, obnovte ho"
             exchange_change_while_open_orders: "Pred zmenou burzy zruste vsetky otvorene prikazy tohto bota na %{exchange_name}"
             destroy_success: "Bot %{bot_label} bol uspesne vymazany"
             api_key_success: "API kluce boli uspesne ulozene"

--- a/config/locales/errors.sv.yml
+++ b/config/locales/errors.sv.yml
@@ -60,6 +60,7 @@ sv:
             transient_unavailable: "%{exchange} är tillfälligt otillgänglig. Boten försöker igen automatiskt."
         bots:
             exchange_asset_mismatch: "Alla tillgångar är inte listade på %{exchange_name}"
+            archived: "Återaktivera denna bot innan du startar den"
             exchange_change_while_open_orders: "Avbryt alla öppna ordrar som denna bot har på %{exchange_name} innan du byter börs"
             destroy_success: "Bot %{bot_label} har tagits bort"
             api_key_success: "API-nycklar sparade"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,6 +231,7 @@ Rails.application.routes.draw do
       resource :start, only: [:edit, :update], controller: 'bots/starts'
       resource :stop, only: [:update], controller: 'bots/stops'
       resource :delete, only: [:edit, :destroy], controller: 'bots/deletes'
+      resource :archive, only: [:edit, :create, :destroy], controller: 'bots/archives'
       resource :add_api_key, only: [:new, :create], controller: 'bots/add_api_keys'
       resource :asset_search, only: [:edit], controller: 'bots/asset_searches'
       resource :export, only: [:create], controller: 'bots/exports'

--- a/test/integration/bots/archive_test.rb
+++ b/test/integration/bots/archive_test.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Archiving is a stop that also hides the bot from the list: the bot keeps its transactions and
+# stays reachable under the "Archived" filter, where its Start button reads "Reactivate".
+class Bots::ArchiveTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true) # onboarding gate
+    @user = create(:user)
+    @bot = create(:dca_single_asset, user: @user, status: :stopped)
+    # A second bot keeps the index on the list instead of redirecting to the only bot.
+    @other = create(:dca_single_asset, user: @user, status: :stopped, exchange: @bot.exchange,
+                                       base_asset: @bot.base_asset, quote_asset: @bot.quote_asset)
+    sign_in @user
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::ActionJob.stubs(:set).returns(stub(perform_later: true))
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+    Bots::DcaSingleAsset.any_instance.stubs(:check_missed_quote_amount_was_set).returns(true)
+  end
+
+  # == The menu entry and its confirmation ==
+
+  test 'the bot menu offers Archive next to Delete' do
+    get bot_path(id: @bot.id)
+
+    assert_response :success
+    assert_select "a[href='#{edit_bot_archive_path(bot_id: @bot.id)}']", text: I18n.t('button.archive')
+  end
+
+  test 'an already archived bot is not offered Archive again' do
+    @bot.update!(status: :archived)
+
+    get bot_path(id: @bot.id)
+
+    assert_response :success
+    assert_select "a[href='#{edit_bot_archive_path(bot_id: @bot.id)}']", count: 0
+  end
+
+  test 'the Archive entry opens a confirmation modal' do
+    get edit_bot_archive_path(bot_id: @bot.id)
+
+    assert_response :success
+    assert_select '.modal .modal__title', text: @bot.label
+    assert_select '.modal', text: /#{Regexp.escape(I18n.t('bot.messages.do_you_want_to_archive'))}/
+    assert_select "form[action='#{bot_archive_path(bot_id: @bot.id)}'] button", text: I18n.t('button.archive')
+  end
+
+  # == Archiving ==
+
+  test 'confirming archives the bot' do
+    post bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :archived?
+  end
+
+  test 'archiving a working bot stops it first, so no tick is left scheduled' do
+    @bot.update!(status: :scheduled, started_at: Time.current)
+    Bots::DcaSingleAsset.any_instance.expects(:cancel_scheduled_action_jobs).at_least_once
+
+    post bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :archived?
+    assert @bot.stopped_at.present?
+  end
+
+  test 'a bot whose pair is gone can still be archived — that is the bot worth archiving' do
+    Ticker.update_all(available: false)
+
+    post bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :archived?
+  end
+
+  # == What an archived bot looks like ==
+
+  test 'an archived bot reads Archived and offers Reactivate instead of Start' do
+    @bot.update!(status: :archived)
+
+    get bot_path(id: @bot.id)
+
+    assert_response :success
+    assert_select '.bot-control__status__text', text: I18n.t('bot.status.archived')
+    assert_select "form[action='#{bot_archive_path(bot_id: @bot.id)}'] button", text: I18n.t('button.reactivate')
+    assert_select '.animicon--start', count: 0
+    assert_select '.animicon--stop', count: 0
+  end
+
+  # == Reactivating ==
+
+  test 'reactivating a bot that has run returns it to paused' do
+    @bot.update!(status: :archived, started_at: 1.day.ago)
+
+    delete bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :stopped?
+    # The bot may have just left the list it was clicked in, so the page is refetched whole.
+    assert_select 'turbo-stream[action="refresh"]', 1
+  end
+
+  test 'a bot whose pair is gone can be reactivated too, not just archived' do
+    @bot.update!(status: :archived, started_at: nil)
+    Ticker.update_all(available: false)
+
+    delete bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :stopped?
+  end
+
+  test 'a stale Reactivate leaves a bot that is running again alone' do
+    @bot.update!(status: :scheduled, started_at: Time.current)
+
+    delete bot_archive_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_response :ok
+    assert_predicate @bot.reload, :scheduled?
+  end
+
+  # == The list ==
+
+  test 'an archived bot is gone from All and shows up under Archived' do
+    @bot.update!(status: :archived)
+
+    get bots_path
+
+    assert_response :success
+    assert_select "a[href='#{bot_path(id: @bot.id)}']", count: 0
+    assert_select "a[href='#{bot_path(id: @other.id)}']", count: 1
+
+    get bots_path(filter: 'archived')
+
+    assert_response :success
+    assert_select "a[href='#{bot_path(id: @bot.id)}']", count: 1
+    assert_select "a[href='#{bot_path(id: @other.id)}']", count: 0
+  end
+
+  test 'the Archived filter appears only once something is archived' do
+    get bots_path
+
+    assert_response :success
+    assert_select "a.segmented__option[data-value='archived']", count: 0
+
+    @bot.update!(status: :archived)
+    get bots_path
+
+    assert_response :success
+    assert_select "a.segmented__option[data-value='archived']", count: 1
+  end
+
+  test 'a user whose every bot is archived still gets the list, not the first-bot screen' do
+    @bot.update!(status: :archived)
+    @other.update!(status: :archived)
+
+    get bots_path
+
+    assert_response :success
+    assert_select "a.segmented__option[data-value='archived']", count: 1
+    assert_select "a[href='#{new_bots_dca_single_assets_pick_buyable_asset_path}']", count: 0
+  end
+
+  test 'an archived bot is not offered in the bot switcher' do
+    @other.update!(status: :archived)
+
+    get bot_path(id: @bot.id)
+
+    assert_response :success
+    assert_select ".dropdown--bots a[href='#{bot_path(id: @other.id)}']", count: 0
+  end
+
+  # == Nothing resurrects an archived bot ==
+
+  test 'a stale Start button cannot start an archived bot' do
+    @bot.update!(status: :archived)
+
+    patch bot_start_path(bot_id: @bot.id), params: { start_fresh: 'true' }, as: :turbo_stream
+
+    assert_response :unprocessable_content
+    assert_predicate @bot.reload, :archived?
+  end
+
+  test 'a stop that lands after archiving leaves the bot archived' do
+    @bot.update!(status: :archived)
+
+    patch bot_stop_path(bot_id: @bot.id), as: :turbo_stream
+
+    assert_predicate @bot.reload, :archived?
+  end
+
+  test 'deleting an API key does not stop (and so unarchive) an archived bot' do
+    @bot.update!(status: :archived)
+
+    @bot.api_key.stop_dependent_bots!
+
+    assert_predicate @bot.reload, :archived?
+  end
+
+  test 'an in-flight action job cannot flip an archived bot back to working' do
+    @bot.update!(status: :archived)
+
+    assert_not Bot::ActionJob.transition_working_bot!(@bot, 'executing')
+    assert_predicate @bot.reload, :archived?
+  end
+end


### PR DESCRIPTION
A bot you are done with but do not want to delete now has a place to go.

The bot menu offers **Archive** next to Delete, behind the same confirmation modal. Confirming stops the bot and takes it out of the list; it stays reachable under a new **Archived** filter, which appears only once something is in it. There its Start button reads **Reactivate**, and the status bar reads *Archived*. Reactivating puts the bot back among the paused ones — it does not resume trading on its own.

Archiving is a status, appended to the enum next to `deleted`, so no migration. It goes through `#stop`, which already owns the job cancellation and the settings-dirty guard, so an archived bot can never leave a tick scheduled behind it.

## Nothing quietly undoes it

- The two key-deletion sweeps asked for `not_deleted.not_stopped`, and the action job's race guard for "not stopped or deleted". All three mean *still working* — they now say `working`, and stay right the next time a status is added.
- A start is refused until the bot is reactivated. Both `#start` implementations validate on `:start`, so one validation covers the button, a stale tab and `BotApi::Bots::Start` alike.
- A stop that lands late — a queued `Bot::StopJob`, a stale tab — leaves the bot archived instead of dropping it back into Inactive.
- `validate_bot_exchange` exempts archived rows. A delisted pair is exactly the bot worth archiving, and it could not be saved otherwise; reactivating restores `:stopped` for the same reason, which is also the status a never-run bot renders identically to `:created`.
- The API portfolio totals grew an archived bucket. They were counting those bots in the total and in no bucket, so `Total bots: 1 (0 active, 0 stopped, 0 not started)` was possible.

## Known gap

A `Bot::ActionJob` already claimed by a worker can overwrite the status of a bot archived mid-flight and place its order. That is the race documented in `Bot::Lifecycle#start`: stop and delete carry it identically, and closing it needs an execution fence, which is a schema change.

## Tests

18 new integration tests in `test/integration/bots/archive_test.rb` cover the menu entry, the modal, archiving a working bot, the Archived reading and Reactivate button, the filter, the list exclusions, the start/stop/reactivate gates and the delisted-pair paths. Full suite: 3720 runs, 0 failures.

Translations for all 15 locales.
