### PR TITLE
Let the dashboard keep the order I put my bots in

### DIFF
--- a/app/assets/stylesheets/new/_bot-tile.sass
+++ b/app/assets/stylesheets/new/_bot-tile.sass
@@ -5,6 +5,15 @@
   padding: 2rem
   cursor: pointer
   gap: 1rem
+  // The reserved spot the dragged tile will land in. A real element rather than the dragged tile
+  // restyled: moving the drag source around the grid mid-drag makes Chrome mis-crop its own ghost
+  // and mis-report which tile the pointer is over. Opaque, not see-through — the grid behind it
+  // reads as clutter through a transparent hole.
+  &--placeholder
+    background: var(--paper)
+    box-shadow: none
+    outline: 0.2rem dashed var(--concrete)
+    outline-offset: -0.2rem
   a
     text-decoration: none
   &__header

--- a/app/controllers/bots/reorders_controller.rb
+++ b/app/controllers/bots/reorders_controller.rb
@@ -1,0 +1,42 @@
+# Takes the ids the dashboard grid is showing, in the order the user dragged them into.
+#
+# The grid is filtered (all / active / inactive / archived), so the payload is often a *subset* of
+# the user's bots. Writing 1..n over just those ids would drag every hidden bot along with them
+# into an order nobody chose. Instead the payload's sequence is spliced back into exactly the
+# slots those bots already occupied, and the whole list is renumbered from there — so bots that
+# were off screen keep their place relative to the ones that were on it.
+#
+# Renumbering everything, rather than redealing the sent bots' existing position values, is also
+# what makes the endpoint self-healing. Two bots created in overlapping transactions can share a
+# position; redealing `[4, 4]` could never express which of them comes first, and `ordered`'s id
+# tie-breaker would settle it the same way forever. A dense rewrite separates them for good.
+class Bots::ReordersController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    bots = current_user.bots.ordered.to_a
+    dragged = dragged_bots(bots)
+    return head :no_content if dragged.empty?
+
+    slots = bots.each_index.select { |i| dragged.include?(bots[i]) }
+    slots.each_with_index { |slot, i| bots[slot] = dragged[i] }
+
+    Bot.transaction do
+      bots.each_with_index do |bot, i|
+        bot.update_column(:position, i + 1) unless bot.position == i + 1
+      end
+    end
+
+    head :no_content
+  end
+
+  private
+
+  # Sanitised on the way in: integers only, no repeats, and nothing the user does not own. Ids
+  # that fall away here also fall out of the sequence, so a stranger's id can neither be written
+  # nor shift the splice by one.
+  def dragged_bots(bots)
+    by_id = bots.index_by(&:id)
+    Array(params[:ids]).map(&:to_i).uniq.filter_map { |id| by_id[id] }
+  end
+end

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -23,7 +23,7 @@ class BotsController < ApplicationController
             when 'archived' then scope.archived
             else scope.not_archived
             end
-    @bots = @bots.order(label: :asc)
+    @bots = @bots.ordered
 
     @total_bots = current_user.bots.not_deleted.not_archived.size
     @has_active = current_user.bots.not_deleted.working.exists?
@@ -76,7 +76,7 @@ class BotsController < ApplicationController
       permitted_params = params.require(:decimals).permit(*Asset.all.pluck(:symbol))
       @decimals = permitted_params.transform_values(&:to_i)
     else
-      @other_bots = current_user.bots.not_deleted.not_archived.order(label: :asc).where.not(id: @bot.id).pluck(:id, :label, :type)
+      @other_bots = current_user.bots.not_deleted.not_archived.ordered.where.not(id: @bot.id).pluck(:id, :label, :type)
 
       # TODO: When transactions point to real asset ids, we can use the asset ids directly instead of symbols
       if @bot.dca_single_asset?

--- a/app/javascript/controllers/bots_reorder_controller.js
+++ b/app/javascript/controllers/bots_reorder_controller.js
@@ -1,0 +1,225 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drag bot tiles around the dashboard grid; the order is saved on drop.
+//
+// The dragged tile is taken out of the grid entirely and a placeholder — an empty dashed cell —
+// slides around in its place, marking where it will land. The tile itself is never moved while the
+// drag is running: relocating the drag source under the pointer makes Chrome mis-crop its own ghost
+// and mis-report which tile the pointer is over, because every insert reflows the grid the browser
+// is hit-testing against. Only the placeholder moves; the real tile takes its slot on drop.
+//
+// ponytail: native HTML5 drag-and-drop, which never fires on touch — phone users see the saved
+// order but cannot change it. Covering them means Pointer Events with a hand-rolled ghost and
+// either a grip handle or long-press scroll suppression.
+export default class extends Controller {
+  static values = { url: String }
+
+  connect() {
+    this.savedOrder = this.ids
+  }
+
+  // dragstart is dispatched at the *source node* — the tile — so `event.target` there is useless
+  // for telling where the gesture actually began. pointerdown does fire at the descendant, so the
+  // origin is recorded here and read one event later.
+  pointerdown(event) {
+    this.fromControl = Boolean(
+      event.target.closest("button, form, input, select, .dropdown-wrapper")
+    )
+  }
+
+  dragstart(event) {
+    const tile = event.target.closest("[data-bot-id]")
+
+    // preventDefault is the only thing that stops a native drag; returning early just declines to
+    // handle one that is already running. Started from the Start button, that would drag the tile
+    // AND swallow the click the user was aiming at.
+    if (!tile || this.fromControl || this.saving) {
+      event.preventDefault()
+      return
+    }
+
+    this.dragged = tile
+    this.dropped = false
+    this.orderBeforeDrag = this.ids
+    // Where inside the tile it was picked up, so dragover can reconstruct where the tile now sits
+    // rather than only knowing where the pointer is.
+    const box = tile.getBoundingClientRect()
+    this.grab = { x: event.clientX - box.left, y: event.clientY - box.top, w: box.width, h: box.height }
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData("text/plain", tile.dataset.botId) // Firefox drags nothing without a payload
+    event.dataTransfer.setDragImage(this.buildDragImage(tile), event.offsetX, event.offsetY)
+  }
+
+  // The ghost is supplied rather than left to the browser. Chrome's own snapshot of this tile comes
+  // out as a wide, mis-cropped slab carrying fragments of its neighbours: the status bar runs a
+  // marquee whose text is far wider than the tile, and the ink overflow of that plus the tile's
+  // box-shadow is included in the bitmap.
+  //
+  // A copy with its Stimulus controllers stripped renders that text static, `overflow: hidden`
+  // guarantees the bitmap stops at the tile's own edges, and it is parked exactly on top of the
+  // real tile behind the page content — an element pushed off-screen to hide it snapshots blank in
+  // Chrome, which is the other way this goes wrong. Chrome takes the bitmap as soon as this handler
+  // returns, so the copy only has to survive one tick.
+  buildDragImage(tile) {
+    const box = tile.getBoundingClientRect()
+    const image = tile.cloneNode(true)
+
+    image.removeAttribute("data-controller")
+    image.querySelectorAll("[data-controller]").forEach((el) => el.removeAttribute("data-controller"))
+    Object.assign(image.style, {
+      position: "fixed", top: `${box.top}px`, left: `${box.left}px`,
+      width: `${box.width}px`, height: `${box.height}px`,
+      margin: "0", overflow: "hidden", pointerEvents: "none", zIndex: "-1"
+    })
+    document.body.appendChild(image)
+    setTimeout(() => image.remove(), 0)
+
+    return image
+  }
+
+  // Fired at the source once the drag session is actually live, which is the one moment the ghost
+  // is guaranteed to be on screen — so it is the only non-guess for pulling the tile out of the
+  // grid. Doing it in dragstart hands the browser an empty tile to snapshot; doing it a frame later
+  // blinks the tile out before the ghost arrives; waiting for dragover leaves both visible at once.
+  drag() {
+    if (!this.dragged || this.placeholder) return
+
+    this.placeholder = this.buildPlaceholder(this.dragged)
+    this.dragged.after(this.placeholder)
+    this.dragged.style.display = "none" // out of the grid, so it cannot be hovered or reflow it
+  }
+
+  dragover(event) {
+    if (!this.placeholder) return
+
+    event.preventDefault() // without this the drop never fires
+    event.dataTransfer.dropEffect = "move"
+
+    // Aim with the dragged tile, not the pointer. Hit-testing `event.target` looks obvious and
+    // feels wrong: the tile is 310px wide, so grabbing it near its left edge and dragging right
+    // puts it almost entirely over its neighbour before the pointer has even reached that
+    // neighbour's edge — and where the swap fires would change with where you happened to grab.
+    //
+    // The placeholder is in the running too, which is what keeps this from being twitchy: the spot
+    // moves once the tile covers a neighbour more than it still covers the spot it came from.
+    const over = this.mostCovered(this.draggedBox(event))
+    if (!over || over === this.placeholder) return
+
+    // Which side needs no geometry, only document order: a tile reached from before the spot takes
+    // it and pushes the spot past itself, and the mirror going the other way. One rule for one
+    // column or four.
+    const reachedFromBefore =
+      this.placeholder.compareDocumentPosition(over) & Node.DOCUMENT_POSITION_FOLLOWING
+    // Element siblings, not `nextSibling`: ERB leaves whitespace text nodes between the tiles, so
+    // the raw sibling is never the placeholder and this guard could never match.
+    const before = reachedFromBefore ? over.nextElementSibling : over
+    if (before === this.placeholder) return
+
+    this.element.insertBefore(this.placeholder, before)
+  }
+
+  drop(event) {
+    if (!this.placeholder) return
+
+    event.preventDefault()
+    this.dropped = true
+    this.settle()
+    this.save()
+  }
+
+  // Fires for every drag, dropped or not. A release outside the grid — or Escape — lands here with
+  // nothing dropped, and the placeholder has already wandered, so the grid has to be put back.
+  dragend() {
+    if (!this.dropped) {
+      this.settle()
+      this.restore(this.orderBeforeDrag)
+    }
+    this.dragged = null
+  }
+
+  // The tile takes the placeholder's slot and rejoins the grid. Idempotent: drop calls it, and
+  // dragend calls it again for the drags that never dropped.
+  settle() {
+    if (!this.placeholder) return
+
+    this.placeholder.replaceWith(this.dragged)
+    this.dragged.style.display = ""
+    this.placeholder = null
+  }
+
+  // Where the dragged tile is right now: the pointer, less wherever inside the tile it was grabbed.
+  draggedBox(event) {
+    const left = event.clientX - this.grab.x
+    const top = event.clientY - this.grab.y
+
+    return { left, top, right: left + this.grab.w, bottom: top + this.grab.h }
+  }
+
+  // The grid cell the dragged tile covers most. The dragged tile itself is display:none and so
+  // measures zero, which drops it out of the contest without a special case.
+  mostCovered(box) {
+    let winner = null
+    let best = 0
+
+    Array.from(this.element.children).forEach((cell) => {
+      const r = cell.getBoundingClientRect()
+      const w = Math.min(box.right, r.right) - Math.max(box.left, r.left)
+      const h = Math.min(box.bottom, r.bottom) - Math.max(box.top, r.top)
+      if (w <= 0 || h <= 0) return
+
+      if (w * h > best) {
+        best = w * h
+        winner = cell
+      }
+    })
+
+    return winner
+  }
+
+  // Height is copied off the tile because an empty div has none, and a collapsing cell would close
+  // the very gap this is reserving.
+  buildPlaceholder(tile) {
+    const node = document.createElement("div")
+    node.className = "bot-tile bot-tile--placeholder"
+    node.style.height = `${tile.getBoundingClientRect().height}px`
+    return node
+  }
+
+  save() {
+    const ids = this.ids
+    if (String(ids) === String(this.savedOrder)) return
+
+    this.saving = true // dragstart refuses while this is set: one write in flight, never a queue
+    fetch(this.urlValue, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content
+      },
+      body: JSON.stringify({ ids: ids })
+    })
+      // `redirected` matters as much as `ok`: Devise answers a signed-out request with a 302 to
+      // the login page, which fetch follows into a perfectly successful-looking 200.
+      .then((response) => {
+        if (response.ok && !response.redirected) {
+          this.savedOrder = ids
+        } else {
+          this.restore(this.savedOrder)
+        }
+      })
+      .catch(() => this.restore(this.savedOrder))
+      .then(() => { this.saving = false })
+  }
+
+  restore(order) {
+    order.forEach((id) => {
+      const tile = this.element.querySelector(`[data-bot-id="${id}"]`)
+      if (tile) this.element.appendChild(tile)
+    })
+  }
+
+  get ids() {
+    return Array.from(this.element.querySelectorAll("[data-bot-id]"), (tile) => tile.dataset.botId)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -25,6 +25,9 @@ application.register("bot--barbell-allocation", Bot__BarbellAllocationController
 import Bot__ChartController from "./bot/chart_controller"
 application.register("bot--chart", Bot__ChartController)
 
+import BotsReorderController from "./bots_reorder_controller"
+application.register("bots-reorder", BotsReorderController)
+
 import Broadcast__OnConnectController from "./broadcast/on_connect_controller"
 application.register("broadcast--on-connect", Broadcast__OnConnectController)
 

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -17,6 +17,14 @@ class Bot < ApplicationRecord
   belongs_to :user
   has_many :transactions, dependent: :destroy
 
+  # The dashboard order, dragged by the user. `:id` is not decoration: two bots created in
+  # overlapping transactions read the same `maximum(:position)` and land on the same number, and
+  # the list still has to come back the same way on every page load. The next drag renumbers them
+  # apart — Bots::ReordersController rewrites the whole sequence, not just the rows it was sent.
+  scope :ordered, -> { order(:position, :id) }
+
+  before_create :assign_position
+
   # Every start path — the button, a stale tab, BotApi::Bots::Start — goes through valid?(:start),
   # so one validation is the whole gate: an archived bot is reactivated first or not at all.
   validate :not_archived, on: :start
@@ -323,6 +331,15 @@ class Bot < ApplicationRecord
 
   def store_previous_exchange_id
     @previous_exchange_id = exchange_id_was
+  end
+
+  # A new bot goes to the end of the user's list. `0` is the unset sentinel rather than `nil`,
+  # because the column is NOT NULL with a default of 0 — `position ||= …` would never fire.
+  # The backfill migration starts at 1 for the same reason.
+  def assign_position
+    return if position.to_i.positive?
+
+    self.position = user&.bots&.maximum(:position).to_i + 1
   end
 
   def custom_exchange_id_changed?

--- a/app/views/bots/bot_tile/_bot_tile.html.erb
+++ b/app/views/bots/bot_tile/_bot_tile.html.erb
@@ -1,5 +1,8 @@
-<div class="widget bot-tile">
-  <%= link_to bot_path(bot) do %>
+<%# draggable="false" on the link is load-bearing: an anchor is implicitly draggable, so without it
+    the browser drags the link out of the page instead of picking the tile up. Clicking through to
+    the bot is unaffected — a completed drag fires no click. %>
+<div class="widget bot-tile" id="<%= dom_id(bot, :tile) %>" data-bot-id="<%= bot.id %>" draggable="true">
+  <%= link_to bot_path(bot), draggable: "false" do %>
     <div class="bot-tile__header">
       <div class="bot-tile__hgroup">
         <div class="bot-tile__title">

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -38,9 +38,21 @@
     </div>
   </div>
 
-  <%= tag.div class: 'itiles', data: @tile_refresh_ids.any? ? { controller: "broadcast--on-connect",
-                                                               broadcast__on_connect_method_value: "pnl_update",
-                                                               broadcast__on_connect_method_args_value: { bot_ids: @tile_refresh_ids }.to_json } : {} do %>
+  <%# The drag is handled here rather than per tile: every drag event bubbles, so one set of
+      handlers covers the whole grid and survives a tile being swapped in by a broadcast.
+
+      Two controllers share the element — the reorder drag is always on, the P&L refresh only while
+      some tile is still cold — so the second is appended to the data-controller list rather than
+      replacing it. Overwriting would leave those tiles spinning until the next manual reload. %>
+  <% tile_data = { controller: "bots-reorder", bots_reorder_url_value: reorder_bots_path,
+                   action: %w[pointerdown dragstart drag dragover drop dragend]
+                             .map { |e| "#{e}->bots-reorder##{e}" }.join(' ') } %>
+  <% if @tile_refresh_ids.any? %>
+    <% tile_data.merge!(controller: "bots-reorder broadcast--on-connect",
+                        broadcast__on_connect_method_value: "pnl_update",
+                        broadcast__on_connect_method_args_value: { bot_ids: @tile_refresh_ids }.to_json) %>
+  <% end %>
+  <%= tag.div class: 'itiles', data: tile_data do %>
     <%= render partial: 'bots/bot_tile/bot_tile', collection: @bots, as: :bot,
                locals: { pnl_hash: @pnl_hash, profit_usd_hash: @profit_usd_hash, loading_hash: @loading_hash } %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,8 @@ Rails.application.routes.draw do
     end
 
     resources :bots do
+      # Explicit target: a bare `patch :reorder` would route to BotsController#reorder.
+      collection { patch :reorder, to: 'bots/reorders#update' }
       resources :bot_signals, only: [:create, :update, :destroy], controller: 'bots/bot_signals'
       resource :start, only: [:edit, :update], controller: 'bots/starts'
       resource :stop, only: [:update], controller: 'bots/stops'

--- a/db/migrate/20260821120000_add_position_to_bots.rb
+++ b/db/migrate/20260821120000_add_position_to_bots.rb
@@ -1,0 +1,31 @@
+# The bots list has always been sorted by `label` — a Haikunator name the user never picked. This
+# gives them a hand-picked order instead, dragged on the dashboard.
+#
+# Backfilled to the order users see today, so nothing moves on the deploy. `(label, id)` rather
+# than `label` alone: labels are unique per user in practice but nothing enforces it, and a tie
+# would otherwise backfill non-deterministically.
+#
+# Starts at 1, never 0: the column default of 0 is the "unset" sentinel `Bot#assign_position`
+# looks for, so a backfilled row must never look unset.
+#
+# Self-contained raw SQL, no Bot model — a historical migration that depends on head-of-branch
+# code breaks fresh installs migrating from zero.
+class AddPositionToBots < ActiveRecord::Migration[8.1]
+  def up
+    add_column :bots, :position, :integer, null: false, default: 0
+
+    # ponytail: correlated subquery, so O(n^2) per user. A container holds one user with tens of
+    # bots; if that ever stops being true this becomes a window function.
+    execute <<~SQL.squish
+      UPDATE bots SET position = 1 + (
+        SELECT COUNT(*) FROM bots AS earlier
+        WHERE earlier.user_id IS bots.user_id
+          AND (earlier.label < bots.label OR (earlier.label = bots.label AND earlier.id < bots.id))
+      )
+    SQL
+  end
+
+  def down
+    remove_column :bots, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_120000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false
@@ -230,6 +230,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
     t.integer "fetch_restarts", default: 0, null: false
     t.string "label"
     t.datetime "last_end_of_funds_notification", precision: nil
+    t.integer "position", default: 0, null: false
     t.integer "restarts", default: 0, null: false
     t.json "settings", default: {}, null: false
     t.datetime "settings_changed_at", precision: nil

--- a/test/controllers/bots/index_reorder_test.rb
+++ b/test/controllers/bots/index_reorder_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The dashboard grid is draggable. This covers the markup the Stimulus controller needs to exist
+# at all — everything it hangs off is server-rendered.
+class Bots::IndexReorderTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true) # onboarding gate
+    @user = create(:user)
+    sign_in @user
+  end
+
+  test 'tiles render in position order, not label order' do
+    first = create(:dca_single_asset, user: @user, label: 'Zulu')
+    second = create(:dca_single_asset, user: @user, label: 'Alpha', exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+
+    get bots_path
+
+    assert_response :success
+    assert_equal [first.id, second.id], rendered_tile_ids
+  end
+
+  test 'a dragged order is what the next page load shows' do
+    first = create(:dca_single_asset, user: @user)
+    second = create(:dca_single_asset, user: @user, exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+
+    patch reorder_bots_path, params: { ids: [second.id, first.id] }
+    get bots_path
+
+    assert_equal [second.id, first.id], rendered_tile_ids
+  end
+
+  test 'the grid wires the reorder controller with its endpoint' do
+    create_two_bots
+
+    get bots_path
+
+    assert_select '.itiles' do |grid|
+      assert_includes grid.first['data-controller'].split, 'bots-reorder'
+      assert_equal reorder_bots_path, grid.first['data-bots-reorder-url-value']
+    end
+  end
+
+  # The grid already carries `broadcast--on-connect` whenever a tile's P&L is still cold.
+  # Overwriting `data-controller` instead of appending to it would silently kill that refresh and
+  # leave the tiles spinning until the next manual reload.
+  test 'the grid keeps its broadcast controller and values alongside the reorder one' do
+    create_two_bots
+
+    get bots_path
+
+    assert_select '.itiles' do |grid|
+      controllers = grid.first['data-controller'].split
+
+      assert_includes controllers, 'bots-reorder'
+      assert_includes controllers, 'broadcast--on-connect'
+      assert_equal 'pnl_update', grid.first['data-broadcast--on-connect-method-value']
+      assert grid.first['data-broadcast--on-connect-method-args-value'].present?
+    end
+  end
+
+  test 'each tile is draggable and carries its bot id' do
+    bots = create_two_bots
+
+    get bots_path
+
+    bots.each do |bot|
+      assert_select %(.bot-tile[draggable="true"][data-bot-id="#{bot.id}"]), 1
+    end
+  end
+
+  # Without this the browser drags the *link* out of the page instead of starting our tile drag.
+  test 'the tile link opts out of being dragged itself' do
+    create_two_bots
+
+    get bots_path
+
+    assert_select '.bot-tile > a[draggable="false"]', 2
+  end
+
+  private
+
+  def rendered_tile_ids
+    css_select('.bot-tile[data-bot-id]').map { |tile| tile['data-bot-id'].to_i }
+  end
+
+  def create_two_bots
+    first = create(:dca_single_asset, user: @user)
+    second = create(:dca_single_asset, user: @user, exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+    [first, second]
+  end
+end

--- a/test/controllers/bots/reorders_controller_test.rb
+++ b/test/controllers/bots/reorders_controller_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The dashboard sends the ids it is showing, in the order the user dragged them into. Everything
+# hard about this endpoint is that "the ids it is showing" can be a *filtered subset*, so the bots
+# that were off screen have to keep their place relative to the ones that were.
+class Bots::ReordersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true, setup_completed: true) # onboarding gate
+    @user = create(:user)
+    sign_in @user
+  end
+
+  test 'a full reorder persists and survives a reload' do
+    bots = create_bots(3)
+
+    patch reorder_bots_path, params: { ids: [bots[2].id, bots[0].id, bots[1].id] }
+
+    assert_response :success
+    assert_equal [bots[2], bots[0], bots[1]], @user.bots.ordered.to_a
+  end
+
+  test 'positions come back as a dense sequence' do
+    bots = create_bots(3)
+
+    patch reorder_bots_path, params: { ids: bots.reverse.map(&:id) }
+
+    assert_equal [1, 2, 3], @user.bots.ordered.map(&:position)
+  end
+
+  # The grid is filtered, so a drop on ?filter=active sends only the active bots. Reordering those
+  # must not shuffle the ones the filter hid.
+  test 'a filtered reorder leaves the hidden bot in its slot relative to the visible ones' do
+    first, hidden, third = create_bots(3)
+
+    patch reorder_bots_path, params: { ids: [third.id, first.id] }
+
+    # The two visible bots swap; `hidden` keeps the slot between them that it started in.
+    assert_equal [third, hidden, first], @user.bots.ordered.to_a
+  end
+
+  # Two bots created in overlapping transactions can share a position. Redealing the slots those
+  # bots already occupy could never express an order across the duplicate — the id tie-breaker
+  # would win forever — so a save renumbers the whole list instead.
+  test 'duplicate stored positions are normalized and the new order sticks' do
+    first, second = create_bots(2)
+    second.update_column(:position, first.position)
+
+    patch reorder_bots_path, params: { ids: [second.id, first.id] }
+
+    assert_equal [second, first], @user.bots.ordered.to_a
+    assert_equal [1, 2], @user.bots.ordered.map(&:position)
+  end
+
+  test "another user's bot is ignored and never written" do
+    mine = create_bots(2)
+    stranger = create(:user)
+    theirs = create(:dca_single_asset, user: stranger, exchange: mine[0].exchange,
+                                       base_asset: mine[0].base_asset, quote_asset: mine[0].quote_asset)
+    was = theirs.position
+
+    patch reorder_bots_path, params: { ids: [theirs.id, mine[1].id, mine[0].id] }
+
+    assert_response :success
+    assert_equal [mine[1], mine[0]], @user.bots.ordered.to_a
+    assert_equal was, theirs.reload.position
+  end
+
+  test 'duplicate and unknown ids do not corrupt the sequence' do
+    first, second, third = create_bots(3)
+
+    patch reorder_bots_path, params: { ids: [third.id, third.id, 999_999, 'nonsense', first.id] }
+
+    assert_response :success
+    assert_equal [third, second, first], @user.bots.ordered.to_a
+  end
+
+  test 'an empty payload changes nothing' do
+    bots = create_bots(2)
+
+    patch reorder_bots_path, params: { ids: [] }
+
+    assert_response :success
+    assert_equal bots, @user.bots.ordered.to_a
+  end
+
+  test 'a signed-out request writes nothing' do
+    bots = create_bots(2)
+    sign_out @user
+
+    patch reorder_bots_path, params: { ids: bots.reverse.map(&:id) }
+
+    assert_redirected_to new_user_session_path
+    assert_equal bots, @user.bots.ordered.to_a
+  end
+
+  private
+
+  # Share the exchange and assets: the factory would otherwise build a second Bitcoin per bot.
+  def create_bots(count)
+    first = create(:dca_single_asset, user: @user)
+    rest = (count - 1).times.map do
+      create(:dca_single_asset, user: @user, exchange: first.exchange,
+                                base_asset: first.base_asset, quote_asset: first.quote_asset)
+    end
+    [first, *rest]
+  end
+end

--- a/test/models/bot_position_test.rb
+++ b/test/models/bot_position_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The dashboard order is the user's, not the alphabet's. `position` carries it; this covers how a
+# bot gets one and how the list reads it back.
+class BotPositionTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  test 'a new bot lands after the ones the user already has' do
+    first = create(:dca_single_asset, user: @user)
+    second = create(:dca_single_asset, user: @user, exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+
+    assert_operator second.position, :>, first.position
+    assert_equal [first, second], @user.bots.ordered.to_a
+  end
+
+  test 'a position is never left at the unset sentinel' do
+    bot = create(:dca_single_asset, user: @user)
+
+    assert_predicate bot.position, :positive?
+  end
+
+  # Positions are per-user, so another account filling up its dashboard must not push this user's
+  # next bot to position 40 — or, worse, make the two lists share a numbering.
+  test "another user's bots do not consume this user's positions" do
+    other = create(:user)
+    theirs = create(:dca_single_asset, user: other)
+    3.times do
+      create(:dca_single_asset, user: other, exchange: theirs.exchange,
+                                base_asset: theirs.base_asset, quote_asset: theirs.quote_asset)
+    end
+
+    mine = create(:dca_single_asset, user: @user, exchange: theirs.exchange,
+                                     base_asset: theirs.base_asset, quote_asset: theirs.quote_asset)
+
+    assert_equal 1, mine.position
+  end
+
+  test 'ordered sorts by position, not by label' do
+    first = create(:dca_single_asset, user: @user, label: 'Zulu')
+    second = create(:dca_single_asset, user: @user, label: 'Alpha', exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+
+    assert_equal [first, second], @user.bots.ordered.to_a
+  end
+
+  # Two bots created in overlapping transactions both read the same `maximum(:position)`. The list
+  # still has to come back in one stable order rather than flipping between page loads.
+  test 'duplicate positions still read back in a stable order' do
+    first = create(:dca_single_asset, user: @user)
+    second = create(:dca_single_asset, user: @user, exchange: first.exchange,
+                                       base_asset: first.base_asset, quote_asset: first.quote_asset)
+    second.update_column(:position, first.position)
+
+    assert_equal [first, second], @user.bots.ordered.to_a
+    assert_equal [first, second], @user.bots.ordered.to_a
+  end
+end


### PR DESCRIPTION
Closes #218

The bots dashboard was sorted by `label` — a Haikunator name the user never chose. With a dozen bots there is no way to put the one you watch daily at the top. Tiles are now draggable, and the order is saved on drop.

## Storing the order

`bots.position`, backfilled per user in the migration to the order the list already showed, so nothing moves on deploy. New bots append. `Bot.ordered` reads `(position, id)` and replaces both existing `order(label: :asc)` call sites — the grid and the show page's bot switcher.

## Reordering a filtered subset

The grid is filtered (all / active / inactive / archived), so a drop sends only the ids that were on screen. Writing `1..n` over just those would drag every hidden bot along into an order nobody chose.

`Bots::ReordersController` instead splices the payload's sequence back into the slots those bots already occupied, then renumbers the user's whole list densely in one transaction. Bots that were off screen keep their place relative to the ones that were on it.

Renumbering everything, rather than redealing the sent bots' existing position values, also makes the endpoint self-healing. Two bots created in overlapping transactions read the same `maximum(:position)` and land on the same number; redealing `[4, 4]` could never express which of them comes first, and the `:id` tie-breaker would settle it the same way forever.

Ids are cast, de-duplicated and intersected with `current_user.bots` before anything is written, so an id belonging to another user can neither be written nor shift the splice by one.

## The drag

Native HTML5 drag-and-drop, no dependency. Three browser behaviours the obvious implementation gets wrong, each found the hard way:

- **The drag source must not move.** Relocating it through the DOM mid-drag makes Chrome mis-crop its own ghost into a wide slab carrying fragments of neighbouring tiles, and mis-report which tile the pointer is over, because every insert reflows the grid it is hit-testing against. The tile is hidden in place and a placeholder travels instead.
- **The tile leaves the grid on `drag`.** Not `dragstart`, which hands the browser an empty tile to snapshot; not `dragover`, by which point the tile and its ghost are both on screen. `drag` is the one event that fires when the drag session is provably live.
- **`dragstart` fires at the source node**, so it cannot tell whether the gesture began on a tile's Start button. The origin is recorded on `pointerdown`, which does fire at the descendant, and the drag is cancelled with `preventDefault()` — returning early does not stop a native drag.

The swap threshold is the dragged tile's own coverage, not the pointer's position: the spot moves once the tile covers a neighbour more than the spot it came from. Hit-testing the pointer put the threshold at 94% of a cell when the tile was grabbed near its edge, and shifted it depending on where it was grabbed. Now it is 50% of a cell for any grab point, and the same rule in one column or four.

A save is refused while another is in flight, so there is only ever one outstanding write and no queue to reconcile. A failed or redirected response restores the DOM to the last order the server confirmed — `redirected` counts as failure because Devise answers a signed-out request with a 302 that `fetch` follows into a 200.

## Not covered

**Touch.** HTML5 drag-and-drop never fires there, so phones show the saved order but cannot change it. Covering them means Pointer Events with a hand-rolled ghost and either a grip handle or long-press scroll suppression — noted in the controller with the upgrade path.

No system test for the drag: the repo has no `test/system` directory or browser driver, and driving native drag-and-drop through WebDriver is the flaky end of browser testing. The drag was instead verified in a real browser against the dev server — hole opening in the hovered slot, swap threshold measured across grab points, `PATCH` payload, persistence across reload, release-outside-grid cancelling, and the Start button still starting the bot rather than picking the tile up.

## Tests

19 new, covering position assignment and per-user isolation, the ordered scope, full and filtered reorders, duplicate stored positions, another user's ids, garbage payloads, signed-out requests, and the grid markup — including that the reorder controller is appended to the existing `broadcast--on-connect` rather than replacing it, which would silently kill the async P&L refresh.

4009 runs, 0 failures.
