### PR TITLE
Put the rebalance note above its live readout

### DIFF
--- a/app/views/bots/settings/_rebalance_info.html.erb
+++ b/app/views/bots/settings/_rebalance_info.html.erb
@@ -7,6 +7,9 @@
     deliberately silent, since they repeat every poll for as long as the drift lasts. %>
 <% if bot.id.present? && bot.rebalance_enabled? %>
   <small id="<%= bot.new_record? ? "new-settings-rebalance-info" : "settings-rebalance-info" %>" class="small-info">
+    <%# The standing explanation first, then the live readout under it: the note describes what the
+        rule IS, the readout is what it happens to say right now. %>
+    <div><%= t("bot.settings.rebalance.note") %></div>
     <% if bot.rebalance_ambiguous? %>
       <div class="text-error">
         <%= t("bot.settings.rebalance.paused") %>
@@ -25,6 +28,5 @@
         </div>
       <% end %>
     <% end %>
-    <div><%= t("bot.settings.rebalance.note") %></div>
   </small>
 <% end %>

--- a/test/integration/bots/rebalance_settings_test.rb
+++ b/test/integration/bots/rebalance_settings_test.rb
@@ -40,6 +40,17 @@ class Bots::RebalanceSettingsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'the standing note comes before the live readout' do
+    enable_rebalancing
+    stub_drift(0.169)
+
+    get bot_path(id: @bot.id)
+
+    lines = css_select('#settings-rebalance-info div').map(&:text).map(&:strip)
+    assert_match(/DCA schedule is stopped/, lines.first)
+    assert_match(/off its target split/, lines.second)
+  end
+
   test 'the drift readout goes green once the criteria are met' do
     enable_rebalancing(threshold: 0.05)
     stub_drift(0.169)

--- a/test/models/bot/rebalance_locales_test.rb
+++ b/test/models/bot/rebalance_locales_test.rb
@@ -7,6 +7,15 @@ require 'yaml'
 class Bot::RebalanceLocalesTest < ActiveSupport::TestCase
   KEYS = %w[sentence_html note drift paused resume resume_confirm still_open resolved].freeze
 
+  # Activity rows with no explicit message render through bot_activity.events.<event>, so every
+  # event the rebalance leg emits needs a key or the feed shows raw translation-missing text.
+  # rebalance_sell_placed / rebalance_buy_placed are built by interpolation
+  # ("rebalance_#{side}_placed"), which no grep for a literal event name would find.
+  EVENTS = %w[
+    rebalance_sell_placed rebalance_buy_placed rebalance_dust
+    rebalance_ambiguous rebalance_manually_resolved dca_skipped_rebalance_pending
+  ].freeze
+
   test 'every available_locale carries the rebalance widget keys in its own bot.<locale>.yml' do
     I18n.available_locales.each do |locale|
       file = Rails.root.join("config/locales/bot.#{locale}.yml")
@@ -18,6 +27,41 @@ class Bot::RebalanceLocalesTest < ActiveSupport::TestCase
       KEYS.each do |key|
         assert data.dig('bot', 'settings', 'rebalance', key),
                "bot.#{locale}.yml is missing bot.settings.rebalance.#{key}"
+      end
+    end
+  end
+
+  test 'every available_locale carries the rebalance activity events in its own base.<locale>.yml' do
+    I18n.available_locales.each do |locale|
+      file = Rails.root.join("config/locales/base.#{locale}.yml")
+      assert File.exist?(file), "missing base locale file for #{locale}"
+
+      data = YAML.load_file(file)[locale.to_s]
+      EVENTS.each do |event|
+        assert data.dig('bot_activity', 'events', event).present?,
+               "base.#{locale}.yml is missing bot_activity.events.#{event}"
+      end
+    end
+  end
+
+  test 'no locale silently ships the English string' do
+    # A key copied verbatim from English passes a presence check while reading as untranslated.
+    english = YAML.load_file(Rails.root.join('config/locales/bot.en.yml'))['en']
+    english_events = YAML.load_file(Rails.root.join('config/locales/base.en.yml'))['en']
+
+    (I18n.available_locales - [:en]).each do |locale|
+      data = YAML.load_file(Rails.root.join("config/locales/bot.#{locale}.yml"))[locale.to_s]
+      events = YAML.load_file(Rails.root.join("config/locales/base.#{locale}.yml"))[locale.to_s]
+
+      KEYS.each do |key|
+        assert_not_equal english.dig('bot', 'settings', 'rebalance', key),
+                         data.dig('bot', 'settings', 'rebalance', key),
+                         "#{locale}: bot.settings.rebalance.#{key} is still the English string"
+      end
+      EVENTS.each do |event|
+        assert_not_equal english_events.dig('bot_activity', 'events', event),
+                         events.dig('bot_activity', 'events', event),
+                         "#{locale}: bot_activity.events.#{event} is still the English string"
       end
     end
   end


### PR DESCRIPTION
Two small follow-ups to the rebalance rule.

## Order in the info block

The standing note ("Keeps running while the DCA schedule is stopped") now sits above the drift readout. The note describes what the rule *is*; the figure is what it happens to say right now, so reading the second before the first was backwards.

## Translation coverage

Audited every key the feature introduced — 8 under `bot.settings.rebalance.*` and 6 under `bot_activity.events.*` — across all 15 locales. All present, none left as the English string.

The locale test now enforces both of those rather than only the first set, closing two gaps a presence check cannot see:

- **The activity-event keys.** Activity rows with no explicit message render through `bot_activity.events.<event>`, and two of the six are built by interpolation (`"rebalance_#{side}_placed"`), so no grep for a literal event name would have found them missing.
- **Keys copied verbatim from English.** Those pass a presence assertion while reading as untranslated in the UI.

One thing deliberately left alone: the `rebalance_threshold` numericality message renders its attribute name in English ("Rebalance threshold must be less than or equal to 1"). That is not specific to this rule — the repo localises no ActiveRecord attribute names at all, so `quote_amount_limit` and `price_drop_limit` behave identically, and fixing one in isolation would be the inconsistent move. The message is also close to unreachable through the UI, since the widget always submits a value and the reader defaults when blank.

`bin/rails test`: 3803 runs, 0 failures. Rubocop clean.