### PR TITLE
Show tokenized securities the logo of what they track

### DIFF
--- a/app/models/market_data.rb
+++ b/app/models/market_data.rb
@@ -813,7 +813,9 @@ class MarketData
       symbol: asset_data['symbol'],
       name: asset_data['name'],
       category: asset_data['category'],
-      image_url: asset_data['image_url'],
+      # Tokenized securities have no CoinGecko image; they share the captured logo of whatever they
+      # track, served host-relative. Same fallback the stock path uses (see sync_stocks).
+      image_url: asset_data['image_url'].presence || absolutize_logo_url(asset_data['logo_url']),
       color: asset_data['color'],
       market_cap_rank: asset_data['market_cap_rank'],
       market_cap: asset_data['market_cap'],

--- a/test/models/market_data_test.rb
+++ b/test/models/market_data_test.rb
@@ -492,6 +492,32 @@ class MarketDataSyncStocksFromDeltabadgerTest < ActiveSupport::TestCase
     end
   end
 
+  test 'builds a crypto asset image_url from logo_url, so tokenized securities show their logo' do
+    # A Hyperliquid RWA token arrives via the crypto asset feed with no CoinGecko image_url — it
+    # carries the host-relative logo of the security it tracks. Same fallback as the stock path.
+    MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
+
+    MarketData.import_assets!([{ 'external_id' => 'hl:0xc8a2', 'symbol' => 'TSLA',
+                                 'name' => 'Tesla - Wagyu.xyz', 'category' => 'Tokenized Stock',
+                                 'color' => '#CC0000', 'image_url' => nil,
+                                 'logo_url' => '/logos/1f/133-1fba5af2.png' }])
+
+    asset = Asset.find_by(external_id: 'hl:0xc8a2')
+    assert_equal 'https://data.deltabadger.com/logos/1f/133-1fba5af2.png', asset.image_url
+    assert_equal '#CC0000', asset.color
+  end
+
+  test 'prefers a coin\'s own image_url over logo_url' do
+    MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
+
+    MarketData.import_assets!([{ 'external_id' => 'bitcoin', 'symbol' => 'BTC', 'name' => 'Bitcoin',
+                                 'category' => 'Cryptocurrency',
+                                 'image_url' => 'https://coingecko.example/btc.png',
+                                 'logo_url' => nil }])
+
+    assert_equal 'https://coingecko.example/btc.png', Asset.find_by(external_id: 'bitcoin').image_url
+  end
+
   test 'builds image_url from the host-relative logo_url when image_url is absent' do
     MarketDataSettings.stubs(:deltabadger_public_url).returns('https://data.deltabadger.com')
     @fake.stubs(:get_stocks).returns(Result::Success.new(


### PR DESCRIPTION
data-api now serves a host-relative `logo_url` on crypto assets, for tokenized securities that have
no CoinGecko image of their own — a Hyperliquid Tesla token points at the logo captured for Tesla.
`upsert_asset_attributes` read only `image_url`, so the field was dropped and those assets rendered
blank.

One line, and the same fallback `sync_stocks` has used since logos landed. It just never reached the
crypto path.

Pairs with deltabadger-data-api#7, which is deployed. Colours are already live — that's a plain
column containers were reading anyway — so the 19 Hyperliquid tokenized securities currently show
their brand colour but no logo image. This is the half that makes the image appear.

Needs a release and fleet update to take effect.
