### PR TITLE
Tighten page padding and inline form spacing

### DIFF
--- a/app/assets/stylesheets/_variables.sass
+++ b/app/assets/stylesheets/_variables.sass
@@ -41,7 +41,7 @@
   font-family: var(--font-family)
 
   @media (min-width: 768px)
-    --ui-padding: 3rem
+    --ui-padding: 2.5rem
 
 [data-locale="el"]
   --font-family: 'Google Sans', sans-serif

--- a/app/assets/stylesheets/new/_conversational.sass
+++ b/app/assets/stylesheets/new/_conversational.sass
@@ -3,7 +3,7 @@
 .conversational
     display: flex
     line-height: 2.8rem
-    gap: 0.75rem
+    gap: 0.5rem
     font-weight: 600
     color: var(--ink)
     flex-wrap: wrap
@@ -19,10 +19,13 @@
         color: var(--stone)
     &--small
         flex-wrap: wrap
+        font-size: 1.75rem
         line-height: 3rem
         .sinput
             margin-left: 0 !important
             margin-right: 0 !important
+            padding-left: 1rem !important
+            padding-right: 1rem !important
             height: 3rem
             line-height: 3rem
             text-align: center
@@ -94,8 +97,6 @@
         line-height: 3rem
         height: 3.5rem
     .sinput
-        margin-left: -.25rem
-        margin-right: -.25rem
         padding-left: 1.5rem
         padding-right: 1.5rem
         color: var(--link)

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -58,7 +58,7 @@
         background: none
         box-shadow: none
         @media (min-width: 768px)
-            padding: calc(var(--ui-padding)/1.33) var(--ui-padding)
+            padding: calc(var(--ui-padding)*2) var(--ui-padding) var(--ui-padding)
             
         // The switch and the readout share one row across the top of the plot: the switch on
         // the left, on the same line as the date range, the numbers stacked on the right.
@@ -105,7 +105,8 @@
         &__modes
             display: flex
             flex-shrink: 0
-            margin-top: calc((2.25rem - 4rem) / 2)
+            @media (min-width: 768px)
+                margin-top: calc((2.25rem - 4rem) / 2)
     .main-rule
         padding-top: 4rem
         padding-bottom: 4rem

--- a/app/views/bots/dca_dual_assets/settings/_marketcap_allocation.html.erb
+++ b/app/views/bots/dca_dual_assets/settings/_marketcap_allocation.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="toggle-group__info" data-controller="class-toggle" data-class-toggle-toggle-classes-value='["hidden"]'>
       <div class="toggle-group__info__label">
-        <%= f.label :marketcap_allocated, t('bot.utils.mkt_cap_adjusted_html').html_safe, class: "label" %>
+        <%= f.label :marketcap_allocated, t('bot.utils.mkt_cap_adjusted_html').html_safe, class: "conversational conversational--small" %>
         <div class="tooltip-info-icon" data-controller="tooltip" data-action="click->tooltip#toggle click->class-toggle#toggle">
           <%= render 'svg/24x24_info' %>
           <%= render 'svg/24x24_info-filled' %>


### PR DESCRIPTION
Spacing only, no behaviour.

- Narrower page gutter on desktop (`--ui-padding`), and more room above the bot chart.
- Tighter inline (`conversational`) form spacing, and the market-cap toggle's label now uses that inline sentence style instead of a plain label, matching every other setting written as a sentence.
