### PR TITLE
Lead the bot tile with the assets it holds

### DIFF
--- a/app/assets/stylesheets/new/_bot-tile.sass
+++ b/app/assets/stylesheets/new/_bot-tile.sass
@@ -1,6 +1,7 @@
 @use "../variables" as *
 
 .bot-tile
+  border-radius: 2rem
   padding: 2rem
   cursor: pointer
   gap: 1rem
@@ -10,12 +11,29 @@
     display: flex
     justify-content: space-between
     gap: 2rem
+  &__hgroup
+    display: flex
+    align-items: center
+    gap: 1rem
+    min-width: 0
+  &__logos
+    display: flex
+    flex: none
+    .asset-logo
+      position: relative
+      @for $i from 1 through 5
+        &:nth-child(#{$i})
+          z-index: 6 - $i
+      + .asset-logo
+        margin-left: -2.25rem
+        width: 3rem
+        border-radius: 1.25rem
   &__title
     font-weight: 550
-    font-size: 2.125rem
+    font-size: 2rem
     line-height: 2rem
     min-height: 2rem
-    color: var(--ash)
+    color: var(--ink)
     display: flex
     align-items: center
     gap: 0.75rem
@@ -33,7 +51,7 @@
   &__subtitle
     color: var(--ash)
     line-height: 4.5rem
-    font-size: 1.75rem
+    font-size: 1.5rem
   &__pnl
     font-weight: 600
     font-size: 2.125rem

--- a/app/assets/stylesheets/new/_small-ui.sass
+++ b/app/assets/stylesheets/new/_small-ui.sass
@@ -166,9 +166,13 @@ select
     display: block
     width: 2.5rem
     height: 2.5rem
-    box-shadow: var(--shadow-basic)
+    background: #fff
+    box-shadow: var(--shadow-paper) !important
     // The global `img { max-width: 100% }` reset resolves against the shrink-wrapped
     // table cell (content box 0), which flattens the logo to 0px wide. Opt out.
     max-width: none
     border-radius: 50%
     object-fit: contain
+    // Crop 2.5% off each side of the source: ~5% zoom, so logos with baked-in
+    // whitespace fill the circle. Ignored by browsers without object-view-box.
+    object-view-box: inset(2.5%)

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -223,6 +223,21 @@ class Bots::DcaIndex < Bot
     preview
   end
 
+  # The index the bot *tracks*, top-weighted first — its desired composition. Deliberately not
+  # bot_index_assets: those rows only exist once the bot has run its first composition refresh,
+  # so a freshly created bot would have nothing to show.
+  def desired_index_assets(limit = 3)
+    return [] if exchange.blank? || quote_asset_id.blank?
+
+    coin_ids = Rails.cache.fetch(['dca_index_top_coins', index_type, index_category_id], expires_in: 1.hour) do
+      result = MarketData.get_top_coins(index_type: index_type, category_id: index_category_id, limit: 150)
+      result.success? ? result.data.map { |coin| coin['id'] } : []
+    end
+    tradeable = exchange.tickers.available.trading_enabled.where(quote_asset_id: quote_asset_id).select(:base_asset_id)
+    assets = Asset.where(external_id: coin_ids, id: tradeable).index_by(&:external_id)
+    coin_ids.filter_map { |coin_id| assets[coin_id] }.first([limit, num_coins.to_i].min)
+  end
+
   def display_index_name
     return "#{index_name_prefix} #{num_coins}" if index_name_prefix.present? && num_coins.present?
     return index_name if index_name.present?

--- a/app/views/assets/_logo.html.erb
+++ b/app/views/assets/_logo.html.erb
@@ -1,5 +1,5 @@
 <%# Small round asset logo; falls back to the asset's own colour when it has no image. %>
-<% if asset&.image_url.present? %>
+<% if asset&.image_url.present? && !local_assigns[:color_only] %>
   <img class="asset-logo" src="<%= asset.image_url %>" alt="" loading="lazy">
 <% else %>
   <span class="asset-logo" style="background: <%= ensure_contrast(asset&.color || '#8A9BA8') %>"></span>

--- a/app/views/bots/bot_tile/_bot_tile.html.erb
+++ b/app/views/bots/bot_tile/_bot_tile.html.erb
@@ -2,34 +2,32 @@
   <%= link_to bot_path(bot) do %>
     <div class="bot-tile__header">
       <div class="bot-tile__hgroup">
+        <% logo_assets = if bot.dca_index?
+                           bot.desired_index_assets(5)
+                         elsif bot.dca_dual_asset?
+                           [bot.base0_asset, bot.base1_asset]
+                         else
+                           [bot.base_asset]
+                         end.compact %>
+        <% if logo_assets.any? %>
+          <div class="bot-tile__logos">
+            <% logo_assets.each_with_index do |logo_asset, i| %>
+              <%= render "assets/logo", asset: logo_asset, color_only: i.positive? %>
+            <% end %>
+          </div>
+        <% end %>
         <div class="bot-tile__title">
           <% hide_quote = bot.exchange&.stock_venue? %>
           <% if bot.dca_single_asset? && bot.quote_asset_id.present? && bot.base_asset_id.present? %>
-            <% unless hide_quote %>
-              <span><%= bot.quote_asset.symbol %></span>
-              <span class="bot-tile__operator">&rarr;</span>
-            <% end %>
             <span><%= bot.base_asset.symbol %></span>
           <% elsif bot.dca_dual_asset? && bot.quote_asset_id.present? && bot.base0_asset_id.present? && bot.base1_asset_id.present? %>
-            <% unless hide_quote %>
-              <span><%= bot.quote_asset.symbol %></span>
-              <span class="bot-tile__operator">&rarr;</span>
-            <% end %>
             <span>
               <span><%= bot.base0_asset.symbol %></span>,
               <span><%= bot.base1_asset.symbol %></span>
             </span>
           <% elsif bot.dca_index? && bot.quote_asset_id.present? && bot.num_coins.present? %>
-            <% unless hide_quote %>
-              <span><%= bot.quote_asset.symbol %></span>
-              <span class="bot-tile__operator">&rarr;</span>
-            <% end %>
             <span><%= bot.display_index_name %></span>
           <% elsif bot.signal? && bot.quote_asset_id.present? && bot.base_asset_id.present? %>
-            <% unless hide_quote %>
-              <span><%= bot.quote_asset.symbol %></span>
-              <span class="bot-tile__operator">&rarr;</span>
-            <% end %>
             <span><%= bot.base_asset.symbol %></span>
           <% end %>
           <% if bot.exchange.present? %>
@@ -37,13 +35,17 @@
           <% end %>
           <%# bot_type_label(bot) %>
         </div>
-        <div class="bot-tile__subtitle">
-          <%= bot.label %>
-        </div>
       </div>
       <% if bot.dca_single_asset? || bot.dca_dual_asset? || bot.dca_index? || bot.signal? %>
         <%= render "bots/bot_tile/bot_tile_pnl", bot: bot, loading: loading_hash[bot.id], pnl: pnl_hash[bot.id] || '' %>
       <% end %>
+    </div>
+    <div class="bot-tile__subtitle">
+      <% unless hide_quote %>
+        <span><%= bot.quote_asset.symbol %></span>
+      <% end %>
+      &middot;
+      <%= bot.label %>
     </div>
   <% end %>
   <div class="bot-control">

--- a/app/views/bots/dca_dual_assets/_metrics.html.erb
+++ b/app/views/bots/dca_dual_assets/_metrics.html.erb
@@ -24,7 +24,7 @@
         <thead>
           <tr>
             <th scope="col" class="table__logo"></th>
-            <th scope="col"><%= t('data_labels.asset') %></th>
+            <th scope="col"></th>
             <th scope="col"><%= t('data_labels.amount') %></th>
             <th scope="col"><%= t('data_labels.avg_price') %></th>
             <th scope="col"><%= t('data_labels.value') %></th>
@@ -86,7 +86,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th scope="col"><%= t('data_labels.asset') %></th>
+            <th scope="col"></th>
             <th scope="col"><%= t('data_labels.amount') %></th>
             <th scope="col"><%= t('data_labels.avg_price') %></th>
             <th scope="col"><%= t('data_labels.value') %></th>

--- a/app/views/bots/dca_single_assets/_metrics.html.erb
+++ b/app/views/bots/dca_single_assets/_metrics.html.erb
@@ -24,7 +24,7 @@
         <thead>
           <tr>
             <th scope="col" class="table__logo"></th>
-            <th scope="col"><%= t('data_labels.asset') %></th>
+            <th scope="col"></th>
             <th scope="col"><%= t('data_labels.amount') %></th>
             <th scope="col"><%= t('data_labels.avg_price') %></th>
             <th scope="col"><%= t('data_labels.value') %></th>
@@ -62,7 +62,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th scope="col"><%= t('data_labels.asset') %></th>
+            <th scope="col"></th>
             <th scope="col"><%= t('data_labels.amount') %></th>
             <th scope="col"><%= t('data_labels.avg_price') %></th>
             <th scope="col"><%= t('data_labels.value') %></th>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -44,7 +44,6 @@ bg:
         value_symbol: "Стойност (%{symbol})"
         invested_symbol: "Инвестирано (%{symbol})"
         date: "Дата"
-        asset: "Актив"
         amount: "Количество"
         avg_price: "Средна цена"
         price: "Цена"

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -44,7 +44,6 @@ cs:
         value_symbol: "Hodnota (%{symbol})"
         invested_symbol: "Investováno (%{symbol})"
         date: "Datum"
-        asset: "Aktivum"
         amount: "Množství"
         avg_price: "Prům. cena"
         price: "Cena"

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -44,7 +44,6 @@ da:
         value_symbol: "Værdi (%{symbol})"
         invested_symbol: "Investeret (%{symbol})"
         date: "Dato"
-        asset: "Aktiv"
         amount: "Beløb"
         avg_price: "Gns. pris"
         price: "Pris"

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -43,7 +43,6 @@ de:
         value_symbol: "Wert (%{symbol})"
         invested_symbol: "Investiert (%{symbol})"
         date: "Datum"
-        asset: "Anlagewert"
         amount: "Menge"
         avg_price: "Durchschn. Preis"
         price: "Preis"

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -44,7 +44,6 @@ el:
         value_symbol: "Αξία (%{symbol})"
         invested_symbol: "Επένδυση (%{symbol})"
         date: "Ημερομηνία"
-        asset: "Asset"
         amount: "Ποσό"
         avg_price: "Μ.Ο. τιμής"
         price: "Τιμή"

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -44,7 +44,6 @@ en:
         value_symbol: "Value (%{symbol})"
         invested_symbol: "Invested (%{symbol})"
         date: "Date"
-        asset: "Asset"
         amount: "Amount"
         avg_price: "Avg. Price"
         price: "Price"

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -43,7 +43,6 @@ es:
         value_symbol: "Valor (%{symbol})"
         invested_symbol: "Invertido (%{symbol})"
         date: "Fecha"
-        asset: "Activo"
         amount: "Cantidad"
         avg_price: "Precio prom."
         price: "Precio"

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -43,7 +43,6 @@ fr:
         value_symbol: "Valeur (%{symbol})"
         invested_symbol: "Investi (%{symbol})"
         date: "Date"
-        asset: "Actif"
         amount: "Montant"
         avg_price: "Prix moy."
         price: "Prix"

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -43,7 +43,6 @@ it:
         value_symbol: "Valore (%{symbol})"
         invested_symbol: "Investito (%{symbol})"
         date: "Data"
-        asset: "Asset"
         amount: "Importo"
         avg_price: "Prezzo medio"
         price: "Prezzo"

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -43,7 +43,6 @@ nl:
         value_symbol: "Waarde (%{symbol})"
         invested_symbol: "Geïnvesteerd (%{symbol})"
         date: "Datum"
-        asset: "Activa"
         amount: "Bedrag"
         avg_price: "Gem. prijs"
         price: "Prijs"

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -43,7 +43,6 @@ pl:
         value_symbol: "Wartość (%{symbol})"
         invested_symbol: "Zainwestowano (%{symbol})"
         date: "Data"
-        asset: "Aktywo"
         amount: "Ilość"
         avg_price: "Śr. cena"
         price: "Cena"

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -43,7 +43,6 @@ pt:
         value_symbol: "Valor (%{symbol})"
         invested_symbol: "Investido (%{symbol})"
         date: "Data"
-        asset: "Ativo"
         amount: "Quantidade"
         avg_price: "Preço méd."
         price: "Preço"

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -43,7 +43,6 @@ ru:
         value_symbol: "Стоимость (%{symbol})"
         invested_symbol: "Вложено (%{symbol})"
         date: "Дата"
-        asset: "Актив"
         amount: "Количество"
         avg_price: "Ср. цена"
         price: "Цена"

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -44,7 +44,6 @@ sk:
         value_symbol: "Hodnota (%{symbol})"
         invested_symbol: "Investované (%{symbol})"
         date: "Dátum"
-        asset: "Aktívum"
         amount: "Množstvo"
         avg_price: "Priem. cena"
         price: "Cena"

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -44,7 +44,6 @@ sv:
         value_symbol: "Värde (%{symbol})"
         invested_symbol: "Investerat (%{symbol})"
         date: "Datum"
-        asset: "Tillgång"
         amount: "Belopp"
         avg_price: "Snittpris"
         price: "Pris"


### PR DESCRIPTION
A bot tile opened with its quote symbol and an arrow — the same three characters on most tiles. It now opens with the asset logos, and the quote moves to the subtitle next to the bot's name.

**What changed**

- Single-asset and signal tiles show their base asset; dual-asset tiles show both.
- An index tile shows the top five members of the index, stacked with the first on top. Only the first carries its image; the rest render in their asset colour, so the stack reads as depth instead of five things to identify (`assets/_logo` takes a `color_only` local for that).
- `Bots::DcaIndex#desired_index_assets` is the index the bot *tracks*, not what it happens to hold. `bot_index_assets` rows only exist after the first composition refresh, so a freshly created bot showed nothing at all. The list is filtered to index members this exchange actually lists for the bot's quote asset — otherwise the tile leads with a coin that never appears anywhere else on the bot's page — capped at `num_coins`, and cached for an hour per index.
- Logo images are zoomed ~5% inside their circle (`object-view-box`), so the ones with baked-in whitespace fill it.
- The metrics tables drop their empty "Asset" header, which labelled a column of logos.
