### PR TITLE
Show tokenized securities the logo of what they track

### DIFF
--- a/app/models/market_data.rb
+++ b/app/models/market_data.rb
@@ -813,7 +813,9 @@ class MarketData
       symbol: asset_data['symbol'],
       name: asset_data['name'],
       category: asset_data['category'],
-      image_url: asset_data['image_url'],
+      # Tokenized securities have no CoinGecko image; they share the captured logo of whatever they
+      # track, served host-relative. Same fallback the stock path uses (see sync_stocks).
+      image_url: asset_data['image_url'].presence || absolutize_logo_url(asset_data['logo_url']),
       color: asset_data['color'],
       market_cap_rank: asset_data['market_cap_rank'],
       market_cap: asset_data['market_cap'],

--- a/test/models/market_data_test.rb
+++ b/test/models/market_data_test.rb
@@ -492,6 +492,32 @@ class MarketDataSyncStocksFromDeltabadgerTest < ActiveSupport::TestCase
     end
   end
 
+  test 'builds a crypto asset image_url from logo_url, so tokenized securities show their logo' do
+    # A Hyperliquid RWA token arrives via the crypto asset feed with no CoinGecko image_url — it
+    # carries the host-relative logo of the security it tracks. Same fallback as the stock path.
+    MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
+
+    MarketData.import_assets!([{ 'external_id' => 'hl:0xc8a2', 'symbol' => 'TSLA',
+                                 'name' => 'Tesla - Wagyu.xyz', 'category' => 'Tokenized Stock',
+                                 'color' => '#CC0000', 'image_url' => nil,
+                                 'logo_url' => '/logos/1f/133-1fba5af2.png' }])
+
+    asset = Asset.find_by(external_id: 'hl:0xc8a2')
+    assert_equal 'https://data.deltabadger.com/logos/1f/133-1fba5af2.png', asset.image_url
+    assert_equal '#CC0000', asset.color
+  end
+
+  test 'prefers a coin\'s own image_url over logo_url' do
+    MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
+
+    MarketData.import_assets!([{ 'external_id' => 'bitcoin', 'symbol' => 'BTC', 'name' => 'Bitcoin',
+                                 'category' => 'Cryptocurrency',
+                                 'image_url' => 'https://coingecko.example/btc.png',
+                                 'logo_url' => nil }])
+
+    assert_equal 'https://coingecko.example/btc.png', Asset.find_by(external_id: 'bitcoin').image_url
+  end
+
   test 'builds image_url from the host-relative logo_url when image_url is absent' do
     MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
     @fake.stubs(:get_stocks).returns(Result::Success.new(


### PR DESCRIPTION
Tokenized securities on Hyperliquid rendered with no logo. They are crypto assets, so they arrive
through the crypto import — which reads only `image_url`, and a token that wraps a share has no
CoinGecko image of its own.

data-api now serves a host-relative `logo_url` on these assets, pointing at the logo captured for
the security the token tracks. A Hyperliquid Tesla token gets Tesla's logo; `MU` and `MUX` both get
Micron's, from one stored file.

`upsert_asset_attributes` was dropping the field, so this adds the fallback:

```ruby
image_url: asset_data['image_url'].presence || absolutize_logo_url(asset_data['logo_url'])
```

That is the same line `sync_stocks` has used since logos landed — it just never reached the crypto
path. `absolutize_logo_url` already exists and prefixes the data-api public host, since a browser
loads these directly and `data-api:3000` cannot serve them.

Colour needed no change; it is a plain column already imported, and is live.

## Rollout

Needs a version bump and a `v*` tag to build, then a fleet update. Until containers run this,
tokenized securities show their brand colour but no image.
