### PR TITLE
Let the chart draw one holding at a time

### DIFF
--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -142,6 +142,15 @@
         tbody
             overflow-y: auto
             height: 0
+            // A holding row draws itself on the chart above while the pointer is on it, and
+            // clicking pins it there. The highlight says the row is live; the accent bar says
+            // this is the one the chart is holding on to now that the pointer has moved away.
+            tr[data-symbol]
+                cursor: pointer
+                &:hover, &.is-selected
+                    background-color: var(--paper-on-washed)
+                &.is-selected td:first-child
+                    box-shadow: inset 0.25rem 0 0 var(--sky)
         th
             color: var(--concrete)
             font-weight: 600

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "@hotwired/stimulus";
 import Chart from "chart.js/auto";
 import "chartjs-adapter-date-fns";
 
+// The rows of both holdings tables — the index's constituents and the coins that left it.
+const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_table tr[data-symbol]";
+
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
   static targets = ["analyzerChart", "summary", "date", "pnl", "percent"];
@@ -12,6 +15,7 @@ export default class extends Controller {
     decimals: Number,
     bot: Number,
     pnl: Array,
+    assets: Object,
   };
 
   connect() {
@@ -23,6 +27,11 @@ export default class extends Controller {
     // inside that window would otherwise rebuild with an undefined budget (Array(NaN) throws,
     // leaving the buttons in one mode and the summary in the other).
     this.maxPointsToDraw = Math.max(1, Math.floor(this.element.offsetWidth / 3.5));
+    // Not null: a pin survives this controller, so a broadcast landing mid-read has to come back
+    // on the asset the user chose rather than snapping to the portfolio while they look at it.
+    this.focused = this.#chartable(this.#pinned);
+    this.pnlSeries = this.#derivePnl();
+    this.#markPinnedRow();
     this.#renderSummary();
     this.resizeObserver = new ResizeObserver(() => {
       // Cancel any pending resize handlers
@@ -72,6 +81,131 @@ export default class extends Controller {
     this.#renderSummary();
   }
 
+  // --- one holding at a time --------------------------------------------------------
+  //
+  // Pointing at a row of either holdings table draws that holding alone, on whichever mode is
+  // in hand; leaving the tables restores the whole bot. Delegated from the document because the
+  // tables are a sibling frame with its own broadcast — there is nothing here to bind to, and a
+  // listener bound to a row would die with the next metrics cycle.
+  focus(event) {
+    this.#focusOn(event.target.closest?.(HOLDING_ROWS)?.dataset.symbol);
+  }
+
+  blur() {
+    this.#focusOn(null);
+  }
+
+  // Clicking a row PINS it, so the pointer is free to leave the table and read along the curve —
+  // which is the whole point of drawing one asset and the one thing hover alone cannot give you.
+  // Clicking it again lets go. Hovering another row still previews it; the pin is what the chart
+  // falls back to, not a lock.
+  select(event) {
+    // The quitters table puts a Sell link on its rows, and arriving at the confirmation with the
+    // chart quietly re-pinned is not what that click was for.
+    if (event.target.closest?.("a, button, input, label")) return;
+
+    const symbol = event.target.closest?.(HOLDING_ROWS)?.dataset.symbol;
+    if (!this.#chartable(symbol)) return;
+
+    this.#pinned = this.#pinned === symbol ? null : symbol;
+    this.#markPinnedRow();
+    this.#focusOn(symbol);
+  }
+
+  // The tables are replaced by their own broadcast, which arrives on its own schedule and takes
+  // the mark with it — the pin outlives the row that was wearing it. Re-applied after any stream
+  // render (rAF: the swap happens in this event's default action, after the listeners).
+  restore() {
+    requestAnimationFrame(() => this.#markPinnedRow());
+  }
+
+  #focusOn(symbol) {
+    // Falls back to the pin, not to the portfolio: moving onto the chart must not undo the choice.
+    const next = this.#chartable(symbol) || this.#chartable(this.#pinned);
+    // mouseover fires again on every cell of the row being tracked along; only a change redraws.
+    if (next === this.focused) return;
+
+    this.focused = next;
+    this.pnlSeries = this.#derivePnl();
+    this.#buildChart();
+    this.#renderSummary();
+  }
+
+  // A holding with no marked point anywhere — every one of its points kept a fill mark — has no
+  // curve to draw, so it is neither hoverable nor pinnable rather than blanking the chart.
+  #chartable(symbol) {
+    const asset = symbol ? this.assetsValue?.[symbol] : null;
+    return asset?.value?.some((amount) => amount !== null) ? symbol : null;
+  }
+
+  // On the body, not on this element or in sessionStorage: it has to outlive the ~5-minute
+  // broadcast that replaces the chart and the tables, and it has to NOT outlive the page — Turbo
+  // swaps the body on a visit, so leaving the bot drops the pin, which is what a view-scoped
+  // choice means. Keyed by bot in case a body ever survives one.
+  get #pinned() {
+    const [bot, symbol] = (document.body.dataset.chartPin || "").split(":");
+    return bot === String(this.botValue) ? symbol : null;
+  }
+
+  set #pinned(symbol) {
+    if (symbol) document.body.dataset.chartPin = `${this.botValue}:${symbol}`;
+    else delete document.body.dataset.chartPin;
+  }
+
+  // The summary names the pinned asset, but the table is where the choice was made, so the row
+  // has to hold it too — the pointer is somewhere over the chart by then.
+  #markPinnedRow() {
+    const pinned = this.#pinned;
+    document.querySelectorAll(HOLDING_ROWS).forEach((row) => {
+      row.classList.toggle("is-selected", row.dataset.symbol === pinned);
+    });
+  }
+
+  // The value and invested curves in force: the focused holding's own, or the whole bot's.
+  get #series() {
+    const asset = this.focused && this.assetsValue[this.focused];
+    return asset ? [asset.value, asset.invested] : this.seriesValue;
+  }
+
+  // ONE ruler across the holdings: moving from one row to the next has to move the curve, not the
+  // axis. Scaled per asset, a 67 and a 2,095 holding draw the identical picture and the comparison
+  // the hover exists for is lost — the reader has no way to see that one of them is the portfolio
+  // and the other is a rounding error.
+  //
+  // Spanned over the assets ALONE, not the portfolio line: in VALUE that line is their sum, so
+  // including it would cost every asset the same margin of empty frame for nothing. The portfolio
+  // keeps its own scale, so the axis moves only when the pointer enters or leaves the tables.
+  get #assetBounds() {
+    this.bounds ||= Object.values(this.assetsValue).reduce(
+      (span, asset) => {
+        asset.value.forEach((amount, i) => {
+          const cost = asset.invested[i];
+          // The invested line is drawn at every point, including ones where value is unmarked.
+          span.value = Math.max(span.value, cost);
+          if (amount === null) return;
+
+          span.value = Math.max(span.value, amount);
+          span.low = Math.min(span.low, amount - cost);
+          span.high = Math.max(span.high, amount - cost);
+        });
+        return span;
+      },
+      // Seeded at zero, which is where both modes read from: VALUE's floor and PnL's baseline.
+      { value: 0, low: 0, high: 0 }
+    );
+    return this.bounds;
+  }
+
+  // Derived, not shipped: a holding's PnL is its value minus what it cost, the same subtraction
+  // `chart_pnl_series` does for the portfolio. Held rather than recomputed — #pnlMode is read on
+  // every pointer move.
+  #derivePnl() {
+    if (!this.focused) return this.pnlValue || [];
+
+    const [value, invested] = this.#series;
+    return value.map((amount, i) => (amount === null ? null : amount - invested[i]));
+  }
+
   // Per tab, not per browser: a mode is a way of reading this page now, not a preference.
   get #storageKey() {
     return `bot-chart-mode:${this.botValue}`;
@@ -95,7 +229,7 @@ export default class extends Controller {
 
   // Requires an actual curve: the plot falls back to VALUE when there is none.
   get #pnlMode() {
-    return this.currentMode === "pnl" && this.pnlValue?.some((point) => point !== null);
+    return this.currentMode === "pnl" && this.pnlSeries.some((point) => point !== null);
   }
 
   // --- summary above the chart: date, PnL in quote currency, PnL in % ------------------
@@ -142,19 +276,25 @@ export default class extends Controller {
   // bot made. That is what lets the switch go uncaptioned — the reader sees one headline and
   // two ways of drawing the history behind it.
   #renderSummary(point = null) {
-    const value = this.seriesValue[0];
-    const invested = this.seriesValue[1];
+    const [value, invested] = this.#series;
     if (!value?.length) return;
 
     const timestamps = this.#timestamps();
-    const last = value.length - 1;
+    // The last point that HAS a value: a focused holding's tail is null wherever the portfolio
+    // point there kept its fill mark, and reading the headline off it would print NaN.
+    let last = value.length - 1;
+    while (last >= 0 && value[last] === null) last -= 1;
+    if (last < 0) return;
+
     const at = point || { x: timestamps[last], value: value[last], invested: invested[last] };
     const spent = Number(at.invested);
     const pnl = Number(at.value) - spent;
     const first = this.#date(timestamps[0]);
     const on = this.#date(at.x);
 
-    this.dateTarget.textContent = point || first === on ? on : `${first} – ${on}`;
+    // Named while focused, or the curve would change under the pointer with nothing saying to what.
+    const range = point || first === on ? on : `${first} – ${on}`;
+    this.dateTarget.textContent = this.focused ? `${this.focused} · ${range}` : range;
     this.pnlTarget.textContent = this.#money(pnl);
     this.percentTarget.textContent = this.#percent(spent > 0 ? pnl / spent : 0);
     this.summaryTarget.classList.toggle("text-danger", pnl < 0);
@@ -187,13 +327,13 @@ export default class extends Controller {
   }
 
   #valueAt(timestamp) {
-    return Number(this.seriesValue[0][this.#indexAt(timestamp)]);
+    return Number(this.#series[0][this.#indexAt(timestamp)]);
   }
 
   // The invested total in force at a timestamp: the last transaction at or before it. Binary
   // search — the labels are sorted and this runs on every pointer move.
   #investedAt(timestamp) {
-    return Number(this.seriesValue[1][this.#indexAt(timestamp)]);
+    return Number(this.#series[1][this.#indexAt(timestamp)]);
   }
 
   #indexAt(timestamp) {
@@ -312,10 +452,16 @@ export default class extends Controller {
   }
 
   #valuePlot(labels) {
-    const series = this.seriesValue.map((serie) =>
-      serie.map((amount, i) => ({ x: labels[i], y: Number(amount) }))
+    // Nulls dropped, not zeroed: a focused holding has no market value at a point the portfolio
+    // left on its fill mark. Every point carries its own timestamp, so a gap costs nothing.
+    const series = this.#series.map((serie) =>
+      serie
+        .map((amount, i) => ({ x: labels[i], y: amount === null ? null : Number(amount) }))
+        .filter((point) => point.y !== null)
     );
-    const maxValue = Math.max(...series[0].map((p) => p.y), ...series[1].map((p) => p.y));
+    const maxValue = this.focused
+      ? this.#assetBounds.value
+      : Math.max(...series[0].map((p) => p.y), ...series[1].map((p) => p.y));
     const profitable = series[0].at(-1).y >= series[1].at(-1).y;
     const points = Math.min(this.maxPointsToDraw, series[0].length, series[1].length);
     const colors = [profitable ? this.#color("--grass") : this.#color("--berry"), this.#color("--benchmark")];
@@ -338,8 +484,8 @@ export default class extends Controller {
   #pnlPlot(curve) {
     const ys = curve.map((point) => point.y);
     // Zero stays in frame whether or not the curve reaches it: the line is what the curve means.
-    const low = Math.min(0, ...ys);
-    const high = Math.max(0, ...ys);
+    const low = this.focused ? this.#assetBounds.low : Math.min(0, ...ys);
+    const high = this.focused ? this.#assetBounds.high : Math.max(0, ...ys);
     const pad = (high - low) * 0.1 || 0.01;
     const up = this.#color("--grass");
     const down = this.#color("--berry");
@@ -374,7 +520,7 @@ export default class extends Controller {
   // with the labels. They are dropped here — every point carries its own timestamp, and
   // decimation cannot sample around a hole.
   #pnlPoints(labels) {
-    return this.pnlValue
+    return this.pnlSeries
       .map((point, i) => ({ x: labels[i], y: point === null ? null : Number(point) }))
       .filter((point) => point.y !== null);
   }

--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -52,7 +52,11 @@ module Bot::ChartSeries
   # grids     - { symbol => [[time, price], ...] } ascending
   # holdings: - ->(i) { { symbol => amount } } held after transaction i
   # cash:     - ->(i) { realized proceeds } after transaction i — cash does not float with price
-  def chart_marked_at_market(chart, grids, holdings:, cash:)
+  # basis:    - ->(i) { { symbol => cost basis } } after transaction i. Given, the chart also
+  #             carries a per-symbol split (:assets) for the holdings tables to hover against.
+  #             Omitted where the split would only duplicate the portfolio line — a single-asset
+  #             bot's one holding IS the whole chart.
+  def chart_marked_at_market(chart, grids, holdings:, cash:, basis: nil)
     labels = chart[:labels]
     values = chart[:series][0]
     invested = chart[:series][1]
@@ -62,6 +66,8 @@ module Bot::ChartSeries
     marked_labels = []
     marked_values = []
     marked_invested = []
+    marked_split = []
+    marked_basis = []
     cursor = 0
 
     axis.each do |time|
@@ -76,9 +82,14 @@ module Bot::ChartSeries
       # that exists: the live point holds exactly what the last transaction left. Keyed on
       # MISSING data, never on a zero value, or a bot that legitimately sold out would be
       # redrawn as still holding its position.
-      held = holdings.call(cursor)
-      held = holdings.call(cursor - 1) if cursor.positive? && held.values.all?(&:nil?)
-      at_market = chart_market_value(held, grids, time)
+      row = cursor
+      held = holdings.call(row)
+      if row.positive? && held.values.all?(&:nil?)
+        row -= 1
+        held = holdings.call(row)
+      end
+      split = chart_market_values(held, grids, time)
+      at_market = split&.values&.sum
 
       if at_market
         marked_values << (at_market + cash.call(cursor))
@@ -90,9 +101,16 @@ module Bot::ChartSeries
 
       marked_labels << time
       marked_invested << invested[cursor]
+      next unless basis
+
+      # nil where the point kept its fill mark: the portfolio total survives there, but no
+      # per-symbol split does, and inventing one would put an asset at zero.
+      marked_split << split
+      marked_basis << basis.call(row)
     end
 
-    chart.merge(labels: marked_labels, series: [marked_values, marked_invested])
+    marked = chart.merge(labels: marked_labels, series: [marked_values, marked_invested])
+    basis ? marked.merge(assets: chart_asset_series(marked_split, marked_basis)) : marked
   end
 
   private
@@ -101,20 +119,37 @@ module Bot::ChartSeries
     grids.values.flatten(1).filter_map { |time, _price| time if time >= from }
   end
 
-  # nil unless every held symbol has a price at this time — a partially-priced portfolio is not
-  # a market value, it is a market value minus whatever could not be priced.
-  def chart_market_value(held, grids, time)
-    total = 0.to_d
+  # { symbol => value at market }, or nil unless every held symbol has a price at this time — a
+  # partially-priced portfolio is not a market value, it is a market value minus whatever could
+  # not be priced. A symbol held at zero needs no price: it is worth zero at any of them.
+  def chart_market_values(held, grids, time)
+    values = {}
     held.each do |symbol, amount|
       amount = amount.to_d
-      next if amount.zero?
+      if amount.zero?
+        values[symbol] = 0.to_d
+        next
+      end
 
       price = chart_grid_price(grids[symbol], time)
       return nil unless price
 
-      total += amount * price
+      values[symbol] = amount * price
     end
-    total
+    values
+  end
+
+  # The per-point splits transposed into one series per symbol, each parallel with the marked
+  # labels — what the chart swaps in when a holdings row is hovered.
+  #
+  # ponytail: every symbol ships its whole series with the page — 57 KB of JSON on a 20-coin index
+  # over 246 points, so a few hundred on a wide one with years of daily candles behind it. Fetch
+  # the hovered symbol on demand if that ever bites.
+  def chart_asset_series(splits, basis)
+    splits.compact.flat_map(&:keys).uniq.index_with do |symbol|
+      { value: splits.map { |split| split && (split[symbol] || 0) },
+        invested: basis.map { |held| held[symbol] || 0 } }
+    end
   end
 
   def chart_grid_price(marks, time)

--- a/app/models/bots/dca_dual_asset/measurable.rb
+++ b/app/models/bots/dca_dual_asset/measurable.rb
@@ -6,10 +6,11 @@ module Bots::DcaDualAsset::Measurable
   include Bot::RebalanceAccounting
 
   def metrics(force: false)
-    # _v3: realised P/L and the contributed/ledger split. The old shape lives up to 30 days in the
+    # _v3: realised P/L and the contributed/ledger split. _v4: a per-leg cost-basis snapshot per
+    # transaction, so the chart can draw one leg on its own. The old shape lives up to 30 days in the
     # cache, so the key must
     # change or every existing bot serves pre-rebalance numbers after deploy.
-    cache_key = "bot_#{id}_metrics_v3"
+    cache_key = "bot_#{id}_metrics_v4"
     Rails.cache.fetch(cache_key, expires_in: 30.days, force: force) do
       data = initialize_metrics_data
       transactions_array = transactions.submitted.order(created_at: :asc).pluck(:created_at,
@@ -55,6 +56,10 @@ module Bots::DcaDualAsset::Measurable
         data[:chart][:series][0] << portfolio_value(totals[:current_value_in_quote].values.sum, books)
         data[:chart][:extra_series][0] << ledger[base0_asset_id][:amount]
         data[:chart][:extra_series][1] << ledger[base1_asset_id][:amount]
+        # What each leg cost, which is the zero line of its own curve when the user hovers its
+        # row. NOT derivable from the total: a rebalance moves basis between the two legs.
+        data[:chart][:invested_series][0] << ledger[base0_asset_id][:invested]
+        data[:chart][:invested_series][1] << ledger[base1_asset_id][:invested]
         (data[:chart][:cash_series] ||= []) << uninvested_cash(books)
       end
 
@@ -121,6 +126,9 @@ module Bots::DcaDualAsset::Measurable
       # extra_series stays parallel with labels — the chart reads holdings by index.
       metrics_data[:chart][:extra_series][0] << metrics_data[:total_base0_amount]
       metrics_data[:chart][:extra_series][1] << metrics_data[:total_base1_amount]
+      metrics_data[:chart][:invested_series] ||= [[], []]
+      metrics_data[:chart][:invested_series][0] << metrics_data[:base0_total_quote_amount_invested]
+      metrics_data[:chart][:invested_series][1] << metrics_data[:base1_total_quote_amount_invested]
       (metrics_data[:chart][:cash_series] ||= []) << metrics_data[:rebalance_cash].to_d
       # Raw per-symbol marks for the chart's price grid (see Bot::ChartSeries).
       metrics_data[:live_prices] = { ticker0.base => price0, ticker1.base => price1 }
@@ -144,6 +152,10 @@ module Bots::DcaDualAsset::Measurable
         holdings: lambda { |i|
           { ticker0.base => metrics_data[:chart][:extra_series][0][i],
             ticker1.base => metrics_data[:chart][:extra_series][1][i] }
+        },
+        basis: lambda { |i|
+          basis = metrics_data[:chart][:invested_series] || [[], []]
+          { ticker0.base => basis[0][i] || 0, ticker1.base => basis[1][i] || 0 }
         },
         # Cash a rebalance sell realized but its buy has not spent yet. Zero except between the two
         # legs — but marking those points at zero would draw a dip the portfolio never took.
@@ -181,11 +193,11 @@ module Bots::DcaDualAsset::Measurable
   private
 
   def metrics_with_current_prices_cache_key
-    "bot_#{id}_metrics_with_current_prices_v3"
+    "bot_#{id}_metrics_with_current_prices_v4"
   end
 
   def metrics_with_current_prices_and_candles_cache_key
-    "bot_#{id}_metrics_with_current_prices_and_candles_v3"
+    "bot_#{id}_metrics_with_current_prices_and_candles_v4"
   end
 
   def calculate_pnl(from, to)
@@ -205,6 +217,10 @@ module Bots::DcaDualAsset::Measurable
         extra_series: [
           [], # base0 amount acquired
           []  # base1 amount acquired
+        ],
+        invested_series: [
+          [], # base0 cost basis, for the per-leg curve
+          []  # base1 cost basis
         ],
         cash_series: [] # rebalance proceeds realized but not yet redeployed
       },

--- a/app/models/bots/dca_index/measurable.rb
+++ b/app/models/bots/dca_index/measurable.rb
@@ -10,10 +10,7 @@ module Bots::DcaIndex::Measurable
   CANDLE_FETCH_THREADS = 6
 
   def metrics(force: false)
-    # _v3: realised P/L and the contributed/ledger split. The old shape lives up to 30 days in the
-    # cache, so the key must change or every existing bot serves pre-realisation numbers after deploy.
-    cache_key = "bot_#{id}_metrics_v3"
-    Rails.cache.fetch(cache_key, expires_in: 30.days, force: force) do
+    Rails.cache.fetch(metrics_cache_key, expires_in: 30.days, force: force) do
       data = initialize_metrics_data
       transactions_array = transactions.submitted.order(created_at: :asc).pluck(
         :created_at,
@@ -50,6 +47,9 @@ module Bots::DcaIndex::Measurable
 
         # Store snapshot of per-asset amounts for candle interpolation
         data[:chart][:extra_series] << ledger.transform_values { |entry| entry[:amount] }
+        # And of what each asset cost, which is the zero line of its own curve when the user
+        # hovers its row. NOT derivable from the totals: a rebalance moves basis between assets.
+        data[:chart][:invested_series] << ledger.transform_values { |entry| entry[:invested] }
         (data[:chart][:cash_series] ||= []) << uninvested_cash(books)
 
         # Metrics data — average entry price is over REGULAR buys only; a swap is not an entry.
@@ -134,6 +134,8 @@ module Bots::DcaIndex::Measurable
       metrics_data[:chart][:labels] << Time.current
       # extra_series stays parallel with labels — the chart reads holdings by index.
       metrics_data[:chart][:extra_series] << metrics_data[:asset_breakdown].transform_values { |data| data[:amount] }
+      (metrics_data[:chart][:invested_series] ||= []) <<
+        metrics_data[:asset_breakdown].transform_values { |data| data[:quote_invested] }
       (metrics_data[:chart][:cash_series] ||= []) << metrics_data[:rebalance_cash].to_d
       metrics_data[:live_prices] = live_prices
 
@@ -163,6 +165,7 @@ module Bots::DcaIndex::Measurable
       metrics_data[:chart] = chart_marked_at_market(
         metrics_data[:chart], grids,
         holdings: ->(i) { (metrics_data[:chart][:extra_series][i] || {}).slice(*priceable) },
+        basis: ->(i) { ((metrics_data[:chart][:invested_series] || [])[i] || {}).slice(*priceable) },
         # Cash a rebalance sell realized but its buy has not spent yet — and, when a remainder ends
         # as dust, permanently. Marking those points at zero would draw a loss that never happened.
         cash: ->(i) { (metrics_data[:chart][:cash_series] || [])[i] || 0 }
@@ -214,12 +217,20 @@ module Bots::DcaIndex::Measurable
     ledger.sum { |symbol, entry| entry[:amount] * (asset_prices[symbol] || 0) }
   end
 
+  # _v3: realised P/L and the contributed/ledger split. _v4: a per-symbol cost-basis snapshot per
+  # transaction, so the chart can draw one holding on its own. The cached shape lives up to 30 days,
+  # so this has to move with it or every existing bot serves the old numbers after a deploy.
+  # A method, not a literal: the tests that seed this cache were reading the string off the source.
+  def metrics_cache_key
+    "bot_#{id}_metrics_v4"
+  end
+
   def metrics_with_current_prices_cache_key
-    "bot_#{id}_metrics_with_current_prices_v3"
+    "bot_#{id}_metrics_with_current_prices_v4"
   end
 
   def metrics_with_current_prices_and_candles_cache_key
-    "bot_#{id}_metrics_with_current_prices_and_candles_v3"
+    "bot_#{id}_metrics_with_current_prices_and_candles_v4"
   end
 
   def optimal_candles_timeframe_for_duration(duration)
@@ -307,6 +318,7 @@ module Bots::DcaIndex::Measurable
           []  # invested
         ],
         extra_series: [],
+        invested_series: [], # per-asset cost basis, for the per-asset curve
         cash_series: [] # rebalance proceeds realized but not yet redeployed
       },
       total_quote_amount_invested: 0,

--- a/app/views/bots/_assets_table.html.erb
+++ b/app/views/bots/_assets_table.html.erb
@@ -17,7 +17,10 @@
   <tbody id="<%= body_id %>">
     <% rows.each do |row| %>
       <% pnl = row[:pnl] %>
-      <tr>
+      <%# The symbol is the handle the chart reads the row by: pointing at a holding draws that
+          one holding, clicking pins it there. Delegated from the document, so no controller
+          lives here — these tables are replaced by a broadcast of their own. %>
+      <tr data-symbol="<%= row[:symbol] %>">
         <td class="table__logo"><%= render 'assets/logo', asset: row[:asset] %></td>
         <td scope="row"><%= row[:symbol] %></td>
         <td><%= row[:amount] %></td>

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -26,14 +26,25 @@
       <% decimals = bot.decimals[:quote] || 8 %>
       <% series = metrics[:chart][:series].map { |serie| serie.map { |amount| amount.round(decimals) } } %>
       <% pnl_series = chart_pnl_series(series[0], series[1]).map(&:to_f) %>
+      <%# One entry per holding the tables can show, rounded on the same ruler as the portfolio
+          line. nil where the point kept its fill mark and has no per-symbol split; the curve
+          skips those rather than drawing the asset at zero. %>
+      <% assets = (metrics[:chart][:assets] || {}).transform_values do |serie|
+           { value: serie[:value].map { |amount| amount&.round(decimals)&.to_f },
+             invested: serie[:invested].map { |amount| amount.to_d.round(decimals).to_f } }
+         end %>
       <%= tag.div data: {
         controller: "bot--chart",
+        action: "mouseover@document->bot--chart#focus mouseleave@document->bot--chart#blur " \
+                "click@document->bot--chart#select " \
+                "turbo:before-stream-render@document->bot--chart#restore",
         bot__chart_bot_value: bot.id,
         bot__chart_quote_value: bot.quote_asset.symbol,
         bot__chart_decimals_value: decimals,
         bot__chart_labels_value: metrics[:chart][:labels].map { |label| label.in_time_zone(current_user.time_zone) },
         bot__chart_series_value: series,
-        bot__chart_pnl_value: pnl_series
+        bot__chart_pnl_value: pnl_series,
+        bot__chart_assets_value: assets
       } do %>
         <%# The switch sits on the date line, opposite it: one row across the top of the plot.
             VALUE always climbs for a DCA bot because the money going in climbs; PnL makes the

--- a/test/controllers/bots/assets_table_test.rb
+++ b/test/controllers/bots/assets_table_test.rb
@@ -36,6 +36,18 @@ class Bots::AssetsTableTest < ActionDispatch::IntegrationTest
     assert_equal ['', '', 'Amount', 'Avg. Price', 'Value', 'P/L'], headers.first
   end
 
+  # The chart hovers against these, one holding at a time; without the symbol on the row there is
+  # nothing for it to key on.
+  test 'every holding row carries the symbol the chart draws it by' do
+    usd = create(:asset, :usd)
+    bot = create(:dca_index, user: @user, quote_asset: usd)
+    warm_index_prices(bot)
+
+    get bot_path(id: bot.id)
+
+    assert_select '#assets_metrics_table tbody tr[data-symbol="AAA"]', 1
+  end
+
   test 'a bot with nothing invested still shows the table, with a placeholder row' do
     bot = create(:dca_single_asset, user: @user)
 

--- a/test/controllers/bots/dca_indexes/quitters_table_test.rb
+++ b/test/controllers/bots/dca_indexes/quitters_table_test.rb
@@ -231,7 +231,7 @@ class Bots::DcaIndexes::QuittersTableTest < ActionDispatch::IntegrationTest
     # exited_symbols, which reads the ledger underneath rather than the priced layer, so that a cold
     # price cache cannot turn a live button into a 404.
     data[:asset_breakdown] = values.transform_values { |v| { amount: v.to_d / 100, quote_invested: v.to_d } }
-    Rails.cache.write("bot_#{@bot.id}_metrics_v3", data)
+    Rails.cache.write(@bot.send(:metrics_cache_key), data)
     Rails.cache.write(@bot.send(:metrics_with_current_prices_cache_key), data)
   end
 

--- a/test/controllers/bots/liquidations_controller_test.rb
+++ b/test/controllers/bots/liquidations_controller_test.rb
@@ -211,7 +211,7 @@ class Bots::LiquidationsControllerTest < ActionDispatch::IntegrationTest
     end
     # The ledger underneath, which is what exited_symbols reads — see the quitters-table test.
     data[:asset_breakdown] = values.transform_values { |v| { amount: v.to_d / 100, quote_invested: v.to_d } }
-    Rails.cache.write("bot_#{@bot.id}_metrics_v3", data)
+    Rails.cache.write(@bot.send(:metrics_cache_key), data)
     Rails.cache.write(@bot.send(:metrics_with_current_prices_cache_key), data)
   end
 end

--- a/test/controllers/bots/show_chart_test.rb
+++ b/test/controllers/bots/show_chart_test.rb
@@ -57,6 +57,28 @@ class Bots::ShowChartTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # One curve per holding, so pointing at a row of the holdings table draws that holding alone.
+  # nil where the portfolio point kept its fill mark and has no per-symbol split to give.
+  test 'chart hands over a curve per holding for the tables to hover against' do
+    data = @bot.metrics.deep_dup
+    data[:chart][:labels] = [Time.utc(2026, 1, 1), Time.utc(2026, 2, 1)]
+    data[:chart][:series] = [[100.0, 260.0], [100.0, 200.0]]
+    data[:chart][:assets] = { 'AAA' => { value: [nil, 260.to_d], invested: [100.to_d, 200.to_d] } }
+    Rails.cache.write(@bot.send(:metrics_with_current_prices_and_candles_cache_key), data)
+
+    get bot_path(id: @bot.id)
+
+    assert_select '#chart [data-controller="bot--chart"]', 1 do |chart|
+      assert_equal({ 'AAA' => { 'value' => [nil, 260.0], 'invested' => [100.0, 200.0] } },
+                   JSON.parse(chart.first['data-bot--chart-assets-value']))
+      # Hover previews, click pins so the pointer can leave the table for the curve, and the
+      # stream listener puts the mark back on a row its own broadcast replaced.
+      %w[#focus #blur #select #restore].each do |handler|
+        assert_match "bot--chart#{handler}", chart.first['data-action']
+      end
+    end
+  end
+
   # Nothing invested, nothing to be ahead or behind of. A switch with one usable side is
   # furniture.
   test 'a chart with no pnl curve offers no switch' do

--- a/test/models/bots/chart_asset_series_test.rb
+++ b/test/models/bots/chart_asset_series_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The chart carries one curve per holding, alongside the portfolio's own, so pointing at a row
+# of either holdings table can draw that holding alone.
+#
+# Marked on the SAME ruler as the portfolio line — the venue's candle grid — so the per-asset
+# curves add up to the line above them and a fill away from market is not a per-asset dip
+# either. A point the portfolio left on its fill mark has no per-symbol split at all: the total
+# survives there, the parts do not, and the asset's curve skips it rather than reading zero.
+#
+# Cost basis is per asset and NOT derivable from the total: a rebalance moves basis between
+# holdings, so the sold one must not keep a full basis against shrunken holdings.
+class ChartAssetSeriesTest < ActiveSupport::TestCase
+  T0 = Time.utc(2026, 1, 1, 12, 0, 0)   # first buy, BTC only
+  T1 = T0 + 2.days                      # second buy, ETH joins
+  NOW = T0 + 14.days                    # > 300h of history -> 1.day candles
+
+  setup do
+    travel_to NOW
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  teardown { travel_back }
+
+  def daily_candles(price, from: T0 - 1.day)
+    day = from.midnight
+    candles = []
+    while day <= NOW
+      candles << [day, price.to_d, price.to_d, price.to_d, price.to_d, 1.to_d]
+      day += 1.day
+    end
+    candles
+  end
+
+  def ticker_stub(id:, base:, price:, from: T0 - 1.day)
+    ticker = stub(id: id, base: base, ticker: "#{base}USDT")
+    ticker.stubs(:get_candles).returns(Result::Success.new(daily_candles(price, from: from)))
+    ticker
+  end
+
+  def exchange_stub
+    exchange = stub
+    exchange.stubs(:get_tickers_prices)
+            .returns(Result::Success.new('BTCUSDT' => 100.to_d, 'ETHUSDT' => 50.to_d))
+    exchange
+  end
+
+  # 1 BTC bought at a 90 fill, then 2 ETH at a 50 fill. The market is flat at 100 / 50, so every
+  # marked point values BTC at 100 and ETH at 100.
+  def index_bot(from: T0 - 1.day)
+    bot = create(:dca_index, user: create(:user))
+    bot.stubs(:metrics).returns(
+      { chart: { labels: [T0, T1],
+                 series: [[90.to_d, 190.to_d], [90.to_d, 190.to_d]],
+                 extra_series: [{ 'BTC' => 1.to_d }, { 'BTC' => 1.to_d, 'ETH' => 2.to_d }],
+                 invested_series: [{ 'BTC' => 90.to_d }, { 'BTC' => 90.to_d, 'ETH' => 100.to_d }],
+                 cash_series: [0.to_d, 0.to_d] },
+        asset_breakdown: { 'BTC' => { amount: 1.to_d, quote_invested: 90.to_d },
+                           'ETH' => { amount: 2.to_d, quote_invested: 100.to_d } },
+        rebalance_cash: 0.to_d,
+        total_quote_amount_invested: 190.to_d }
+    )
+    bot.stubs(:tickers).returns([ticker_stub(id: 1, base: 'BTC', price: 100, from: from),
+                                 ticker_stub(id: 2, base: 'ETH', price: 50, from: from)])
+    bot.stubs(:exchange).returns(exchange_stub)
+    bot
+  end
+
+  def dual_bot
+    bot = create(:dca_dual_asset, user: create(:user))
+    bot.stubs(:metrics).returns(
+      { chart: { labels: [T0, T1],
+                 series: [[90.to_d, 190.to_d], [90.to_d, 190.to_d]],
+                 extra_series: [[1.to_d, 1.to_d], [0.to_d, 2.to_d]],
+                 invested_series: [[90.to_d, 90.to_d], [0.to_d, 100.to_d]],
+                 cash_series: [0.to_d, 0.to_d] },
+        total_base0_amount: 1.to_d, total_base1_amount: 2.to_d,
+        base0_total_quote_amount_invested: 90.to_d,
+        base1_total_quote_amount_invested: 100.to_d,
+        total_quote_amount_invested: 190.to_d,
+        rebalance_cash: 0.to_d }
+    )
+    bot.stubs(:ticker0).returns(ticker_stub(id: 1, base: 'BTC', price: 100))
+    bot.stubs(:ticker1).returns(ticker_stub(id: 2, base: 'ETH', price: 50))
+    bot.stubs(:exchange).returns(exchange_stub)
+    bot
+  end
+
+  def chart(bot)
+    bot.metrics_with_current_prices_and_candles(force: true)[:chart]
+  end
+
+  def at(chart_data, symbol, field, time)
+    chart_data[:assets][symbol][field][chart_data[:labels].index(time)]
+  end
+
+  # == one curve per holding ==
+
+  test 'every holding gets its own value and cost-basis series' do
+    data = chart(index_bot)
+
+    assert_equal %w[BTC ETH], data[:assets].keys.sort
+    data[:assets].each_value do |serie|
+      assert_equal data[:labels].size, serie[:value].size
+      assert_equal data[:labels].size, serie[:invested].size
+    end
+  end
+
+  test 'a holding is valued at market on its own, not given a share of the total' do
+    data = chart(index_bot)
+
+    assert_equal 100.to_d, at(data, 'BTC', :value, T1) # 1 BTC at 100
+    assert_equal 100.to_d, at(data, 'ETH', :value, T1) # 2 ETH at 50
+  end
+
+  test 'a holding carries the basis it was bought with, not the portfolio total' do
+    data = chart(index_bot)
+
+    assert_equal 90.to_d, at(data, 'BTC', :invested, T1)
+    assert_equal 100.to_d, at(data, 'ETH', :invested, T1)
+  end
+
+  test 'a holding the bot did not own yet is worth nothing, and cost nothing' do
+    data = chart(index_bot)
+
+    assert_equal 0, at(data, 'ETH', :value, T0)
+    assert_equal 0, at(data, 'ETH', :invested, T0)
+  end
+
+  test 'the holdings add up to the line drawn above them' do
+    data = chart(index_bot)
+
+    data[:labels].each_index do |i|
+      parts = data[:assets].values.filter_map { |serie| serie[:value][i] }
+      next if parts.size < data[:assets].size # an unmarked point has no split at all
+
+      assert_equal data[:series][0][i], parts.sum
+    end
+  end
+
+  # == a point with no split is skipped, never zeroed ==
+
+  test 'a point left on its fill mark carries no per-symbol value' do
+    # Candles only start the day after the first buy, so T0 has nothing below it to interpolate
+    # from and keeps the 90 `metrics` gave it.
+    data = chart(index_bot(from: T1 - 1.day))
+
+    assert_equal 90.to_d, data[:series][0][data[:labels].index(T0)]
+    assert_nil at(data, 'BTC', :value, T0)
+    assert_equal 100.to_d, at(data, 'BTC', :value, T1) # covered again, and marked
+  end
+
+  # == the pair ==
+
+  test 'each leg of a dual-asset bot gets its own curve' do
+    data = chart(dual_bot)
+
+    assert_equal 100.to_d, at(data, 'BTC', :value, T1)
+    assert_equal 100.to_d, at(data, 'ETH', :value, T1)
+    assert_equal 90.to_d, at(data, 'BTC', :invested, T1)
+    assert_equal 100.to_d, at(data, 'ETH', :invested, T1)
+  end
+
+  # == the one bot that needs no split ==
+
+  test 'a single-asset bot ships no split — its one holding IS the chart' do
+    bot = create(:dca_single_asset, user: create(:user))
+    bot.stubs(:metrics).returns(
+      { chart: { labels: [T0], series: [[90.to_d], [90.to_d]],
+                 extra_series: [[1.to_d], [0.to_d]] },
+        total_base_amount: 1.to_d, total_realized_proceeds: 0.to_d,
+        total_quote_amount_invested: 90.to_d }
+    )
+    bot.stubs(:ticker).returns(ticker_stub(id: 1, base: 'BTC', price: 100))
+    bot.stubs(:exchange).returns(exchange_stub)
+
+    assert_nil chart(bot)[:assets]
+  end
+end


### PR DESCRIPTION
Closes #222.

The bot chart only ever drew the portfolio. On a ten-coin index that is the one line
you cannot read a coin out of — the table says BCH is down 25% and the chart says the
bot is up 10%, with nothing connecting the two.

Hovering a row of the holdings table, or of the coins that left the index, now draws
that holding alone: its own value against its own cost basis in VALUE, its own return
in P/L. The summary names it (`ETH · Jan 22 – Aug 21`), so the headline is that
holding's P/L in quote and in percent — the same figure the row shows.

Clicking a row pins it. That is what makes the chart readable: with the asset held, the
pointer is free to leave the table and track along the curve, reading the value at every
date. Clicking the row again lets go, and so does leaving the bot. Hovering another row
still previews it; the pin is what focus falls back to, not a lock.

While a holding is in focus the y axis is spanned over **all** of them — same zero, same
scale — so moving between rows moves the curve and not the axis. Measured on a live
index: every asset draws on `0–2500` in VALUE and on `−355.1 … 228.8` in P/L, so BTC at
2,100 fills the frame and SOL at 67 hugs the floor, which is the actual relationship
between them. The portfolio keeps its own scale; in VALUE that line is their sum, so
folding it into the shared span would cost every asset the same margin of empty frame.

## How the split is built

`Bot::ChartSeries#chart_marked_at_market` takes an optional `basis:` lambda and emits
`chart[:assets] = { symbol => { value:, invested: } }`, each array parallel with the
marked labels. The per-symbol values fall straight out of the market-value pass that was
already there, so every asset is marked on the same candle grid as the portfolio line —
the parts add up to the whole, and a fill away from market is no more a per-asset dip
than it is a portfolio one. Points the portfolio left on their fill mark carry `nil`:
the total survives there, no per-symbol split does, and the curve skips them rather than
drawing the asset at zero.

Per-asset cost basis is not derivable from the total, because a rebalance transfers basis
between holdings — the sold asset must not keep a full basis against shrunken holdings.
So the index and the pair now snapshot `ledger[…][:invested]` per transaction.

A single-asset bot ships no split. Its one holding is the whole chart, so the data would
duplicate the portfolio line to redraw the identical picture.

## Deploying

The index and dual-asset `metrics` cache keys move **v3 → v4**, so every index and pair
recomputes its metrics from all transactions the first time it is viewed after the
release. The index's key is now a `metrics_cache_key` method — two tests were reading the
literal string out of the source.

Per-asset series ship inline with the page: 57 KB of JSON on a 20-coin index over 246
points. `chart_series.rb` carries the note and the fetch-on-hover upgrade path if a wide
bot with years of daily candles ever makes that hurt.

## Not covered

The rows are pointer-only — no keyboard path, matching the chart itself. Every number
stays readable as table text.

## Verified

3,999 tests plus the new `ChartAssetSeriesTest` (per-asset value and basis, holdings
summing to the portfolio line, unmarked points carrying no split, both legs of a pair,
and a single-asset bot shipping nothing). Driven in the browser on a live index: both
modes, both tables, pin surviving a real metrics broadcast that replaces the chart and
the tables, the pin cleared by navigating away, and the quitters table's Sell link not
hijacked by the pin click.

