### PR TITLE
Strip the bot tile back to its name

### DIFF
--- a/app/assets/stylesheets/new/_bot-control.sass
+++ b/app/assets/stylesheets/new/_bot-control.sass
@@ -18,7 +18,7 @@
         color: var(--label-select-inactive)
         position: relative
         box-shadow: var(--shadow-basic)
-        font-weight: 550
+        font-weight: 600
         white-space: nowrap
         text-overflow: ellipsis
         &__text

--- a/app/assets/stylesheets/new/_bot-tile.sass
+++ b/app/assets/stylesheets/new/_bot-tile.sass
@@ -16,20 +16,8 @@
     align-items: center
     gap: 1rem
     min-width: 0
-  &__logos
-    display: flex
-    flex: none
-    .asset-logo
-      position: relative
-      @for $i from 1 through 5
-        &:nth-child(#{$i})
-          z-index: 6 - $i
-      + .asset-logo
-        margin-left: -2.25rem
-        width: 3rem
-        border-radius: 1.25rem
   &__title
-    font-weight: 550
+    font-weight: 600
     font-size: 2rem
     line-height: 2rem
     min-height: 2rem
@@ -62,7 +50,7 @@
     padding: 0
     line-height: 3rem
     font-size: 1.75rem
-    font-weight: 550
+    font-weight: 600
     box-shadow: none !important
     &__text
       padding: 0

--- a/app/assets/stylesheets/new/_tooltip.sass
+++ b/app/assets/stylesheets/new/_tooltip.sass
@@ -3,7 +3,7 @@
 .tooltip
     opacity: 0
     position: absolute
-    font-weight: 550
+    font-weight: 600
     background: var(--sky)
     color: #fff
     padding: 2rem 2.25rem

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -223,21 +223,6 @@ class Bots::DcaIndex < Bot
     preview
   end
 
-  # The index the bot *tracks*, top-weighted first — its desired composition. Deliberately not
-  # bot_index_assets: those rows only exist once the bot has run its first composition refresh,
-  # so a freshly created bot would have nothing to show.
-  def desired_index_assets(limit = 3)
-    return [] if exchange.blank? || quote_asset_id.blank?
-
-    coin_ids = Rails.cache.fetch(['dca_index_top_coins', index_type, index_category_id], expires_in: 1.hour) do
-      result = MarketData.get_top_coins(index_type: index_type, category_id: index_category_id, limit: 150)
-      result.success? ? result.data.map { |coin| coin['id'] } : []
-    end
-    tradeable = exchange.tickers.available.trading_enabled.where(quote_asset_id: quote_asset_id).select(:base_asset_id)
-    assets = Asset.where(external_id: coin_ids, id: tradeable).index_by(&:external_id)
-    coin_ids.filter_map { |coin_id| assets[coin_id] }.first([limit, num_coins.to_i].min)
-  end
-
   def display_index_name
     return "#{index_name_prefix} #{num_coins}" if index_name_prefix.present? && num_coins.present?
     return index_name if index_name.present?

--- a/app/views/assets/_logo.html.erb
+++ b/app/views/assets/_logo.html.erb
@@ -1,5 +1,5 @@
 <%# Small round asset logo; falls back to the asset's own colour when it has no image. %>
-<% if asset&.image_url.present? && !local_assigns[:color_only] %>
+<% if asset&.image_url.present? %>
   <img class="asset-logo" src="<%= asset.image_url %>" alt="" loading="lazy">
 <% else %>
   <span class="asset-logo" style="background: <%= ensure_contrast(asset&.color || '#8A9BA8') %>"></span>

--- a/app/views/bots/bot_tile/_bot_tile.html.erb
+++ b/app/views/bots/bot_tile/_bot_tile.html.erb
@@ -2,22 +2,7 @@
   <%= link_to bot_path(bot) do %>
     <div class="bot-tile__header">
       <div class="bot-tile__hgroup">
-        <% logo_assets = if bot.dca_index?
-                           bot.desired_index_assets(5)
-                         elsif bot.dca_dual_asset?
-                           [bot.base0_asset, bot.base1_asset]
-                         else
-                           [bot.base_asset]
-                         end.compact %>
-        <% if logo_assets.any? %>
-          <div class="bot-tile__logos">
-            <% logo_assets.each_with_index do |logo_asset, i| %>
-              <%= render "assets/logo", asset: logo_asset, color_only: i.positive? %>
-            <% end %>
-          </div>
-        <% end %>
         <div class="bot-tile__title">
-          <% hide_quote = bot.exchange&.stock_venue? %>
           <% if bot.dca_single_asset? && bot.quote_asset_id.present? && bot.base_asset_id.present? %>
             <span><%= bot.base_asset.symbol %></span>
           <% elsif bot.dca_dual_asset? && bot.quote_asset_id.present? && bot.base0_asset_id.present? && bot.base1_asset_id.present? %>
@@ -41,10 +26,6 @@
       <% end %>
     </div>
     <div class="bot-tile__subtitle">
-      <% unless hide_quote %>
-        <span><%= bot.quote_asset.symbol %></span>
-      <% end %>
-      &middot;
       <%= bot.label %>
     </div>
   <% end %>


### PR DESCRIPTION
The asset logos leading the tile repeated what the name already says, so they're gone — and with them `desired_index_assets`, the index-only lookup that existed only to feed them: a top-150 market fetch behind an hourly cache, per index tile. `assets/_logo` loses the `color_only` flag that only the stacked-logo row used.

The subtitle no longer repeats the quote asset. The title already carries the pair, which also retires the stock-venue special case that hid the quote there.

Tile title, status button and tooltip move from font-weight 550 to 600.

3853 tests, 0 failures.