### PR TITLE
Name a new bot after what it holds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ gem "jaro_winkler", "~> 1.7"
 gem "oj", "~> 3.16"
 gem "dartsass-rails", "~> 0.5.1"
 gem "pagy", "~> 43.5"
-gem "haikunator", "~> 1.1"
 gem "sqids" # for obfuscating IDs
 gem 'ruby-technical-analysis', git: 'https://github.com/guillemap/ruby-technical-analysis' # TODO: use the official gem once https://github.com/johnnypaper/ruby-technical-analysis/pull/32 is merged
 install_if -> { !Gem.win_platform? } do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,6 @@ GEM
       rake (~> 13.3)
     h2c (0.2.1)
       ecdsa (~> 1.2.0)
-    haikunator (1.1.1)
     haml (7.4.1)
       prism (>= 1.1.0)
       temple (>= 0.8.2)
@@ -631,7 +630,6 @@ DEPENDENCIES
   faraday
   faraday-manual-cache!
   faraday-net_http_persistent (~> 2.3.0)
-  haikunator (~> 1.1)
   haml-rails (~> 3.0)
   honeymaker (~> 0.11.1)
   hyperliquid-rb
@@ -750,7 +748,6 @@ CHECKSUMS
   google-protobuf (4.36.0-x86_64-linux-gnu) sha256=8c253f7cb7647cdf1f54fc3f215e151206b5159e03d74fe29b8599264903de2b
   google-protobuf (4.36.0-x86_64-linux-musl) sha256=d6c510ff9743b3dcde6acdea06512e4e4ecf53246e5c5b689879861e05d4738a
   h2c (0.2.1) sha256=a53b7dfeb95660c97b615235ea1b29ec8e1856edc571845685682d94b6e8e227
-  haikunator (1.1.1) sha256=ec99f690b216edf20c518ea9a6d83f6bd479e86c37d89b2afc3376e752b32ca8
   haml (7.4.1) sha256=e5d09bfcf91c0c7e49e564385adb9aab0a91bc73767736eb1acbdb97eaf21754
   haml-rails (3.1.0) sha256=4366474d973e4b9d5326cb216f2073150cfeff4c2a3c07fadb49a490ffdf610b
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sanitized_bot_config
-    (session[:bot_config] || {}).slice('exchange_id', 'label', 'settings')
+    (session[:bot_config] || {}).slice('exchange_id', 'settings')
   end
 
   def redirect_to_setup_if_needed

--- a/app/controllers/bots/dca_dual_assets/pick_second_buyable_assets_controller.rb
+++ b/app/controllers/bots/dca_dual_assets/pick_second_buyable_assets_controller.rb
@@ -26,7 +26,6 @@ class Bots::DcaDualAssets::PickSecondBuyableAssetsController < Bots::Wizard::Pic
     settings = cfg['settings'] || {}
     base = settings['base0_asset_id'] || settings['base_asset_id']
     session[:bot_config] = {
-      'label' => Bots::DcaSingleAsset.new.label,
       'flow' => cfg['flow'],
       'exchange_id' => cfg['exchange_id'],
       'settings' => { 'base_asset_id' => base }.compact

--- a/app/controllers/bots/dca_indexes/pick_exchanges_controller.rb
+++ b/app/controllers/bots/dca_indexes/pick_exchanges_controller.rb
@@ -8,7 +8,6 @@ class Bots::DcaIndexes::PickExchangesController < Bots::Wizard::PickExchangesCon
   def new
     session[:bot_config] ||= {}
     prepare_step
-    session[:bot_config]['label'] ||= @bot.label
   end
 
   private

--- a/app/controllers/bots/dca_single_assets/orders_controller.rb
+++ b/app/controllers/bots/dca_single_assets/orders_controller.rb
@@ -22,7 +22,7 @@ class Bots::DcaSingleAssets::OrdersController < ApplicationController
   end
 
   # On the order switch the "current step" is the target variant's first step, so
-  # reset_downstream! wipes the whole config (keeping label + the new flow).
+  # reset_downstream! wipes the whole config (keeping the new flow).
   def current_step = current_order.first
   def bot_relation = current_user.bots.dca_single_asset
 

--- a/app/controllers/bots/dca_single_assets/pick_buyable_assets_controller.rb
+++ b/app/controllers/bots/dca_single_assets/pick_buyable_assets_controller.rb
@@ -7,7 +7,6 @@ class Bots::DcaSingleAssets::PickBuyableAssetsController < Bots::Wizard::PickBuy
     # hover, so any state mutation here would wipe wizard state from a link hover
     # and cause the wizard to loop back to step 1.
     session[:bot_config] ||= {}
-    session[:bot_config]['label'] ||= Bots::DcaSingleAsset.new.label
     @bot = build_bot
 
     # Exchange-first reaches this step after exchange+api; bounce back if an
@@ -42,11 +41,9 @@ class Bots::DcaSingleAssets::PickBuyableAssetsController < Bots::Wizard::PickBuy
   end
 
   # Re-committing this step clears everything it (and later steps) own — in
-  # asset-first that is the whole wizard (the historic "restart" wipe); the
-  # label is preserved so the bot keeps its name across the restart.
+  # asset-first that is the whole wizard (the historic "restart" wipe).
   def prepare_session_for_pick
     session[:bot_config] ||= {}
-    session[:bot_config]['label'] ||= Bots::DcaSingleAsset.new.label
     reset_downstream!
   end
 

--- a/app/controllers/bots/dca_single_assets/pick_exchanges_controller.rb
+++ b/app/controllers/bots/dca_single_assets/pick_exchanges_controller.rb
@@ -10,7 +10,6 @@ class Bots::DcaSingleAssets::PickExchangesController < Bots::Wizard::PickExchang
     settings = cfg['settings'] || {}
     base = settings.delete('base_asset_id') || settings['base0_asset_id']
     session[:bot_config] = {
-      'label' => Bots::DcaDualAsset.new.label,
       'flow' => cfg['flow'],
       'exchange_id' => cfg['exchange_id'],
       'settings' => { 'base0_asset_id' => base }.compact

--- a/app/controllers/bots/signals/pick_buyable_assets_controller.rb
+++ b/app/controllers/bots/signals/pick_buyable_assets_controller.rb
@@ -2,7 +2,6 @@ class Bots::Signals::PickBuyableAssetsController < Bots::Wizard::PickBuyableAsse
   def new
     session[:bot_config] ||= {}
     prepare_step
-    session[:bot_config]['label'] ||= @bot.label
     render_asset_page(bot: @bot, asset_field: :base_asset_id)
   end
 

--- a/app/controllers/bots/wizard/pick_buyable_assets_controller.rb
+++ b/app/controllers/bots/wizard/pick_buyable_assets_controller.rb
@@ -1,7 +1,7 @@
 # Shared "pick the asset to buy" wizard step (single first step, dual second
 # asset, signals first step). The three `new` actions genuinely diverge
-# (session init vs prerequisite guard, label timing), so subclasses keep their
-# own; the base holds the shared create skeleton and the view-state setup.
+# (session init vs prerequisite guard), so subclasses keep their own; the base
+# holds the shared create skeleton and the view-state setup.
 class Bots::Wizard::PickBuyableAssetsController < ApplicationController
   before_action :authenticate_user!
 

--- a/app/controllers/bots/wizard/pick_exchanges_controller.rb
+++ b/app/controllers/bots/wizard/pick_exchanges_controller.rb
@@ -1,7 +1,7 @@
 # Shared "pick the exchange" wizard step. Subclasses supply the bot relation,
 # routes and params as explicit overrides; the index step overrides `new`,
-# the view state and the search wholesale (market-data/index gates, label
-# init, per-exchange coin previews) and shares only the create flow.
+# the view state and the search wholesale (market-data/index gates,
+# per-exchange coin previews) and shares only the create flow.
 class Bots::Wizard::PickExchangesController < ApplicationController
   before_action :authenticate_user!
   before_action :redirect_if_session_expired, only: :create

--- a/app/models/automation/labelable.rb
+++ b/app/models/automation/labelable.rb
@@ -4,8 +4,16 @@ module Automation::Labelable
   included do
     validates :label, presence: true
 
-    after_initialize :set_default_label, if: -> { label.blank? }
+    # Named at save time, not at build time: the name comes from the settings, and the wizard
+    # fills those in one step at a time on an in-memory bot.
+    before_validation :set_default_label, if: -> { label.blank? }
     after_find :ensure_label_exists
+  end
+
+  # What the bot holds, said the way the user would say it. Each type overrides this; nil means
+  # there is nothing to read a name from (a settings-less bot, an asset row that went away).
+  def default_label
+    nil
   end
 
   private
@@ -21,11 +29,15 @@ module Automation::Labelable
   end
 
   def generate_label
-    label = nil
-    100.times do
-      label = Haikunator.haikunate(0, ' ').titleize
-      break unless self.class.unscoped.exists?(label: label, user_id: user_id)
-    end
-    label
+    default_label.presence || I18n.t('bot.new')
+  end
+
+  # "BTC, ETH, XRP + 3" — a basket is named after its first few holdings, then how many are left.
+  def basket_label(*asset_ids)
+    by_id = Asset.where(id: asset_ids.compact).index_by { |asset| asset.id.to_s }
+    symbols = asset_ids.filter_map { |id| by_id[id.to_s]&.symbol }
+    rest = symbols.size - 3
+
+    rest.positive? ? "#{symbols.first(3).join(', ')} + #{rest}" : symbols.join(', ')
   end
 end

--- a/app/models/bots/dca_dual_asset.rb
+++ b/app/models/bots/dca_dual_asset.rb
@@ -122,6 +122,11 @@ class Bots::DcaDualAsset < Bot
     include_exchanges ? Asset.includes(:exchanges).where(id: asset_ids) : Asset.where(id: asset_ids)
   end
 
+  # Named after what it holds: "BTC, ETH".
+  def default_label
+    basket_label(base0_asset_id, base1_asset_id)
+  end
+
   def base0_asset
     @base0_asset ||= asset_with_id(base0_asset_id)
   end

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -232,6 +232,17 @@ class Bots::DcaIndex < Bot
     preview
   end
 
+  # "Layer 1 · 20". A count-named index ("Nasdaq 7") and a Top-N ("Top 10") already carry their
+  # size in the name, so only a thematic category has the coin count appended.
+  def default_label
+    # The name must quote the count the bot will actually buy, and the clamp that decides it runs
+    # later in the same validation.
+    clamp_num_coins_to_bounded_index
+    return display_index_name if index_name_prefix.present? || index_type != INDEX_TYPE_CATEGORY
+
+    [display_index_name, num_coins].compact.join(' · ')
+  end
+
   def display_index_name
     return "#{index_name_prefix} #{num_coins}" if index_name_prefix.present? && num_coins.present?
     return index_name if index_name.present?

--- a/app/models/bots/dca_single_asset.rb
+++ b/app/models/bots/dca_single_asset.rb
@@ -74,6 +74,12 @@ class Bots::DcaSingleAsset < Bot
     @base_asset ||= asset_with_id(base_asset_id)
   end
 
+  # Named after what it buys: "Bitcoin", "iShares Core S&P 500 ETF". Read straight from the
+  # table rather than through #base_asset, whose memo would then answer for a later re-pick.
+  def default_label
+    Asset.find_by(id: base_asset_id)&.name
+  end
+
   def quote_asset
     @quote_asset ||= asset_with_id(quote_asset_id)
   end

--- a/app/models/bots/signal.rb
+++ b/app/models/bots/signal.rb
@@ -75,6 +75,10 @@ class Bots::Signal < Bot
     @base_asset ||= asset_with_id(base_asset_id)
   end
 
+  def default_label
+    Asset.find_by(id: base_asset_id)&.name
+  end
+
   def quote_asset
     @quote_asset ||= asset_with_id(quote_asset_id)
   end

--- a/app/services/bot_api/bots/create.rb
+++ b/app/services/bot_api/bots/create.rb
@@ -73,7 +73,7 @@ module BotApi
         bot = @user.bots.new(
           type: 'Bots::DcaSingleAsset',
           exchange: exchange,
-          label: effective_label(@base_asset.upcase, @quote_asset.upcase, exchange),
+          label: @label,
           settings: {
             'base_asset_id' => asset_ids[:base_asset_id],
             'quote_asset_id' => asset_ids[:quote_asset_id],
@@ -94,7 +94,7 @@ module BotApi
         bot = @user.bots.new(
           type: 'Bots::DcaDualAsset',
           exchange: exchange,
-          label: effective_label("#{@base_asset.upcase}+#{@second_base_asset.upcase}", @quote_asset.upcase, exchange),
+          label: @label,
           settings: {
             'base0_asset_id' => first_asset_ids[:base_asset_id],
             'base1_asset_id' => second[:base_asset_id],
@@ -150,12 +150,6 @@ module BotApi
         else
           "#{@base_asset.upcase}/#{@quote_asset.upcase}"
         end
-      end
-
-      def effective_label(pair_str, quote_str, exchange)
-        return @label if @label.present?
-
-        "#{pair_str}/#{quote_str} #{exchange.name}"
       end
 
       def missing_required_parameter(missing)

--- a/test/controllers/bots/dca_dual_assets/pick_second_buyable_assets_controller_test.rb
+++ b/test/controllers/bots/dca_dual_assets/pick_second_buyable_assets_controller_test.rb
@@ -29,7 +29,6 @@ class Bots::DcaDualAssets::PickSecondBuyableAssetsControllerTest < ActionDispatc
     post demote_to_single_bots_dca_dual_assets_pick_second_buyable_asset_path
     assert_redirected_to new_bots_dca_single_assets_pick_spendable_asset_path
 
-    assert_predicate session[:bot_config]['label'], :present?
     assert_equal @btc.id, session[:bot_config].dig('settings', 'base_asset_id')
     assert_nil session[:bot_config].dig('settings', 'base0_asset_id')
     assert_equal @binance.id.to_s, session[:bot_config]['exchange_id'].to_s

--- a/test/controllers/bots/signals/pick_buyable_assets_controller_test.rb
+++ b/test/controllers/bots/signals/pick_buyable_assets_controller_test.rb
@@ -22,12 +22,6 @@ class Bots::Signals::PickBuyableAssetsControllerTest < ActionDispatch::Integrati
     assert_match 'ETH', response.body
   end
 
-  test 'new initialises the wizard session with a label' do
-    get new_bots_signals_pick_buyable_asset_path
-    assert_response :ok
-    assert_predicate session[:bot_config]['label'], :present?
-  end
-
   test 'create stores the asset and routes to the exchange step' do
     btc = create(:asset, :bitcoin)
     create(:ticker, :btc_usd, exchange: @binance, base_asset: btc, quote_asset: @usd)

--- a/test/controllers/concerns/bots/wizard/navigable_test.rb
+++ b/test/controllers/concerns/bots/wizard/navigable_test.rb
@@ -136,13 +136,12 @@ class Bots::Wizard::NavigableTest < ActiveSupport::TestCase
 
   # ── reset_downstream! ──────────────────────────────────────────────────────
 
-  test 'reset_downstream! on the first asset step is a full wipe but keeps label and flow' do
+  test 'reset_downstream! on the first asset step is a full wipe but keeps the flow' do
     h = harness(current_step: :currencies,
                 config: config_with(exchange: 7, base: 3, base0: 4, base1: 5, quote: 9,
-                                    label: 'My bot', flow: 'asset_first'))
+                                    flow: 'asset_first'))
     h.call(:reset_downstream!)
     cfg = h.session[:bot_config]
-    assert_equal 'My bot', cfg['label']
     assert_equal 'asset_first', cfg['flow']
     assert_nil cfg['exchange_id']
     assert_equal({}, cfg['settings'])

--- a/test/integration/bots/dca_single_assets_creation_test.rb
+++ b/test/integration/bots/dca_single_assets_creation_test.rb
@@ -45,6 +45,7 @@ class Bots::DcaSingleAssetsCreationTest < ActionDispatch::IntegrationTest
     assert_response :ok
 
     bot = Bots::DcaSingleAsset.last
+    assert_equal 'Bitcoin', bot.label
     assert_equal @bitcoin, bot.base_asset
     assert_equal @usd, bot.quote_asset
     assert_equal @exchange, bot.exchange

--- a/test/models/bot_default_label_test.rb
+++ b/test/models/bot_default_label_test.rb
@@ -1,0 +1,123 @@
+require 'test_helper'
+
+# A new bot names itself after what it holds, so the list reads as a portfolio instead of a
+# kennel of random two-word names. The user renames it from the edit modal; nothing here ever
+# overwrites a name that is already set.
+class BotDefaultLabelTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @btc = create(:asset, :bitcoin)
+    @eth = create(:asset, :ethereum)
+    @usd = create(:asset, :usd)
+  end
+
+  # --- one asset ---------------------------------------------------------------
+
+  test 'a single-asset bot is named after the asset it buys' do
+    bot = create(:dca_single_asset, user: @user, base_asset: @btc, quote_asset: @usd)
+
+    assert_equal 'Bitcoin', bot.label
+  end
+
+  test 'a signal bot is named after its asset too' do
+    bot = create(:signal_bot, user: @user, base_asset: @btc, quote_asset: @usd)
+
+    assert_equal 'Bitcoin', bot.label
+  end
+
+  test 'a name the user picked is never overwritten' do
+    bot = create(:dca_single_asset, user: @user, base_asset: @btc, quote_asset: @usd, label: 'Retirement')
+
+    bot.quote_amount = 50
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 'Retirement', bot.label
+  end
+
+  # --- a basket of assets ------------------------------------------------------
+
+  test 'a two-asset bot is named by its tickers' do
+    bot = create(:dca_dual_asset, user: @user, base0_asset: @btc, base1_asset: @eth, quote_asset: @usd)
+
+    assert_equal 'BTC, ETH', bot.label
+  end
+
+  test 'a basket names its first three assets and counts the rest' do
+    xrp = create(:asset, symbol: 'XRP', name: 'XRP', external_id: 'ripple')
+    sol = create(:asset, symbol: 'SOL', name: 'Solana', external_id: 'solana')
+    ada = create(:asset, symbol: 'ADA', name: 'Cardano', external_id: 'cardano')
+    bot = build(:dca_dual_asset, user: @user, base0_asset: @btc, base1_asset: @eth, quote_asset: @usd)
+
+    assert_equal 'BTC, ETH, XRP + 2', bot.send(:basket_label, @btc.id, @eth.id, xrp.id, sol.id, ada.id)
+  end
+
+  test 'a basket skips assets that no longer exist' do
+    bot = build(:dca_dual_asset, user: @user, base0_asset: @btc, base1_asset: @eth, quote_asset: @usd)
+
+    assert_equal 'BTC', bot.send(:basket_label, @btc.id, nil, -1)
+  end
+
+  # --- an index ----------------------------------------------------------------
+
+  test 'a category index bot is named after the index and how many coins it holds' do
+    bot = build(:dca_index, user: @user, quote_asset: @usd)
+    bot.index_type = Bots::DcaIndex::INDEX_TYPE_CATEGORY
+    bot.index_category_id = 'layer-1'
+    bot.index_name = 'Layer 1'
+    bot.num_coins = 20
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 'Layer 1 · 20', bot.label
+  end
+
+  test 'a count-named index carries the count inside its own name' do
+    Index.create!(external_id: 'nasdaq-100', source: Index::SOURCE_DELTABADGER,
+                  name: 'Nasdaq 100', top_coins: (1..100).map { |i| "s#{i}" })
+    bot = build(:dca_index, user: @user, quote_asset: @usd)
+    bot.index_type = Bots::DcaIndex::INDEX_TYPE_CATEGORY
+    bot.index_category_id = 'nasdaq-100'
+    bot.index_name = 'Nasdaq 100'
+    bot.index_name_prefix = 'Nasdaq'
+    bot.num_coins = 7
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 'Nasdaq 7', bot.label
+  end
+
+  test 'the count in the name is the count the bot will actually buy' do
+    Index.create!(external_id: 'nasdaq-100', source: Index::SOURCE_DELTABADGER,
+                  name: 'Nasdaq 20', top_coins: (1..20).map { |i| "s#{i}" })
+    bot = build(:dca_index, user: @user, quote_asset: @usd)
+    bot.index_type = Bots::DcaIndex::INDEX_TYPE_CATEGORY
+    bot.index_category_id = 'nasdaq-100'
+    bot.index_name_prefix = 'Nasdaq'
+    bot.num_coins = 50
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 'Nasdaq 20', bot.label, 'the clamp runs before the name is taken'
+  end
+
+  test 'a top-coins index bot is named by its size' do
+    bot = build(:dca_index, user: @user, quote_asset: @usd)
+    bot.num_coins = 6
+    bot.set_missed_quote_amount
+    bot.save!
+
+    assert_equal 'Top 6', bot.label
+  end
+
+  # --- nothing to name it after ------------------------------------------------
+
+  test 'a bot whose asset has gone missing still gets a name' do
+    bot = Bots::DcaSingleAsset.new(user: @user, settings: { 'quote_amount' => 10 })
+
+    bot.validate
+
+    assert_predicate bot.label, :present?
+    assert_empty bot.errors[:label]
+  end
+end

--- a/test/services/bot_api/bots/create_test.rb
+++ b/test/services/bot_api/bots/create_test.rb
@@ -25,6 +25,18 @@ class BotApi::Bots::CreateTest < ActiveSupport::TestCase
       quote_amount: 100, interval: 'day' }
   end
 
+  # ---------- naming ----------
+
+  test 'a bot created without a label is named like one made in the wizard' do
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+
+    result = BotApi::Bots::Create.call(user: @user, **base_params)
+
+    assert result.success?
+    assert_equal 'Bitcoin', @user.bots.last.label
+  end
+
   # ---------- immediate start (unchanged behavior) ----------
 
   test 'without start_at the bot starts immediately' do


### PR DESCRIPTION
Closes #215.

A new bot used to be called something like "Wandering Sunset" — a Haikunator name nobody picked, on a list where every row is meant to say what it invests in. Now it names itself from its own settings.

| bot | name |
|---|---|
| one asset | `Bitcoin`, `iShares Core S&P 500 ETF` — the full asset name |
| index | `Layer 1 · 20` — the index and how many coins it holds |
| a basket | `BTC, ETH, XRP + 3` — the first three tickers, then how many are left |

`Top 10` and `Nasdaq 7` already carry their size in the index name, so only a thematic category gets the count appended.

### How it works

The name is taken at save time (`before_validation`) rather than at build time, because the wizard fills the settings in one step at a time on an in-memory bot: at `Bot.new` there is nothing to read a name from yet. Each type answers `default_label`; a bot with nothing to read a name from falls back to "New bot", so the presence validation can never block a save.

That timing is what retires the label the wizard carried through the session. It existed to keep a random name stable across a wizard restart — a name derived from the settings is stable by itself.

The count in an index name is the count the bot will actually buy: the clamp that trims `num_coins` to a bounded index runs before the name is taken, so a crafted request can't leave a bot called "Nasdaq 50" buying ten stocks.

The REST/MCP create path had its own default ("BTC/USD Binance"). It's deleted, so a bot created through the API is named like one made in the wizard.

The `haikunator` gem is gone.

### Scope

Existing bots keep their names — this only ever fills in a blank one, and a name the user typed is never overwritten. The custom-portfolio bot lives on an unmerged branch; it gets this by defining `default_label` as `basket_label(*base_asset_ids)`.

### Tests

`test/models/bot_default_label_test.rb` covers each type's rule, the "+ N" remainder, the index clamp, a user-picked name surviving a save, and the fallback. The single-asset wizard integration test now asserts the created bot is called "Bitcoin", and the API create test asserts the same for a label-less API call. 4036 tests green.
