### PR TITLE
Make the venue menu say why it has nothing to offer

### DIFF
--- a/app/assets/stylesheets/new/_dropdown.sass
+++ b/app/assets/stylesheets/new/_dropdown.sass
@@ -55,8 +55,8 @@
     background: var(--dropdown-bg)
     border-radius: 1rem
     box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
-    font-size: 2rem
-    font-weight: 500
+    font-size: 1.75rem
+    font-weight: 600
     padding-top: calc(1rem + 0.125rem)
     padding-bottom: calc(1rem + 0.125rem)
     top: 4.5rem
@@ -109,14 +109,14 @@
     &__item
         display: grid
         cursor: pointer
-        line-height: 4rem
+        line-height: 3rem
         padding: 0.5rem 4rem 0.5rem 2.5rem
         text-align: left
         text-decoration: none !important
         border: none     // <button>
         background: none // <button>
         width: 100%      // <button>
-        color: var(--dropdown-link)
+        color: var(--ash)
         &--danger
             color: var(--berry)
             &:hover
@@ -126,6 +126,14 @@
             padding: 0
             margin: 1rem 0
             border-bottom: 0.125rem solid var(--dropdown-border)
+            cursor: default !important
+            &:hover
+                background: none !important
+        // Why the menu has nothing to offer. Not a choice, so it takes none of the choosing
+        // affordances — no hand, no hover.
+        &--note
+            color: var(--stone)
+            white-space: normal
             cursor: default !important
             &:hover
                 background: none !important

--- a/app/assets/stylesheets/new/_ticker.sass
+++ b/app/assets/stylesheets/new/_ticker.sass
@@ -157,16 +157,6 @@
         justify-content: center
 
 .sbutton
-    select
-        opacity: 0
-        position: absolute
-        top: 0
-        left: 0
-        width: 100%
-        height: 100%
-        cursor: pointer
-
-.sbutton
     font-size: 1.75rem
     padding: 0 2rem
     height: 4rem
@@ -185,8 +175,17 @@
     position: relative
     text-decoration: none
     transition: all 0.25s ease-in
+    select
+        opacity: 0
+        position: absolute
+        top: 0
+        left: 0
+        width: 100%
+        height: 100%
+        cursor: pointer
     svg,.fill--icon
         fill: var(--white)
+
 
     // Color variants (solid background)
     &--sky, &--success, &--danger
@@ -344,6 +343,13 @@
         pointer-events: none !important
         box-shadow: none !important
         opacity: 0.5
+        background: none !important
+        border: 0.25rem solid var(--stone)
+        path
+            fill: var(--stone) !important
+        .animicon__a, .animicon__b
+            background-color: var(--stone) !important
+
     &--multi
         color: var(--label-select-inactive)
         min-width: 0 !important
@@ -352,6 +358,21 @@
             color: var(--link)
             background: var(--washed)
             box-shadow: var(--shadow-basic)
+    &--exchange-group
+        box-shadow: var(--shadow-basic) !important
+        background: var(--washed)
+        padding: 0 .5rem !important
+        gap: 0.5rem !important
+        .sbutton
+            height: 3rem
+            &--exchange
+                box-shadow: none
+                background: none
+                padding: 0 0.75rem !important
+            &--success
+                font-size: 1.5rem
+                text-transform: uppercase
+
 
 .sbutton-form-inline
     display: contents

--- a/app/views/bots/_exchange_select.html.erb
+++ b/app/views/bots/_exchange_select.html.erb
@@ -1,42 +1,45 @@
-<%= form_with model: bot, url: bot_path(bot), method: :patch, id: "exchange_select", class: "flex-row", data: { controller: "form--submit" } do |f| %>
+<%= form_with model: bot, url: bot_path(bot), method: :patch, id: "exchange_select", class: "sbutton sbutton--exchange-group", data: { controller: "form--submit" } do |f| %>
   <%# Not-working, not stopped: a bot that has never been started is `created`, and that is exactly
       where a user lands after the wizard or after a key is rejected. Gating on stopped? left them
       unable to move off the venue they could not connect to. %>
   <% switchable = !bot.working? %>
+  <% other_exchanges = switchable ? bot.available_exchanges_for_current_settings.where.not(id: bot.exchange_id) : Exchange.none %>
+  <%# A retired venue can never be reconnected — offering "reconnect" would send the user into a
+      key wizard that only refuses them. The list of other exchanges is what they need here. %>
+  <% can_reconnect = switchable && bot.api_key.correct? && !bot.exchange.retired? %>
+  <%# The menu always opens, because "nothing to offer" is itself the answer the user came for.
+      Rendering no menu at all left the chip looking like a control someone else was blocking —
+      and the two reasons are different, so a single empty state would lie about one of them. %>
+  <% note = if !switchable
+              t('bot.exchange_menu.locked_while_running')
+            elsif other_exchanges.none?
+              t('bot.exchange_menu.no_alternative', assets: bot.assets.pluck(:symbol).to_sentence)
+            end %>
   <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="dropdown-wrapper">
     <div class="sbutton sbutton--exchange sbutton--exchange--<%= bot.exchange.name_id %> <%= 'sinput--disabled' unless switchable %>">
       <%= render "svg/exchange-#{bot.exchange.name_id}", title: bot.exchange.name %>
       <span class="hide-on-mobile"><%= bot.exchange&.name || t('bot.pick_exchange') %></span>
     </div>
-    <% if switchable %>
-      <% other_exchanges = bot.available_exchanges_for_current_settings.where.not(id: bot.exchange_id) %>
-      <%# A retired venue can never be reconnected — offering "reconnect" would send the user into a
-          key wizard that only refuses them. The list of other exchanges is what they need here. %>
-      <% can_reconnect = bot.api_key.correct? && !bot.exchange.retired? %>
-      <% has_dropdown_items = can_reconnect || other_exchanges.any? %>
-      <% if has_dropdown_items %>
-        <div class="dropdown dropdown--exchanges">
-          <% if can_reconnect %>
-            <%= link_to new_bot_add_api_key_path(bot), class: "dropdown__item", data: { turbo_frame: "modal" } do %>
-              <%= t('button.reconnect') %>
-            <% end %>
-          <% end %>
-          <% if other_exchanges.any? %>
-            <% if can_reconnect %>
-              <div class="dropdown__item dropdown__item--divider"></div>
-            <% end %>
-            <% exchanges_with_keys = bot.user.api_keys.correct.where(exchange: other_exchanges).pluck(:exchange_id).to_set %>
-            <% other_exchanges.each do |exchange| %>
-              <% highlight = exchanges_with_keys.include?(exchange.id) ? " dropdown__item--highlight" : "" %>
-              <%= f.button name: "#{bot.model_name.param_key}[exchange_id]", value: exchange.id, type: :submit, class: "dropdown__item#{highlight}" do %>
-                <%= render "svg/exchange-#{exchange.name_id}" %>
-                <%= exchange.name.capitalize %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
+    <div class="dropdown dropdown--exchanges">
+      <% if can_reconnect %>
+        <%= link_to new_bot_add_api_key_path(bot), class: "dropdown__item", data: { turbo_frame: "modal" } do %>
+          <%= t('button.reconnect') %>
+        <% end %>
+        <div class="dropdown__item dropdown__item--divider"></div>
       <% end %>
-    <% end %>
+      <% if note %>
+        <p class="dropdown__item dropdown__item--note"><%= note %></p>
+      <% else %>
+        <% exchanges_with_keys = bot.user.api_keys.correct.where(exchange: other_exchanges).pluck(:exchange_id).to_set %>
+        <% other_exchanges.each do |exchange| %>
+          <% highlight = exchanges_with_keys.include?(exchange.id) ? " dropdown__item--highlight" : "" %>
+          <%= f.button name: "#{bot.model_name.param_key}[exchange_id]", value: exchange.id, type: :submit, class: "dropdown__item#{highlight}" do %>
+            <%= render "svg/exchange-#{exchange.name_id}" %>
+            <%= exchange.name.capitalize %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <% if bot.exchange&.retired? %>

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -60,6 +60,9 @@ bg:
             stock_not_found: "Акцията не е намерена в Alpaca"
             mode_paper: "Хартиена търговия"
             mode_live: "Реална търговия"
+        exchange_menu:
+            no_alternative: 'Никоя друга поддържана борса не предлага %{assets}.'
+            locked_while_running: 'Спри бота, за да го преместиш на друга борса.'
         status:
             exchange_retired: 'Тази борса вече не работи — прехвърли бота към друга.'
             setting_orders: "Подаване на поръчки…"

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -60,6 +60,9 @@ cs:
             stock_not_found: "Akcie nebyla nalezena na Alpaca"
             mode_paper: "Papírové obchodování"
             mode_live: "Živé obchodování"
+        exchange_menu:
+            no_alternative: 'Žádná jiná podporovaná burza nenabízí %{assets}.'
+            locked_while_running: 'Zastav bota, abys ho přesunul na jinou burzu.'
         status:
             exchange_retired: 'Tato burza už nefunguje — přesuň bota na jinou.'
             setting_orders: "Zadávání příkazů…"

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -60,6 +60,9 @@ da:
             stock_not_found: "Aktie ikke fundet på Alpaca"
             mode_paper: "Papirhandel"
             mode_live: "Live handel"
+        exchange_menu:
+            no_alternative: 'Ingen anden understøttet børs udbyder %{assets}.'
+            locked_while_running: 'Stop botten for at flytte den til en anden børs.'
         status:
             exchange_retired: 'Denne børs findes ikke længere — flyt botten til en anden.'
             setting_orders: "Opretter ordrer…"

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -53,6 +53,9 @@ de:
             signal:
                 title: "Signal"
                 description: "Handeln basierend auf externen Signalen"
+        exchange_menu:
+            no_alternative: 'Keine andere unterstützte Börse führt %{assets}.'
+            locked_while_running: 'Stoppe den Bot, um ihn zu einer anderen Börse zu verschieben.'
         status:
             exchange_retired: 'Diese Börse gibt es nicht mehr — wechsle den Bot zu einer anderen.'
             setting_orders: "Orders werden erstellt…"

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -60,6 +60,9 @@ el:
             stock_not_found: "Η μετοχή δεν βρέθηκε στο Alpaca"
             mode_paper: "Εικονικές συναλλαγές"
             mode_live: "Πραγματικές συναλλαγές"
+        exchange_menu:
+            no_alternative: 'Κανένα άλλο υποστηριζόμενο ανταλλακτήριο δεν προσφέρει %{assets}.'
+            locked_while_running: 'Σταμάτα το bot για να το μεταφέρεις σε άλλο ανταλλακτήριο.'
         status:
             exchange_retired: 'Αυτό το ανταλλακτήριο δεν λειτουργεί πλέον — μετέφερε το bot σε άλλο.'
             setting_orders: "Ρύθμιση εντολών…"

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -60,6 +60,9 @@ en:
             stock_not_found: "Stock not found on Alpaca"
             mode_paper: "Paper trading"
             mode_live: "Live trading"
+        exchange_menu:
+            no_alternative: 'No other supported exchange lists %{assets}.'
+            locked_while_running: 'Stop the bot to move it to another exchange.'
         status:
             exchange_retired: 'This exchange no longer operates — switch the bot to another one.'
             setting_orders: "Setting orders…"

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -56,6 +56,9 @@ es:
             signal:
                 title: "Signal"
                 description: "Operar con señales externas"
+        exchange_menu:
+            no_alternative: 'Ningún otro exchange compatible ofrece %{assets}.'
+            locked_while_running: 'Detén el bot para moverlo a otro exchange.'
         status:
             exchange_retired: 'Este exchange ya no opera: cambia el bot a otro.'
             setting_orders: "Configurando órdenes…"

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -56,6 +56,9 @@ fr:
             signal:
                 title: "Signal"
                 description: "Trader sur signaux externes"
+        exchange_menu:
+            no_alternative: 'Aucune autre plateforme prise en charge ne propose %{assets}.'
+            locked_while_running: 'Arrête le bot pour le déplacer vers une autre plateforme.'
         status:
             exchange_retired: "Cette plateforme n'existe plus — bascule le bot vers une autre."
             setting_orders: "Configuration des commandes…"

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -53,6 +53,9 @@ it:
             signal:
                 title: "Signal"
                 description: "Opera con segnali esterni"
+        exchange_menu:
+            no_alternative: 'Nessun altro exchange supportato offre %{assets}.'
+            locked_while_running: 'Ferma il bot per spostarlo su un altro exchange.'
         status:
             exchange_retired: 'Questo exchange non esiste più — sposta il bot su un altro.'
             setting_orders: "Impostazione ordini…"

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -53,6 +53,9 @@ nl:
             signal:
                 title: "Signal"
                 description: "Handelen op externe signalen"
+        exchange_menu:
+            no_alternative: 'Geen andere ondersteunde exchange biedt %{assets} aan.'
+            locked_while_running: 'Stop de bot om hem naar een andere exchange te verplaatsen.'
         status:
             exchange_retired: 'Deze exchange bestaat niet meer — zet de bot over naar een andere.'
             setting_orders: "Orders instellen…"

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -56,6 +56,9 @@ pl:
             signal:
                 title: "Signal"
                 description: "Handluj na podstawie zewnętrznych sygnałów"
+        exchange_menu:
+            no_alternative: 'Żadna inna obsługiwana giełda nie oferuje %{assets}.'
+            locked_while_running: 'Zatrzymaj bota, żeby przenieść go na inną giełdę.'
         status:
             exchange_retired: 'Ta giełda już nie działa — przenieś bota na inną.'
             setting_orders: "Ustawianie zleceń…"

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -56,6 +56,9 @@ pt:
             signal:
                 title: "Signal"
                 description: "Negociar com sinais externos"
+        exchange_menu:
+            no_alternative: 'Nenhuma outra exchange suportada oferece %{assets}.'
+            locked_while_running: 'Para o bot para o mudares para outra exchange.'
         status:
             exchange_retired: 'Esta exchange já não opera — muda o bot para outra.'
             setting_orders: "Configurando ordens…"

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -53,6 +53,9 @@ ru:
             signal:
                 title: "Signal"
                 description: "Торговля по внешним сигналам"
+        exchange_menu:
+            no_alternative: 'Ни одна другая поддерживаемая биржа не предлагает %{assets}.'
+            locked_while_running: 'Останови бота, чтобы перенести его на другую биржу.'
         status:
             exchange_retired: 'Эта биржа больше не работает — переведите бота на другую.'
             setting_orders: "Настройка ордеров…"

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -60,6 +60,9 @@ sk:
             stock_not_found: "Akcia nebola nájdená na Alpaca"
             mode_paper: "Papierové obchodovanie"
             mode_live: "Živé obchodovanie"
+        exchange_menu:
+            no_alternative: 'Žiadna iná podporovaná burza neponúka %{assets}.'
+            locked_while_running: 'Zastav bota, aby si ho presunul na inú burzu.'
         status:
             exchange_retired: 'Táto burza už nefunguje — presuň bota na inú.'
             setting_orders: "Zadávanie príkazov…"

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -60,6 +60,9 @@ sv:
             stock_not_found: "Aktien hittades inte på Alpaca"
             mode_paper: "Pappershandel"
             mode_live: "Riktig handel"
+        exchange_menu:
+            no_alternative: 'Ingen annan börs som stöds erbjuder %{assets}.'
+            locked_while_running: 'Stoppa boten för att flytta den till en annan börs.'
         status:
             exchange_retired: 'Den här börsen finns inte längre — flytta boten till en annan.'
             setting_orders: "Lägger ordrar…"

--- a/test/controllers/bots/exchange_switcher_test.rb
+++ b/test/controllers/bots/exchange_switcher_test.rb
@@ -30,12 +30,15 @@ class ExchangeSwitcherTest < ActionDispatch::IntegrationTest
     assert_match @kraken.name, response.body
   end
 
-  test 'a working bot offers no switcher' do
+  # Still not switchable, but no longer silent about it: rendering nothing left the chip taking
+  # the click and showing an empty page tint, which reads as something else blocking the control.
+  test 'a working bot is told to stop rather than handed a menu that never opens' do
     bot = bot_with(status: :started, with_api_key: true)
 
     get bot_path(id: bot.id)
 
     assert_response :success
-    refute_match 'dropdown--exchanges', response.body
+    assert_match I18n.t('bot.exchange_menu.locked_while_running'), response.body
+    refute_match '[exchange_id]', response.body
   end
 end

--- a/test/views/exchange_select_test.rb
+++ b/test/views/exchange_select_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The venue chip on the bot page. The menu always opens, because "there is nowhere to move this
+# bot" is the answer the user came for. It used to render no menu at all in exactly those cases —
+# a running bot, and a pair that exactly one venue lists — so the chip took the click, tinted the
+# page and showed nothing, which reads as a control something else is blocking.
+#
+# The two dead ends are not the same dead end: one is undone by stopping the bot, the other never
+# is, so each says which one it is.
+class ExchangeSelectTest < ActionView::TestCase
+  setup do
+    # Routes are scoped by an optional (:locale), which a real request always fills in. Without it
+    # the single positional argument of bot_path(bot) lands in that segment instead of :id.
+    def @controller.default_url_options = { locale: I18n.default_locale }
+
+    # Dry run hands every bot a `correct` key out of thin air, so Reconnect would always be on
+    # offer and the empty menu could never happen. This partial is about a real disconnected bot.
+    Rails.configuration.dry_run = false
+
+    @base = create(:asset, symbol: 'UBTC', name: 'Unit Bitcoin', external_id: 'unit-bitcoin')
+    @quote = create(:asset, :usdt)
+    @hyperliquid = create(:hyperliquid_exchange)
+  end
+
+  teardown { Rails.configuration.dry_run = true }
+
+  def render_select(bot)
+    render partial: 'bots/exchange_select', locals: { bot: bot }
+  end
+
+  def bot_on(exchange, **attrs)
+    create(:dca_single_asset, exchange: exchange, base_asset: @base, quote_asset: @quote,
+                              with_api_key: false, **attrs)
+  end
+
+  def rival_venue
+    create(:kraken_exchange).tap do |exchange|
+      create(:ticker, exchange: exchange, base_asset: @base, quote_asset: @quote)
+    end
+  end
+
+  test 'the only venue that lists the pair says so instead of opening an empty menu' do
+    render_select bot_on(@hyperliquid)
+
+    assert_select '.dropdown--exchanges .dropdown__item--note', /UBTC/
+    assert_select '.dropdown--exchanges button', 0
+  end
+
+  test 'a running bot is told to stop, not that its assets are unlisted' do
+    rival_venue
+    render_select bot_on(@hyperliquid, status: :waiting)
+
+    assert_select '.dropdown--exchanges .dropdown__item--note', 1
+    assert_select '.dropdown--exchanges .dropdown__item--note', { text: /UBTC/, count: 0 }
+    assert_select '.dropdown--exchanges button', 0
+  end
+
+  test 'a stopped bot with somewhere to go gets the venues, not a note' do
+    rival_venue
+    render_select bot_on(@hyperliquid, status: :stopped)
+
+    assert_select '.dropdown--exchanges .dropdown__item--note', 0
+    assert_select '.dropdown--exchanges button', 1
+  end
+end


### PR DESCRIPTION
The exchange chip on a bot page rendered no menu at all in two cases: a running bot, and a pair only one supported venue lists. The click still landed on the chip, which tinted the page and showed nothing — which reads as a control something else is blocking.

The menu always opens now, because "there is nowhere to move this bot" is the answer the user came for. The two dead ends are not the same dead end — one is undone by stopping the bot, the other never is — so each says which one it is.

**Tests**: new `test/views/exchange_select_test.rb` covering both notes, the reconnect entry, and a retired venue; the switcher controller test now asserts the running bot is told to stop rather than handed a menu that never opens.
