### PR TITLE
Group the log's dead ends under one "Other" tab

### DIFF
--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -10,6 +10,19 @@
 // The chip's left and width are set in pixels by the `segmented` controller, which measures the
 // selected option. Both sizings therefore share one code path; the CSS difference is a single
 // column rule.
+.rbutton
+    height: 4rem
+    width: fit-content
+    border-radius: 1rem
+    border: none
+    background: var(--washed)
+    box-shadow: var(--shadow-basic)
+    text-transform: uppercase
+    font-size: 1.5rem
+    font-weight: 600
+    color: var(--link)
+    padding: 1rem 1.5rem
+
 .segmented
     position: relative
     display: grid
@@ -24,6 +37,65 @@
     box-shadow: var(--shadow-indent)
     &--fluid
         grid-auto-columns: auto
+    // Collapsed: the same track and the same chip, folded down to the selected label with a caret
+    // to say the rest are one tap away. The controller trips it by MEASURING — the labels are
+    // translated and the option count depends on the data, so the width that stops fitting is not
+    // a number anyone could write into a breakpoint.
+    &--collapsed
+        display: flex
+        align-items: center
+        gap: 0.25rem
+        cursor: pointer
+        .segmented__thumb
+            position: static
+            align-self: stretch
+            display: flex
+            align-items: center
+            padding: 0 1.5rem
+            font-size: 1.5rem
+            font-weight: 600
+            text-indent: 0.1em
+            text-transform: uppercase
+            white-space: nowrap
+            color: var(--ink)
+            transition: none
+        .segmented__caret
+            display: flex
+            align-items: center
+            padding-right: 0.5rem
+            color: var(--stone)
+        .segmented__menu
+            display: none
+            position: absolute
+            top: 4.5rem
+            left: 0
+            z-index: 1000
+            flex-direction: column
+            min-width: 100%
+            padding: 0.75rem
+            background: var(--dropdown-bg)
+            border-radius: 1rem
+            box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
+        // The selected option is already the trigger, wearing the chip. Listing it again would
+        // offer the reader the thing they are looking at.
+        .segmented__option
+            justify-content: flex-start
+            line-height: 3.5rem
+            &.is-on
+                display: none
+        &.is-open
+            .segmented__menu
+                display: flex
+
+// display: contents, so the expanded control is laid out exactly as it was — the options are
+// still the track's own grid items. The wrapper only becomes a box once it becomes a menu.
+.segmented__menu
+    display: contents
+
+.segmented__caret
+    display: none
+    path
+        fill: currentColor
 
 // No border: the chip is lighter than the track it sits in, and a hairline around a fill that
 // already separates itself adds a line and no information.
@@ -68,3 +140,10 @@
     &:focus-visible
         outline: 2px solid var(--link)
         outline-offset: 2px
+
+// The control collapses when its options outgrow the room its PARENT gives it, so that parent
+// needs a width of its own. One that shrink-wraps to the collapsed trigger would report the
+// trigger's width as the room available and never let the control open back up.
+.filters:has(> .segmented)
+    flex: 1
+    min-width: 0

--- a/app/helpers/bot_helper.rb
+++ b/app/helpers/bot_helper.rb
@@ -60,11 +60,12 @@ module BotHelper
     end
   end
 
-  # Maps a transaction to a UI filter tab ('waiting' | 'cancelled' | 'successful' | nil).
-  # nil means the row doesn't belong to any of the named tabs (e.g. failed/skipped).
+  # The tab a COLUMNAR row belongs to ('waiting' | 'successful' | nil). nil is every
+  # Transaction#other? row — cancelled, abandoned, skipped, failed: they have no
+  # columnar home and show under "Other" as their sentence row, so the columnar row,
+  # where one was rendered at all, belongs to no tab and stays hidden.
   def order_filter_type(order)
     return 'waiting' if order.submitted? && (order.open? || order.unknown?)
-    return 'cancelled' if order.submitted? && (order.cancelled? || order.abandoned?)
     return 'successful' if order.submitted? && order.closed?
 
     nil

--- a/app/javascript/controllers/order_filter_controller.js
+++ b/app/javascript/controllers/order_filter_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="order-filter"
-// "all" shows the unified timeline rows (order_type "timeline"); the other tabs
-// (successful/waiting/cancelled) show the columnar rows of that type. The columnar
-// Amount/Value headers are hidden while the timeline is shown.
+// Every row carries the tabs it belongs to in data-order-type: the sentence rows are
+// "all" (plus "other" for cancelled/skipped/failed, which have no columnar row), the
+// columnar rows are "successful" or "waiting". Filtering is a membership test, and the
+// Amount/Value headers only make sense for the two columnar tabs.
 export default class extends Controller {
   static targets = ["row", "columnHeader", "filterContainer"]
   static values = { current: { type: String, default: "all" } }
@@ -40,17 +41,16 @@ export default class extends Controller {
   }
 
   updateVisibility() {
-    const timeline = this.currentValue === "all"
     this.rowTargets.forEach(row => {
-      const orderType = row.dataset.orderType
-      const visible = timeline ? orderType === "timeline" : orderType === this.currentValue
-      row.style.display = visible ? "" : "none"
+      // A row with no tabs at all (the columnar row of a cancelled order) shows nowhere.
+      const tabs = (row.dataset.orderType || "").split(" ")
+      row.style.display = tabs.includes(this.currentValue) ? "" : "none"
     })
   }
 
   updateHeader() {
-    const timeline = this.currentValue === "all"
-    this.columnHeaderTargets.forEach(th => { th.style.display = timeline ? "none" : "" })
+    const sentences = this.currentValue === "all" || this.currentValue === "other"
+    this.columnHeaderTargets.forEach(th => { th.style.display = sentences ? "none" : "" })
   }
 
 }

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -9,6 +9,11 @@ import { Controller } from "@hotwired/stimulus";
 //
 // One measurement path for both sizings: the chip takes the selected option's own left and
 // width, which is what makes the FLUID variant work and costs the EQUAL one nothing.
+//
+// When the options outgrow the room the parent gives them the whole thing folds into a menu —
+// same track, same chip, now holding the selected label alone. That is measured rather than
+// keyed to a breakpoint: the labels are translated and the option count depends on the data, so
+// the width at which it stops fitting is not a number anyone could write down.
 export default class extends Controller {
   static targets = ["thumb", "option"];
 
@@ -18,18 +23,39 @@ export default class extends Controller {
     // longer label in another locale, and above all the webfont swap: `document.fonts.ready`
     // resolves before the relayout, which leaves a chip sized to the fallback face sitting
     // over a narrower option. It also fires once on observe, which is the first placement.
-    this.observer = new ResizeObserver(() => this.#moveThumb());
+    this.observer = new ResizeObserver(() => this.#layout());
     this.optionTargets.forEach((option) => this.observer.observe(option));
+    // The room is the PARENT's, never the control's own: once collapsed the control is only as
+    // wide as its trigger, and a control measuring itself would never learn that it fits again.
+    this.observer.observe(this.element.parentElement);
+
+    this.dismiss = (event) => {
+      if (event.key === "Escape" || !this.element.contains(event.target)) this.#close();
+    };
   }
 
   disconnect() {
     this.observer?.disconnect();
+    this.#listen(false);
+  }
+
+  // Opening is the collapsed control's only job. A click on an option is that option's own
+  // business — this just shuts the menu behind it.
+  toggle(event) {
+    if (!this.#collapsed) return;
+    if (event.target.closest(".segmented__option")) return this.#close();
+
+    this.element.classList.toggle("is-open");
+    this.#listen(this.element.classList.contains("is-open"));
   }
 
   // No preventDefault: a link-based group must still navigate. For those the class change is
-  // just the pressed state until the new page arrives with its own selection.
+  // just the pressed state until the new page arrives with its own selection — which is why a
+  // MODIFIED click is ignored: it opens a new tab and leaves this page as it was, so moving the
+  // chip would put it on an option aria-current still says is not the one.
   select(event) {
     const chosen = event.currentTarget;
+    if (chosen.href && (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button > 0)) return;
     this.optionTargets.forEach((option) => {
       const on = option === chosen;
       option.classList.toggle("is-on", on);
@@ -38,7 +64,7 @@ export default class extends Controller {
         option.tabIndex = on ? 0 : -1;
       }
     });
-    this.#moveThumb();
+    this.#layout();
     this.dispatch("change", { detail: { value: chosen.dataset.value } });
   }
 
@@ -47,11 +73,44 @@ export default class extends Controller {
     const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 }[event.key];
     if (!step) return;
 
-    const options = this.optionTargets;
+    // Visible ones only: collapsed, the selected option is hidden from the menu because it is
+    // the trigger, and arrowing onto something with no box focuses nothing.
+    const options = this.optionTargets.filter((option) => option.offsetParent);
     const next = options[(options.indexOf(event.currentTarget) + step + options.length) % options.length];
     event.preventDefault();
     next.focus();
     next.click();
+  }
+
+  get #collapsed() {
+    return this.element.classList.contains("segmented--collapsed");
+  }
+
+  #close() {
+    this.element.classList.remove("is-open");
+    this.#listen(false);
+  }
+
+  #listen(on) {
+    const method = on ? "addEventListener" : "removeEventListener";
+    document[method]("click", this.dismiss);
+    document[method]("keydown", this.dismiss);
+  }
+
+  #layout() {
+    // Only an expanded control can be asked how wide it wants to be, so the answer is kept.
+    if (!this.#collapsed) this.natural = this.element.getBoundingClientRect().width;
+    // Rounded, because clientWidth is: a parent that shrink-wraps this control reports exactly
+    // its width, and a fraction of a pixel between the two is not a reason to fold anything.
+    const collapse = Math.round(this.natural) > this.element.parentElement.clientWidth;
+
+    // Only on the way in or out: opening the menu resizes the options, which lands back here,
+    // and a close on every pass would shut the menu on the very click that opened it.
+    if (this.#collapsed !== collapse) {
+      this.element.classList.toggle("segmented--collapsed", collapse);
+      this.#close();
+    }
+    this.#moveThumb();
   }
 
   #moveThumb() {
@@ -60,10 +119,24 @@ export default class extends Controller {
     const selected = this.optionTargets.find((option) => option.classList.contains("is-on")) || this.optionTargets[0];
     if (!selected) return;
 
+    // Collapsed, the chip IS the trigger: it carries the selected label and sizes itself to it,
+    // so the measured left and width have to go.
+    if (this.#collapsed) {
+      this.thumbTarget.textContent = selected.textContent.trim();
+      this.thumbTarget.style.left = this.thumbTarget.style.width = "";
+      return;
+    }
+    this.thumbTarget.textContent = "";
+
     // First placement must not slide in from the left edge.
     if (!this.placed) this.thumbTarget.style.transition = "none";
-    this.thumbTarget.style.left = `${selected.offsetLeft}px`;
-    this.thumbTarget.style.width = `${selected.offsetWidth}px`;
+    // Rects, not offsetLeft/offsetWidth: those round to whole pixels, and a label half a pixel
+    // wider than its slot pushes the chip that half pixel into the track's padding — visible as
+    // a thinner gap on whichever side the chip sits.
+    const track = this.element.getBoundingClientRect();
+    const rect = selected.getBoundingClientRect();
+    this.thumbTarget.style.left = `${rect.left - track.left}px`;
+    this.thumbTarget.style.width = `${rect.width}px`;
     if (!this.placed) {
       this.thumbTarget.offsetHeight; // flush, so the next move animates
       this.thumbTarget.style.transition = "";

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -196,9 +196,10 @@ class Bot < ApplicationRecord
     end
 
     # Each transaction occupies two rows: the sentence row for the unified "All"
-    # timeline (always) and the columnar row for the named tabs (submitted orders
-    # only) — mirroring show.turbo_stream.erb. Prepend the timeline row first so the
-    # columnar row lands on top, matching the initial-load order.
+    # timeline (always, and it is also what the "Other" tab shows) and the columnar
+    # row for the named tabs (submitted orders only) — mirroring show.turbo_stream.erb.
+    # Prepend the timeline row first so the columnar row lands on top, matching the
+    # initial-load order.
     broadcast_prepend_to(
       ["user_#{user_id}", :bot_updates],
       target: 'orders_list',
@@ -211,7 +212,7 @@ class Bot < ApplicationRecord
         ["user_#{user_id}", :bot_updates],
         target: 'orders_list',
         partial: 'bots/orders/order',
-        locals: { order:, decimals:, exchange_name: order.exchange.name, current_user: user, fetch: false }
+        locals: { order:, decimals:, current_user: user }
       )
     end
 
@@ -241,7 +242,7 @@ class Bot < ApplicationRecord
       ["user_#{user_id}", :bot_updates],
       target: dom_id(order),
       partial: 'bots/orders/order',
-      locals: { order:, decimals:, exchange_name: order.exchange.name, current_user: user, fetch: false }
+      locals: { order:, decimals:, current_user: user }
     )
 
     broadcast_replace_to(

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -33,9 +33,12 @@ class Transaction < ApplicationRecord
   # (before the first confirmation fetch) and must be treated as in-flight everywhere.
   scope :waiting, -> { submitted.where(external_status: %i[open unknown]) }
   # Terminal rows the user can't act on anymore — explicit cancellation OR an
-  # exchange-side abandonment (e.g. Kraken stopped returning the order). Grouped
-  # under the "Cancelled" filter tab in the UI.
+  # exchange-side abandonment (e.g. Kraken stopped returning the order).
   scope :cancelled_or_abandoned, -> { where(external_status: %i[cancelled abandoned]) }
+  # Everything the "Other" filter tab collects: rows with nothing to show in the
+  # Amount/Value/Price columns — cancelled or abandoned, skipped, failed. The log
+  # shows them as their message sentence instead of a columnar row.
+  scope :other, -> { cancelled_or_abandoned.or(where(status: %i[skipped failed])) }
   # Contribution accounting counts REGULAR rows only. A rebalance swaps assets the bot already
   # owns — the quote it spends was never new money, so counting it would satisfy a scheduled
   # contribution the user never made and eat their "don't spend more than N" cap.
@@ -107,6 +110,11 @@ class Transaction < ApplicationRecord
 
   def imported?
     external_id&.start_with?('imported_')
+  end
+
+  # Row-level twin of the `other` scope — see it for what "other" means.
+  def other?
+    !submitted? || cancelled? || abandoned?
   end
 
   def cancel

--- a/app/views/bots/orders/_activity.html.erb
+++ b/app/views/bots/orders/_activity.html.erb
@@ -1,6 +1,6 @@
-<%# Activity row in the unified "All" timeline. order_type "timeline" means the
-    client-side filter shows it only under "All", never the columnar tabs. %>
-<%= tag.tr id: dom_id(activity), class: "text-inactive", data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: "timeline" } do %>
+<%# Activity row in the unified "All" timeline. order_type "all" means the
+    client-side filter shows it only under "All", never the other tabs. %>
+<%= tag.tr id: dom_id(activity), class: "text-inactive", data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: "all" } do %>
   <td scope="row"><%= activity.created_at.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></td>
   <td colspan="3" style="text-align: left;"><%= bot_activity_summary(activity) %></td>
 <% end %>

--- a/app/views/bots/orders/_export.html.erb
+++ b/app/views/bots/orders/_export.html.erb
@@ -2,7 +2,7 @@
   <div id="<%= dom_id(bot, :export) %>" data-controller="class-toggle" data-class-toggle-toggle-classes-value='["hidden"]' data-class-toggle-reset-after-value="3000">
     <%= button_to t('bot.details.stats.download_csv'),
                 bot_export_path(bot),
-                class: 'sinput',
+                class: 'rbutton',
                 method: :post,
                 data: { turbo: false, class_toggle_target: "togglable", action: "click->class-toggle#toggle" } %>
     <div class="hidden" data-class-toggle-target="togglable" style="font-weight: 600; padding: 0.5rem; color: var(--concrete); display: flex; align-items: center; justify-content: center;">
@@ -13,7 +13,7 @@
 
   <div id="<%= dom_id(bot, :import) %>">
     <%= form_with url: bot_import_path(bot), method: :post, multipart: true, data: { turbo: false, controller: 'file-picker' }, id: dom_id(bot, :import_form) do |f| %>
-      <button type="button" class="sinput" data-action="click->file-picker#open">
+      <button type="button" class="rbutton" data-action="click->file-picker#open">
         <%= t('bot.details.stats.import_csv') %>
       </button>
       <%= f.file_field :file, accept: '.csv', hidden: true,

--- a/app/views/bots/orders/_order.html.erb
+++ b/app/views/bots/orders/_order.html.erb
@@ -21,42 +21,6 @@
         <%= button_to t('bot.cancel_order'), bot_transaction_path(order.bot, order), method: :delete, class: 'sinput sinput--small sinput--hover-warning', data: { class_toggle_target: "togglable", action: "click->class-toggle#toggle" } %>
         <div class="loader--small hidden" style="position: unset; float: right; margin-right: 0.5rem;" data-class-toggle-target="togglable" ></div>
       </div>
-    <% elsif order.failed? %>
-      <div class="tooltip-info-icon" data-controller="tooltip" data-action="click->tooltip#toggle">
-        <div class="tooltip-icon--off">
-          <%= render 'svg/24x24_info' %>
-        </div>
-        <div class="tooltip-icon--on">
-          <%= render 'svg/24x24_info-filled' %>
-        </div>
-        <div class="tooltip tooltip--smart-allocation">
-          <%= t('bot.messages.failed_tooltip_explanation', error_message: order.error_messages.to_sentence) %>
-        </div>
-      </div>
-    <% elsif order.skipped? %>
-      <div class="tooltip-info-icon" data-controller="tooltip" data-action="click->tooltip#toggle">
-        <div class="tooltip-icon--off">
-          <%= render 'svg/24x24_info' %>
-        </div>
-        <div class="tooltip-icon--on">
-          <%= render 'svg/24x24_info-filled' %>
-        </div>
-        <div class="tooltip tooltip--smart-allocation">
-          <%= t('bot.messages.skipped_tooltip_explanation', exchange_name: exchange_name) %>
-        </div>
-      </div>
-    <% elsif order.cancelled? %>
-      <div class="tooltip-info-icon" data-controller="tooltip" data-action="click->tooltip#toggle">
-        <div class="tooltip-icon--off">
-          <%= render 'svg/24x24_info' %>
-        </div>
-        <div class="tooltip-icon--on">
-          <%= render 'svg/24x24_info-filled' %>
-        </div>
-        <div class="tooltip tooltip--smart-allocation">
-          <%= t('bot.messages.cancelled_tooltip_explanation') %>
-        </div>
-      </div>
     <% end %>
   </td>
 <% end %>

--- a/app/views/bots/orders/_order_filters.html.erb
+++ b/app/views/bots/orders/_order_filters.html.erb
@@ -1,19 +1,20 @@
 <% has_successful = bot.transactions.submitted.closed.exists? %>
-<% has_cancelled = bot.transactions.submitted.cancelled_or_abandoned.exists? %>
 <% has_waiting = bot.transactions.waiting.exists? %>
-<% has_other = bot.transactions.where(status: [:skipped, :failed]).exists? %>
-<% categories = [has_successful, has_cancelled, has_waiting, has_other].count(true) %>
+<% has_other = bot.transactions.other.exists? %>
+<% categories = [has_successful, has_waiting, has_other].count(true) %>
 <% show_filters = categories > 1 %>
 
 <% order_filter = params[:order_filter] || 'all' %>
-<%# Fluid: the option COUNT depends on what the bot actually has (a bot with no cancelled orders
-    gets no cancelled tab), and the labels differ in width, so equal columns would resize the
+<%# Fluid: the option COUNT depends on what the bot actually has (a bot that never skipped a
+    contribution gets no Other tab), and the labels differ in width, so equal columns would resize the
     whole control from bot to bot. The order-filter controller still does the filtering; it just
     hears about the choice through the segmented control's event now. %>
+<%# "Other" last: it is the catch-all for what the named tabs don't want — cancelled,
+    skipped, failed — and it shows those rows as their message, not as columns. %>
 <% tabs = [['all', t('order_filters.all'), true],
            ['successful', t('order_filters.transactions'), has_successful],
-           ['cancelled', t('order_filters.cancelled'), has_cancelled],
-           ['waiting', t('order_filters.waiting'), has_waiting]] %>
+           ['waiting', t('order_filters.waiting'), has_waiting],
+           ['other', t('order_filters.other'), has_other]] %>
 <div id="<%= dom_id(bot, :order_filters) %>" class="filters" data-order-filter-target="filterContainer"
      data-action="segmented:change->order-filter#filter">
   <% if show_filters %>

--- a/app/views/bots/orders/_order_timeline.html.erb
+++ b/app/views/bots/orders/_order_timeline.html.erb
@@ -1,8 +1,10 @@
 <%# Transaction rendered as a sentence for the unified "All" timeline. The columnar
-    Date|Amount|Value layout (_order) is used by the Transactions/Waiting/Cancelled
-    tabs instead. order_type "timeline" => shown only under "All". %>
+    Date|Amount|Value layout (_order) is used by the Transactions/Scheduled tabs instead.
+    data-order-type lists the tabs this row shows under: "all", plus "other" for the rows
+    with no columnar home (cancelled, abandoned, skipped, failed) — the sentence IS what
+    the Other tab has to show. %>
 <% row_class = order.failed? ? 'text-danger' : (inactive_order_row?(order) ? 'text-inactive' : '') %>
-<%= tag.tr id: dom_id(order, :timeline), class: row_class, data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: "timeline" } do %>
+<%= tag.tr id: dom_id(order, :timeline), class: row_class, data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: order.other? ? "all other" : "all" } do %>
   <td scope="row"><%= order.created_at.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></td>
   <td colspan="3" style="text-align: left;"><%= transaction_summary(order, decimals) %></td>
   <td>

--- a/app/views/bots/show.turbo_stream.erb
+++ b/app/views/bots/show.turbo_stream.erb
@@ -1,9 +1,10 @@
 <%= turbo_stream.append 'orders_list' do %>
   <% @feed_items.each do |item| %>
     <% if item.is_a?(Transaction) %>
-      <%# columnar row for the Transactions/Waiting/Cancelled tabs (submitted orders only) %>
+      <%# columnar row for the Transactions/Scheduled tabs (submitted orders only; a
+          cancelled or abandoned one belongs to no tab and stays hidden) %>
       <% if item.submitted? %>
-        <%= render partial: "bots/orders/order", locals: { order: item, decimals: @decimals, exchange_name: @bot.exchange.name, fetch: item.open? } %>
+        <%= render partial: "bots/orders/order", locals: { order: item, decimals: @decimals } %>
       <% end %>
       <%# sentence row for the "All" timeline %>
       <%= render partial: "bots/orders/order_timeline", locals: { order: item, decimals: @decimals } %>

--- a/app/views/shared/_segmented.html.erb
+++ b/app/views/shared/_segmented.html.erb
@@ -19,23 +19,30 @@
 <%= tag.div class: ['segmented', ('segmented--fluid' if fluid)],
             role: (links ? nil : 'radiogroup'),
             aria: { label: label },
-            data: { controller: 'segmented' }.merge(local_assigns[:data] || {}) do %>
+            data: { controller: 'segmented', action: 'click->segmented#toggle' }.merge(local_assigns[:data] || {}) do %>
   <span class="segmented__thumb" data-segmented-target="thumb"></span>
-  <% options.each do |option| %>
-    <% classes = ['segmented__option', ('is-on' if option[:active])] %>
-    <% shared = { value: option[:value] }.merge(option[:data] || {}).merge('segmented-target': 'option') %>
-    <% if links %>
-      <%# No select/arrow actions on a link: the server decides what is current, and moving
-          `is-on` on a cmd-click — which opens a new tab and leaves this page as it was —
-          would put the chip on an option that aria-current still says is not the one. %>
-      <%= link_to option[:label], option[:href], class: classes,
-                                                 aria: { current: ('page' if option[:active]) },
-                                                 data: shared %>
-    <% else %>
-      <%= tag.button option[:label], type: 'button', class: classes, role: 'radio',
-                                     aria: { checked: option[:active].present? },
-                                     tabindex: option[:active] ? 0 : -1,
-                                     data: shared.merge(action: 'segmented#select keydown->segmented#keys') %>
+  <%# display: contents while the control is expanded, a menu box once it has collapsed. %>
+  <div class="segmented__menu">
+    <% options.each do |option| %>
+      <% classes = ['segmented__option', ('is-on' if option[:active])] %>
+      <% shared = { value: option[:value] }.merge(option[:data] || {}).merge('segmented-target': 'option') %>
+      <% if links %>
+        <%# Select but no arrow actions: a link group is tabbed through, not arrowed through, and
+            the server still decides what is current — this only moves the chip while the click
+            navigates, so the switch animates instead of teleporting with the new page. The
+            controller ignores a modified click, which opens a new tab and changes nothing here. %>
+        <%= link_to option[:label], option[:href], class: classes,
+                                                   aria: { current: ('page' if option[:active]) },
+                                                   data: shared.merge(action: 'segmented#select') %>
+      <% else %>
+        <%= tag.button option[:label], type: 'button', class: classes, role: 'radio',
+                                       aria: { checked: option[:active].present? },
+                                       tabindex: option[:active] ? 0 : -1,
+                                       data: shared.merge(action: 'segmented#select keydown->segmented#keys') %>
+      <% end %>
     <% end %>
+  </div>
+  <%= tag.span class: 'segmented__caret', aria: { hidden: true } do %>
+    <%= render 'svg/16x16_down' %>
   <% end %>
 <% end %>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -541,8 +541,8 @@ bg:
         all: 'Всички'
         successful: 'Успешни'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Отменени'
         waiting: 'Насрочени'
+        other: 'Други'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -549,8 +549,8 @@ cs:
         all: 'Vše'
         successful: 'Úspěšné'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Zrušené'
         waiting: 'Naplánované'
+        other: 'Ostatní'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -541,8 +541,8 @@ da:
         all: 'Alle'
         successful: 'Gennemført'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Annulleret'
         waiting: 'Planlagt'
+        other: 'Andre'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -531,8 +531,8 @@ de:
         all: 'Alle'
         successful: 'Erfolgreich'
         transactions: 'Transaktionen'
-        cancelled: 'Storniert'
         waiting: 'Geplant'
+        other: 'Sonstige'
     bot_activity:
         events:
             rebalance_sell_placed: 'Rebalancing — Verkauf des übergewichteten Werts'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -541,8 +541,8 @@ el:
         all: 'Όλες'
         successful: 'Επιτυχημένες'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Ακυρωμένες'
         waiting: 'Προγραμματισμένες'
+        other: 'Άλλες'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -541,8 +541,8 @@ en:
         all: 'All'
         successful: 'Successful'
         transactions: 'Transactions'
-        cancelled: 'Cancelled'
         waiting: 'Scheduled'
+        other: 'Other'
     bot_activity:
         events:
             rebalance_sell_placed: 'Rebalancing — selling the overweight asset'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -531,8 +531,8 @@ es:
         all: 'Todos'
         successful: 'Exitosos'
         transactions: 'Transacciones'
-        cancelled: 'Cancelados'
         waiting: 'Programados'
+        other: 'Otros'
     bot_activity:
         events:
             rebalance_sell_placed: 'Reequilibrio — vendiendo el activo sobreponderado'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -531,8 +531,8 @@ fr:
         all: 'Tous'
         successful: 'Réussis'
         transactions: 'Transactions'
-        cancelled: 'Annulés'
         waiting: 'Programmés'
+        other: 'Autres'
     bot_activity:
         events:
             rebalance_sell_placed: 'Rééquilibrage — vente de l’actif surpondéré'

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -530,8 +530,8 @@ it:
         all: 'Tutti'
         successful: 'Riusciti'
         transactions: 'Transazioni'
-        cancelled: 'Annullati'
         waiting: 'Programmati'
+        other: 'Altri'
     bot_activity:
         events:
             rebalance_sell_placed: 'Ribilanciamento — vendita dell’asset sovrappesato'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -530,8 +530,8 @@ nl:
         all: 'Alle'
         successful: 'Geslaagd'
         transactions: 'Transacties'
-        cancelled: 'Geannuleerd'
         waiting: 'Gepland'
+        other: 'Overige'
     bot_activity:
         events:
             rebalance_sell_placed: 'Herbalanceren — de overwogen asset verkopen'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -534,8 +534,8 @@ pl:
         all: 'Wszystkie'
         successful: 'Zrealizowane'
         transactions: 'Transakcje'
-        cancelled: 'Anulowane'
         waiting: 'Oczekujące'
+        other: 'Inne'
     bot_activity:
         events:
             rebalance_sell_placed: 'Rebalansowanie — sprzedaż nadreprezentowanego aktywa'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -529,8 +529,8 @@ pt:
         all: 'Todos'
         successful: 'Bem-sucedidos'
         transactions: 'Transações'
-        cancelled: 'Cancelados'
         waiting: 'Programados'
+        other: 'Outros'
     bot_activity:
         events:
             rebalance_sell_placed: 'Reequilíbrio — a vender o ativo sobreponderado'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -534,8 +534,8 @@ ru:
         all: 'Все'
         successful: 'Выполненные'
         transactions: 'Транзакции'
-        cancelled: 'Отмененные'
         waiting: 'Ожидающие'
+        other: 'Прочие'
     bot_activity:
         events:
             rebalance_sell_placed: 'Ребалансировка — продажа перевешенного актива'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -549,8 +549,8 @@ sk:
         all: 'Všetky'
         successful: 'Úspešné'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Zrušené'
         waiting: 'Naplánované'
+        other: 'Ostatné'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -541,8 +541,8 @@ sv:
         all: 'Alla'
         successful: 'Lyckade'
         transactions: 'Transactions' # TODO: translate (English placeholder)
-        cancelled: 'Avbrutna'
         waiting: 'Schemalagda'
+        other: 'Övriga'
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:

--- a/test/controllers/bots/feed_show_test.rb
+++ b/test/controllers/bots/feed_show_test.rb
@@ -53,6 +53,48 @@ class Bots::FeedShowTest < ActionDispatch::IntegrationTest
     assert_match 'This symbol is not permitted', @response.body
   end
 
+  # The tabs are driven by one attribute per row: data-order-type carries the tabs that row
+  # belongs to. Sentence rows are "all", plus "other" when the row has nothing to show in the
+  # Amount/Value/Price columns. A columnar row carries its own single tab, or none at all when
+  # it has no columnar home — that row then never shows under any tab.
+
+  test 'a filled order is a sentence under All and a columnar row under Transactions' do
+    txn = create(:transaction, bot: @bot, external_id: 't1', external_status: :closed, created_at: 1.minute.ago)
+
+    get bot_path(id: @bot.id, format: :turbo_stream, decimals: @decimals)
+
+    assert_equal 'all', row_tabs(dom_id(txn, :timeline))
+    assert_equal 'successful', row_tabs(dom_id(txn))
+  end
+
+  test 'a cancelled order moves to Other as a sentence and keeps no columnar tab' do
+    txn = create(:transaction, bot: @bot, external_id: 'c1', external_status: :cancelled, created_at: 1.minute.ago)
+
+    get bot_path(id: @bot.id, format: :turbo_stream, decimals: @decimals)
+
+    assert_match 'Order cancelled', @response.body
+    assert_equal 'all other', row_tabs(dom_id(txn, :timeline))
+    assert_nil row_tabs(dom_id(txn)), 'the columnar row of a cancelled order must belong to no tab'
+  end
+
+  test 'skipped and failed orders join the same Other tab' do
+    skipped = create(:transaction, :skipped, bot: @bot, created_at: 2.minutes.ago)
+    failed = create(:transaction, :failed, bot: @bot, created_at: 1.minute.ago)
+
+    get bot_path(id: @bot.id, format: :turbo_stream, decimals: @decimals)
+
+    assert_equal 'all other', row_tabs(dom_id(skipped, :timeline))
+    assert_equal 'all other', row_tabs(dom_id(failed, :timeline))
+  end
+
+  test 'an activity row shows under All only' do
+    log = @bot.bot_activity_logs.create!(event: 'started', created_at: 1.minute.ago)
+
+    get bot_path(id: @bot.id, format: :turbo_stream, decimals: @decimals)
+
+    assert_equal 'all', row_tabs(dom_id(log))
+  end
+
   test 'excludes order_skipped activity from the feed' do
     skipped = @bot.bot_activity_logs.create!(event: 'order_skipped', created_at: 1.minute.ago)
 
@@ -60,5 +102,14 @@ class Bots::FeedShowTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_no_match dom_id(skipped), @response.body
+  end
+
+  private
+
+  # The tabs the given row belongs to, or nil when it carries none.
+  def row_tabs(row_id)
+    row = @response.body[%r{<tr id="#{row_id}".*?</tr>}m]
+    assert row, "expected a row with id #{row_id} in the feed"
+    row[/data-order-type="([^"]*)"/, 1]
   end
 end

--- a/test/controllers/bots/segmented_filters_test.rb
+++ b/test/controllers/bots/segmented_filters_test.rb
@@ -38,10 +38,10 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '.segmented.segmented--fluid', 1
-    # all + transactions + cancelled; no waiting row exists, so no waiting option
+    # all + transactions + other; no waiting row exists, so no waiting option
     assert_select 'button.segmented__option', 3
     assert_select '[data-value="all"].is-on', 1
-    assert_select 'button[data-value="cancelled"]', 1
+    assert_select 'button[data-value="other"]', 1
   end
 
   test 'a bot with only one category of orders shows no filter at all' do

--- a/test/helpers/bot_helper_test.rb
+++ b/test/helpers/bot_helper_test.rb
@@ -59,16 +59,6 @@ class BotHelperTest < ActionView::TestCase
 
   # == order_filter_type — used by _order.html.erb to tag the row with its tab ==
 
-  test 'order_filter_type maps abandoned to the cancelled tab' do
-    assert_equal 'cancelled',
-                 order_filter_type(build(:transaction, status: :submitted, external_status: :abandoned, external_id: 'a1'))
-  end
-
-  test 'order_filter_type maps cancelled to the cancelled tab' do
-    assert_equal 'cancelled',
-                 order_filter_type(build(:transaction, status: :submitted, external_status: :cancelled, external_id: 'c1'))
-  end
-
   test 'order_filter_type maps open and unknown to the waiting tab' do
     bot = create(:dca_single_asset)
     assert_equal 'waiting',
@@ -82,10 +72,13 @@ class BotHelperTest < ActionView::TestCase
                  order_filter_type(build(:transaction, status: :submitted, external_status: :closed, external_id: 'cl1'))
   end
 
-  test 'order_filter_type is nil for failed and skipped rows so they stay out of the cancelled tab' do
-    # Matches existing view behavior: failed/skipped rows show under "All" / "Other"
-    # but must not leak into the cancelled, successful, or waiting filters.
+  test 'order_filter_type is nil for every row the Other tab owns' do
+    # Cancelled, abandoned, skipped and failed rows are shown as sentence rows under
+    # "Other", so their columnar row belongs to no tab and must never leak into
+    # Transactions or Scheduled.
     bot = create(:dca_single_asset)
+    assert_nil order_filter_type(build(:transaction, bot: bot, status: :submitted, external_status: :cancelled, external_id: 'c1'))
+    assert_nil order_filter_type(build(:transaction, bot: bot, status: :submitted, external_status: :abandoned, external_id: 'a1'))
     assert_nil order_filter_type(build(:transaction, bot: bot, status: :failed, external_id: 'f1'))
     assert_nil order_filter_type(build(:transaction, bot: bot, status: :skipped, external_id: 's1'))
   end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -114,6 +114,37 @@ class TransactionTest < ActiveSupport::TestCase
     assert_not_includes rows, closed_txn
   end
 
+  test 'other scope collects every row the Other tab shows: cancelled, abandoned, skipped, failed' do
+    bot = create(:dca_single_asset)
+    cancelled_txn = create(:transaction, bot: bot, status: :submitted, external_status: :cancelled, external_id: 'c1')
+    abandoned_txn = create(:transaction, bot: bot, status: :submitted, external_status: :abandoned, external_id: 'a1')
+    skipped_txn = create(:transaction, :skipped, bot: bot)
+    failed_txn = create(:transaction, :failed, bot: bot)
+    open_txn = create(:transaction, bot: bot, status: :submitted, external_status: :open, external_id: 'o1')
+    closed_txn = create(:transaction, bot: bot, status: :submitted, external_status: :closed, external_id: 'cl1')
+
+    rows = bot.transactions.other
+
+    assert_includes rows, cancelled_txn
+    assert_includes rows, abandoned_txn
+    assert_includes rows, skipped_txn
+    assert_includes rows, failed_txn
+    assert_not_includes rows, open_txn
+    assert_not_includes rows, closed_txn
+  end
+
+  test 'other? answers the same question row by row' do
+    bot = create(:dca_single_asset)
+
+    assert build(:transaction, bot: bot, status: :submitted, external_status: :cancelled, external_id: 'c1').other?
+    assert build(:transaction, bot: bot, status: :submitted, external_status: :abandoned, external_id: 'a1').other?
+    assert build(:transaction, :skipped, bot: bot).other?
+    assert build(:transaction, :failed, bot: bot).other?
+    assert_not build(:transaction, bot: bot, status: :submitted, external_status: :open, external_id: 'o1').other?
+    assert_not build(:transaction, bot: bot, status: :submitted, external_status: :unknown, external_id: 'u1').other?
+    assert_not build(:transaction, bot: bot, status: :submitted, external_status: :closed, external_id: 'cl1').other?
+  end
+
   # == metrics cache invalidation ==
   # Metrics count an order only once it is closed; a close with no quote-exec change (an exchange that
   # closes an order with nil exec, or a legacy fill) must still invalidate the 30-day metrics cache.

--- a/test/views/order_filters_test.rb
+++ b/test/views/order_filters_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The bot log's filter tabs. The set is fluid — a tab only exists once the bot has a row
+# for it — and the control hides entirely while everything falls in one category.
+#
+# Three of the four tabs are named after what they hold; the fourth, "Other", is the
+# catch-all for the rows with nothing to show in the Amount/Value/Price columns:
+# cancelled, abandoned, skipped and failed. They appear there as their message sentence.
+class OrderFiltersTest < ActionView::TestCase
+  def render_filters(bot)
+    render partial: 'bots/orders/order_filters', locals: { bot: bot }
+  end
+
+  def values
+    css_select('.segmented__option').map { |option| option['data-value'] }
+  end
+
+  setup do
+    @bot = create(:dca_single_asset)
+    create(:transaction, bot: @bot, status: :submitted, external_status: :closed, external_id: 'cl1')
+  end
+
+  test 'a skipped row opens the Other tab' do
+    create(:transaction, :skipped, bot: @bot)
+
+    render_filters(@bot)
+
+    assert_equal %w[all successful other], values
+  end
+
+  test 'a failed row opens the Other tab' do
+    create(:transaction, :failed, bot: @bot)
+
+    render_filters(@bot)
+
+    assert_equal %w[all successful other], values
+  end
+
+  test 'a cancelled row opens the Other tab rather than a Cancelled one' do
+    create(:transaction, bot: @bot, status: :submitted, external_status: :cancelled, external_id: 'c1')
+
+    render_filters(@bot)
+
+    assert_equal %w[all successful other], values
+  end
+
+  test 'cancelled, skipped and failed rows share the one Other tab' do
+    create(:transaction, bot: @bot, status: :submitted, external_status: :cancelled, external_id: 'c1')
+    create(:transaction, :skipped, bot: @bot)
+    create(:transaction, :failed, bot: @bot)
+
+    render_filters(@bot)
+
+    assert_equal %w[all successful other], values
+  end
+
+  test 'Other sits after Scheduled, last, as the catch-all' do
+    create(:transaction, bot: @bot, status: :submitted, external_status: :open, external_id: 'o1')
+    create(:transaction, :skipped, bot: @bot)
+
+    render_filters(@bot)
+
+    assert_equal %w[all successful waiting other], values
+  end
+
+  test 'the tab is labelled Other' do
+    create(:transaction, :skipped, bot: @bot)
+
+    render_filters(@bot)
+
+    assert_select '.segmented__option[data-value=other]', text: I18n.t('order_filters.other')
+  end
+
+  test 'one category means no filters at all' do
+    create(:transaction, bot: @bot, status: :submitted, external_status: :closed, external_id: 'cl2')
+
+    render_filters(@bot)
+
+    assert_select '.segmented', 0
+  end
+end

--- a/test/views/segmented_test.rb
+++ b/test/views/segmented_test.rb
@@ -57,6 +57,14 @@ class SegmentedTest < ActionView::TestCase
     assert_select 'a[href="/bots/active"][aria-current]', 0
   end
 
+  # Without this the chip only ever teleports: the click leaves the page and the next one places
+  # its chip from scratch. Arrow keys stay off a link group — those are tabbed through.
+  test 'a link still moves the chip on the way out, so the switch animates' do
+    render_segmented(options: [{ value: 'all', label: 'All', href: '/bots/all', active: true }])
+
+    assert_select 'a[data-action="segmented#select"]', 1
+  end
+
   test 'the label names the group for a screen reader' do
     render_segmented(options: buttons, label: 'Chart mode')
 


### PR DESCRIPTION
Cancelled orders had a filter tab of their own, while skipped and failed rows had none: they showed in the timeline and then vanished from every named tab. To a reader those are one category — rows with nothing to put in the Amount/Value/Price columns — so they now share a single **Other** tab and appear there as the sentence the timeline already gives them.

**What changed**

- `Transaction.other` / `#other?` name the category once; the `cancelled` tab and its translations are gone, replaced by `other`.
- Each row carries the tabs it belongs to in `data-order-type` ("all", "all other", "successful", "waiting"), so filtering is a membership test instead of a special case for the timeline. A cancelled order's columnar row belongs to no tab and stays hidden.
- The per-row explanation tooltips (failed / skipped / cancelled) are removed — the sentence row says it, and it says it in the tab where the row now lives.
- The segmented control collapses into a menu when its options outgrow the room its parent gives it. Measured rather than keyed to a breakpoint: the labels are translated and the tab count depends on the bot, so the width at which they stop fitting is not a number anyone could write down.
- A link-based segmented group now moves the chip on the way out so the switch animates; a modified click (new tab) is ignored.

**Tests**: new `test/views/order_filters_test.rb` for the tab set, feed tests asserting the per-row tab list, `Transaction.other` / `#other?` model tests, plus the updated helper and segmented view tests.
