### PR TITLE
Keep the interval grid on absolute time

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,6 +2,28 @@ class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encounter transient errors
   # retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
+  # Run every job in the app zone, whatever the payload says.
+  #
+  # ActiveJob stamps Time.zone into the payload at enqueue and re-applies it around perform. A
+  # self-rescheduling chain (Bot::ActionJob) enqueues its successor from inside that block, so it
+  # re-stamps the same zone on every hop: one enqueue under a foreign zone pins it on the chain
+  # for as long as the chain lives — months, and invisibly, since nothing in the app sets
+  # Time.zone any more. Under a DST zone, calendar math then silently shifts an interval grid by
+  # the offset. Registered after ActiveJob's own zone callback, so it runs inside it and wins.
+  # Views that want the user's zone ask for it explicitly (in_time_zone), so nothing needs the
+  # inherited one.
+  around_perform { |_job, block| Time.use_zone(Time.zone_default, &block) }
+
+  # And clean the payload itself, not just the perform window. retry_on handlers — and the retry
+  # enqueue they trigger — run OUTSIDE the perform callbacks (rescue_with_handler is called once
+  # run_callbacks has unwound), and serialize reads this attribute rather than the current zone,
+  # so a retried job would carry a stale zone onward. Normalizing here also disarms every payload
+  # already sitting in a queue: the first hop after deploy drops the foreign zone for good.
+  def deserialize(job_data)
+    super
+    self.timezone = Time.zone_default.name
+  end
+
   # Use ActiveJob's built-in executions count for retry tracking
   def retry_count
     executions - 1

--- a/app/models/automation/schedulable.rb
+++ b/app/models/automation/schedulable.rb
@@ -73,8 +73,15 @@ module Automation::Schedulable
         return checkpoint if checkpoint > Time.current
       end
     else
+      # Both sides of this must speak the same clock. The count is elapsed SECONDS, so the step
+      # has to be added as seconds too (.to_f), not as a calendar duration: `time + n.weeks`
+      # preserves the LOCAL WALL CLOCK, so under a DST zone it lands an hour off the grid the
+      # count was measured against — before it, going into summer. A checkpoint in the past is
+      # re-enqueued immediately and spins the job at machine speed until real time catches up.
+      # Jobs are pinned to the app zone (ApplicationJob), so this is belt and braces — but the
+      # grid must not depend on which zone the caller happens to be in either way.
       intervals_since_checkpoint = ((Time.current - checkpoint) / effective_interval_duration.seconds).ceil
-      checkpoint + (intervals_since_checkpoint * effective_interval_duration)
+      checkpoint + (intervals_since_checkpoint * effective_interval_duration.to_f)
     end
   end
 
@@ -92,7 +99,14 @@ module Automation::Schedulable
   end
 
   def last_interval_checkpoint_at
-    next_interval_checkpoint_at - effective_interval_duration
+    # Step back the same way the forward grid steps forward, or the pair straddles a DST
+    # transition: subtracting a calendar duration from an absolute grid point lands 25 hours back
+    # in autumn, and Bot::Accountable#pending_quote_amount floors an interval count against this
+    # value — one whole contribution dropped. Months keep calendar arithmetic; they are not a
+    # fixed number of seconds, and the forward branch treats them the same way.
+    return next_interval_checkpoint_at - effective_interval_duration if effective_interval_duration == 1.month
+
+    next_interval_checkpoint_at - effective_interval_duration.to_f
   end
 
   def progress_percentage

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+# Records the Time.zone its perform actually ran in.
+class ZoneProbeJob < ApplicationJob
+  cattr_accessor :observed_zone
+
+  def perform
+    self.class.observed_zone = Time.zone.name
+  end
+end
+
+class ApplicationJobTest < ActiveSupport::TestCase
+  # ActiveJob stamps Time.zone into the payload at enqueue and re-applies it around every perform,
+  # and a self-rescheduling chain re-stamps whatever zone it ran in — so a single enqueue under a
+  # foreign zone pins that zone on the chain for as long as it lives. The app runs on UTC
+  # (config.time_zone), and job-side date math must not depend on which zone a chain inherited:
+  # under a DST zone, calendar arithmetic silently moves an interval grid by the offset.
+  test 'performs in the app zone even when the payload carries another one' do
+    ZoneProbeJob.observed_zone = nil
+    job = Time.use_zone('Vienna') { ZoneProbeJob.new }
+    assert_equal 'Vienna', job.timezone, 'precondition: the payload carries the foreign zone'
+
+    job.perform_now
+
+    assert_equal 'UTC', ZoneProbeJob.observed_zone
+    assert_equal 'UTC', Time.zone.name, 'the zone must be restored after the job'
+  end
+
+  # retry_on handlers and the retry enqueue itself run OUTSIDE the perform callbacks
+  # (rescue_with_handler is called once run_callbacks has unwound), so wrapping perform is not
+  # enough: a retried job re-serializes its own timezone attribute and would carry a stale zone
+  # onward. Normalizing on deserialize cleans every payload already sitting in the queue.
+  test 'a deserialized payload carrying a foreign zone is normalized to the app zone' do
+    payload = Time.use_zone('Vienna') { ZoneProbeJob.new.serialize }
+    assert_equal 'Vienna', payload['timezone'], 'precondition: the stored payload carries it'
+
+    job = ActiveJob::Base.deserialize(payload)
+
+    assert_equal 'UTC', job.timezone
+    assert_equal 'UTC', job.serialize['timezone'], 'a retry must not re-persist the stale zone'
+  end
+end

--- a/test/models/automation/schedulable_test.rb
+++ b/test/models/automation/schedulable_test.rb
@@ -100,4 +100,68 @@ class Automation::SchedulableTest < ActiveSupport::TestCase
     # With feature disabled, repeat_anchor_at must equal started_at
     assert_equal bot.started_at, bot.repeat_anchor_at
   end
+
+  # ---------- DST: the interval grid must be absolute, not wall-clock ----------
+
+  # An ActiveJob payload carries the Time.zone it was enqueued in, and ActiveJob re-applies that
+  # zone (Time.use_zone) around every perform — so a self-rescheduling chain keeps running under
+  # whatever zone it was born in. Adding the interval as a CALENDAR duration preserves the local
+  # wall clock across a DST change, while the elapsed-interval count above is measured in absolute
+  # seconds. A chain anchored in CET and running in CEST therefore computed a checkpoint one hour
+  # BEFORE the boundary it had just counted against — a checkpoint in the past, which
+  # Bot::ActionJob re-enqueues immediately, at machine speed, for the length of the DST offset.
+  # Production hit exactly this: 14,192 ActionJobs in one hour on a single weekly bot, which
+  # rate-limited the exchange account for every other bot in that container.
+  test 'weekly grid stays on the absolute interval under a DST job zone' do
+    anchor = Time.utc(2026, 3, 13, 12, 24, 25)  # CET  (UTC+1)
+    travel_to Time.utc(2026, 8, 21, 11, 24, 27) # CEST (UTC+2), just past the wall-clock slot
+    bot = create(:dca_single_asset, :started, :weekly)
+    bot.started_at = anchor
+    bot.save!
+
+    Time.use_zone('Vienna') do
+      checkpoint = bot.next_interval_checkpoint_at
+      assert_equal anchor + (23 * 1.week.to_i), checkpoint.utc
+      assert checkpoint.future?, 'a checkpoint in the past is re-enqueued immediately, forever'
+    end
+  end
+
+  test 'daily grid stays on the absolute interval under a DST job zone' do
+    anchor = Time.utc(2026, 3, 13, 12, 24, 25)
+    travel_to Time.utc(2026, 8, 21, 11, 24, 27)
+    bot = create(:dca_single_asset, :started)
+    bot.started_at = anchor
+    bot.save!
+
+    Time.use_zone('Vienna') do
+      checkpoint = bot.next_interval_checkpoint_at
+      assert_equal Time.utc(2026, 8, 21, 12, 24, 25), checkpoint.utc
+      assert checkpoint.future?, 'a checkpoint in the past is re-enqueued immediately, forever'
+    end
+  end
+
+  # The forward and backward steps must agree. Around the autumn transition a calendar subtraction
+  # from an absolute grid point lands 25 hours back, and Bot::Accountable#pending_quote_amount
+  # floors an interval count against it — one whole contribution silently dropped.
+  test 'previous checkpoint sits exactly one interval before the next under a DST job zone' do
+    anchor = Time.utc(2026, 10, 23, 12, 0, 0)  # CEST
+    travel_to Time.utc(2026, 10, 25, 11, 0, 0) # the day Vienna falls back to CET
+    bot = create(:dca_single_asset, :started)  # daily
+    bot.started_at = anchor
+    bot.save!
+
+    Time.use_zone('Vienna') do
+      assert_equal Time.utc(2026, 10, 25, 12, 0, 0), bot.next_interval_checkpoint_at.utc
+      assert_equal Time.utc(2026, 10, 24, 12, 0, 0), bot.last_interval_checkpoint_at.utc
+    end
+  end
+
+  # Months are calendar objects, not a fixed number of seconds — the month branch stays calendar.
+  test 'monthly previous checkpoint keeps calendar semantics' do
+    bot = create(:dca_single_asset, :started, :monthly)
+    bot.started_at = @now - 1.day
+    bot.save!
+
+    assert_equal bot.next_interval_checkpoint_at - 1.month, bot.last_interval_checkpoint_at
+  end
 end


### PR DESCRIPTION
## What happened

A weekly bot ran **14,192 `Bot::ActionJob`s in one hour** — about four a second — and exhausted the
exchange account's rate limit. A different bot in the same container then lost its own weekly tick
to `RateLimitedError`, went through all four retries, and mailed its owner a red "execution
failed". The spinning bot never placed the buy that interval was for.

None of it looks like an error while it runs: the jobs all succeed, so nothing surfaces in the
exception scans. The only visible symptom is the collateral damage on a neighbouring bot.

## Why

`next_interval_checkpoint_at` measured elapsed intervals in absolute seconds and then added them
back as a **calendar** duration. `time + n.weeks` preserves the local wall clock, so a chain
anchored in CET and stepping in CEST lands an hour *before* the boundary the count was just
measured against. A `wait_until` in the past is dispatched immediately, the job recomputes the same
past value, re-enqueues, and spins at machine speed — for exactly the length of the DST offset,
every interval, until the zone leaves DST.

The non-UTC zone comes from ActiveJob. It stamps `Time.zone` into the payload at enqueue and
re-applies it with `Time.use_zone` around every perform; a self-rescheduling chain enqueues its
successor from inside that block, so the zone is re-stamped on every hop. One enqueue under a
user's zone pins it on the chain for months — long after nothing in the app sets `Time.zone` at
all.

## Changes

- **`Automation::Schedulable`** — the interval grid steps in seconds, so it no longer depends on
  the caller's zone. Months keep calendar arithmetic: a month is not a fixed number of seconds.
- **`last_interval_checkpoint_at`** steps back the same way the grid steps forward. Left as a
  calendar subtraction it straddles the autumn transition — 25 hours back from an absolute grid
  point — and `Bot::Accountable#pending_quote_amount` floors an interval count against that value,
  which silently drops a whole contribution.
- **`ApplicationJob`** — jobs run in the app zone, and a foreign zone is dropped on `deserialize`.
  The second half matters for rollout: `retry_on` handlers run *outside* the perform callbacks and
  `serialize` reads the job's own `timezone` attribute, so a retried job would otherwise carry the
  stale zone onward. Normalising at deserialize means **every payload already sitting in a queue
  heals on its first hop** — no data migration, no re-enqueueing by hand.

Chains that had inherited a zone were also bucketing weekly/monthly candles and tax-report day
boundaries in that zone; those go back to UTC too.

## Tests

Five new, each failing before the change — the schedulable ones reproduce the observed
`11:24:25` checkpoint exactly. Full suite green (4006 runs).
