### PR TITLE
Let me read my portfolio as allocation, not as money

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -96,10 +96,11 @@ class SettingsController < ApplicationController
   # It lives in the menu rather than on this page because it is a way of reading every screen,
   # and the answer is a refresh for the same reason the currency select's is: it changes every
   # figure on the page, not one frame. The broadcast carries that refresh to the account's other
-  # open bot screens, which would otherwise keep the markup they were served before the flip.
+  # open tabs, which would otherwise keep the markup they were served before the flip — the
+  # layout subscribes every signed-in page to that stream.
   def update_hide_balances
     current_user.update!(hide_balances: !current_user.hide_balances?)
-    Turbo::StreamsChannel.broadcast_refresh_to("user_#{current_user.id}", :bot_updates)
+    Turbo::StreamsChannel.broadcast_refresh_to("user_#{current_user.id}", :preferences)
     render turbo_stream: turbo_stream_page_refresh
   end
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -22,3 +22,30 @@ Turbo.StreamActions.remove_class = function () {
   const className = this.getAttribute("class-name");
   this.targetElements.forEach((element) => element.classList.remove(className));
 };
+
+// Turbo keeps a snapshot of every page visited and restores it, without a request, when the user
+// goes Back. Turning "Hide balances" on therefore leaves the balances one Back press away: the
+// snapshot was taken while they were still on screen, and a broadcast refresh reaches the live
+// document but not the cache behind it.
+//
+// Per tab, and keyed on what the tab has actually RENDERED rather than on the click, because the
+// preference is account-wide: a tab that was never the one toggled still holds stale snapshots and
+// still has to drop them. The class on <body> is the rendered state, so a change in it between two
+// loads is exactly the moment every snapshot in this tab became wrong.
+//
+// The limit: a tab asleep or with its cable reconnecting misses the refresh broadcast entirely, so
+// it goes on showing what it last rendered until it is navigated. Closing that would cost a server
+// round-trip every time any tab regains focus, which is a poor trade for a window in which nobody
+// is looking at the tab anyway.
+document.addEventListener("turbo:load", () => {
+  const hidden = document.body.classList.contains("hide-balances") ? "1" : "0";
+  try {
+    if (sessionStorage.getItem("hide-balances") === hidden) return;
+
+    sessionStorage.setItem("hide-balances", hidden);
+  } catch {
+    // Storage can be denied outright (private mode, embedded webview). Clearing a cache we
+    // cannot reason about is the safe way to be wrong.
+  }
+  Turbo.cache.clear();
+});

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -1,3 +1,8 @@
+<%# A hide-balances toggle in another tab refreshes this one. Subscribed per page rather than in
+    the layout: the refresh REPLACES the document, so a settings or setup page listening for it
+    would throw away whatever the user had half-typed into an email, password or API-key form.
+    Only the pages that state balances have anything to re-render. %>
+<%= turbo_stream_from "user_#{current_user.id}", :preferences %>
 <%= turbo_stream_from "user_#{current_user.id}", :bot_updates %>
 
 <%# Not @bots.empty?: a user whose bots are all archived still has bots, and needs the filter row. %>

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -1,3 +1,8 @@
+<%# A hide-balances toggle in another tab refreshes this one. Subscribed per page rather than in
+    the layout: the refresh REPLACES the document, so a settings or setup page listening for it
+    would throw away whatever the user had half-typed into an email, password or API-key form.
+    Only the pages that state balances have anything to re-render. %>
+<%= turbo_stream_from "user_#{current_user.id}", :preferences %>
 <%= turbo_stream_from "user_#{current_user.id}", :bot_updates %>
 
 <%= turbo_frame_tag "bot" do %>

--- a/app/views/tracker/_portfolio_chart.html.erb
+++ b/app/views/tracker/_portfolio_chart.html.erb
@@ -1,15 +1,24 @@
 <%
-  slices = (@portfolio_slices || []).map do |s|
+  hide_balances = current_user.hide_balances?
+  holdings = @portfolio_slices || []
+  holdings_total = holdings.sum { |s| s[:usd_value].to_f }
+  slices = holdings.map do |s|
     asset = s[:asset]
+    share = holdings_total.positive? ? (s[:usd_value].to_f / holdings_total * 100) : 0
     {
       label: asset.symbol,
       symbol: asset.symbol,
       name: asset.name,
-      value: s[:usd_value].to_f,
+      # The donut only ever needed proportions — it draws shares and labels them in percent — so
+      # while balances are hidden it is handed the share itself. An absolute value here would be
+      # the whole portfolio sitting in a data attribute for anyone who opened the inspector, which
+      # is the one thing this page is being asked not to say.
+      value: hide_balances ? share : s[:usd_value].to_f,
       color: ensure_contrast(asset.color.presence || '#8A9BA8'),
       assetId: asset.id
     }
   end
+  # Either way the shares below come out the same: hidden, the values ARE shares and this is 100.
   slices_total = slices.sum { |s| s[:value] }
 %>
 <%= turbo_frame_tag 'tracker-portfolio-chart', class: 'tracker-portfolio' do %>
@@ -48,7 +57,9 @@
                   </div>
                 </div>
                 <div class="allocation"><%= pct.round(1) %>%</div>
-                <div class="tracker-portfolio__asset-value"><%= @denomination.format(slice[:value], precision: 2) %></div>
+                <% unless hide_balances %>
+                  <div class="tracker-portfolio__asset-value"><%= @denomination.format(slice[:value], precision: 2) %></div>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -13,10 +13,12 @@
     <% end %>
   </td>
   <td><%= at.base_currency %></td>
-  <td><%= at.base_amount %></td>
+  <% unless current_user.hide_balances? %><td><%= at.base_amount %></td><% end %>
   <td><%= at.quote_currency || '-' %></td>
-  <td><%= at.quote_amount.present? ? at.quote_amount : '-' %></td>
-  <td><%= at.fee_amount.present? ? "#{at.fee_amount} #{at.fee_currency}" : '-' %></td>
+  <% unless current_user.hide_balances? %>
+    <td><%= at.quote_amount.present? ? at.quote_amount : '-' %></td>
+    <td><%= at.fee_amount.present? ? "#{at.fee_amount} #{at.fee_currency}" : '-' %></td>
+  <% end %>
   <td>
     <% if at.bot_transaction.present? %>
       <%= link_to at.bot_transaction.bot.label || t('tracker.bot'), bot_path(at.bot_transaction.bot) %>

--- a/app/views/tracker/index.html.erb
+++ b/app/views/tracker/index.html.erb
@@ -1,3 +1,9 @@
+<% hide_balances = current_user.hide_balances? %>
+<%# A hide-balances toggle in another tab refreshes this one. Subscribed per page rather than in
+    the layout: the refresh REPLACES the document, so a settings or setup page listening for it
+    would throw away whatever the user had half-typed into an email, password or API-key form.
+    Only the pages that state balances have anything to re-render. %>
+<%= turbo_stream_from "user_#{current_user.id}", :preferences %>
 <%= turbo_stream_from "user_#{current_user.id}", :tax_report %>
 <%= turbo_stream_from "user_#{current_user.id}", :sync %>
 <%= render 'sync_warning', exchanges: @sync_failures %>
@@ -14,7 +20,9 @@
     </div>
   </div>
 <% else %>
-<% if @portfolio_total_usd && @portfolio_total_usd.positive? %>
+<%# The portfolio total has no percentage to fall back on the way a bot's P/L does — it is the
+    balance, and nothing else. The allocation below is what the page shows instead. %>
+<% if !hide_balances && @portfolio_total_usd && @portfolio_total_usd.positive? %>
   <section class="dash-intro">
     <h1 class="header header--1">
       <%= @denomination.format(@portfolio_total_usd, precision: 2) %>
@@ -58,10 +66,14 @@
           <th class="text-left"><%= t('tracker.columns.date') %></th>
           <th><%= t('tracker.columns.type') %></th>
           <th><%= t('tracker.columns.base') %></th>
-          <th><%= t('tracker.columns.amount') %></th>
+          <%# The same three figures the bot log drops: what was traded, what it cost, and what was
+              paid to trade it. The currencies keep their own columns. %>
+          <% unless hide_balances %><th><%= t('tracker.columns.amount') %></th><% end %>
           <th><%= t('tracker.columns.quote') %></th>
-          <th><%= t('tracker.columns.quote_amount') %></th>
-          <th><%= t('tracker.columns.fee') %></th>
+          <% unless hide_balances %>
+            <th><%= t('tracker.columns.quote_amount') %></th>
+            <th><%= t('tracker.columns.fee') %></th>
+          <% end %>
           <th><%= t('tracker.columns.bot') %></th>
         </tr>
       </thead>

--- a/test/controllers/settings/hide_balances_test.rb
+++ b/test/controllers/settings/hide_balances_test.rb
@@ -35,11 +35,26 @@ class Settings::HideBalancesTest < ActionDispatch::IntegrationTest
   end
 
   # ...and the user's OTHER open tabs have to hear about it too, or a second window keeps
-  # rendering the markup it was served before the toggle.
-  test 'the toggle refreshes the account\'s other open bot screens' do
-    assert_turbo_stream_broadcasts(["user_#{@user.id}", :bot_updates], count: 1) do
+  # rendering the markup it was served before the toggle. Account-wide, so the layout subscribes
+  # every signed-in page rather than the three that happen to show balances.
+  test 'the toggle refreshes the account\'s other open tabs' do
+    assert_turbo_stream_broadcasts(["user_#{@user.id}", :preferences], count: 1) do
       patch settings_update_hide_balances_path
     end
+  end
+
+  # ...but only the pages that state balances listen. A refresh REPLACES the document, so a
+  # settings page listening for one would throw away a half-typed API key or password.
+  test 'a page that states no balances does not listen for the refresh' do
+    get settings_account_path
+
+    assert_select 'turbo-cable-stream-source', false
+  end
+
+  test 'the pages that state balances do listen' do
+    get tracker_path
+
+    assert_select 'turbo-cable-stream-source', 3
   end
 
   test 'the body says whether balances are hidden' do

--- a/test/integration/tracker_hide_balances_test.rb
+++ b/test/integration/tracker_hide_balances_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The tracker with balances hidden. The portfolio is still the whole point of the page, so it stays
+# — as allocation. Each holding keeps its share, its colour and its slice of the donut, and states
+# no value; the transactions table follows the same rule the bot log does.
+class TrackerHideBalancesTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, admin: true, setup_completed: true, hide_balances: true)
+    @exchange = create(:binance_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    sign_in @user
+  end
+
+  # 30,000 of BTC beside 10,000 of ETH: a 75/25 split, so the shares are unmistakable in the markup
+  # whichever way they are expressed.
+  def stub_portfolio
+    AccountBalance.create!(user: @user, exchange: @exchange, asset: create(:asset, :bitcoin),
+                           free: 1, usd_price: 30_000, usd_value: 30_000, synced_at: Time.current)
+    AccountBalance.create!(user: @user, exchange: @exchange,
+                           asset: create(:asset, symbol: 'ETH', name: 'Ethereum', external_id: 'ethereum'),
+                           free: 5, usd_price: 2_000, usd_value: 10_000, synced_at: Time.current)
+  end
+
+  test 'the portfolio total is not stated' do
+    stub_portfolio
+
+    get tracker_path
+
+    assert_select '.dash-intro .header--1', false
+  end
+
+  test 'the portfolio total is stated when balances are shown' do
+    @user.update!(hide_balances: false)
+    stub_portfolio
+
+    get tracker_path
+
+    assert_select '.dash-intro .header--1'
+  end
+
+  test 'each holding keeps its share and states no value' do
+    stub_portfolio
+
+    get tracker_path
+
+    assert_select '.tracker-portfolio__asset .allocation', text: '75.0%'
+    assert_select '.tracker-portfolio__asset .allocation', text: '25.0%'
+    assert_select '.tracker-portfolio__asset-value', false
+  end
+
+  # The donut only ever needed proportions. Handing it shares rather than dollars keeps the
+  # portfolio out of the data attribute as well as off the page.
+  test 'the donut is handed shares rather than values' do
+    stub_portfolio
+
+    get tracker_path
+
+    data = JSON.parse(css_select('[data-donut-chart-data-value]').first['data-donut-chart-data-value'])
+    assert_equal([75.0, 25.0], data.map { |slice| slice['value'] })
+  end
+
+  test 'the donut is handed values when balances are shown' do
+    @user.update!(hide_balances: false)
+    stub_portfolio
+
+    get tracker_path
+
+    data = JSON.parse(css_select('[data-donut-chart-data-value]').first['data-donut-chart-data-value'])
+    assert_equal([30_000.0, 10_000.0], data.map { |slice| slice['value'] })
+  end
+
+  test 'a transaction row keeps its date, type and currencies' do
+    create(:account_transaction, api_key: @api_key, exchange: @exchange, entry_type: :buy,
+                                 base_currency: 'BTC', base_amount: 0.5,
+                                 quote_currency: 'USD', quote_amount: 25_000.0,
+                                 fee_amount: 12.5, fee_currency: 'USD', transacted_at: 1.day.ago)
+
+    get tracker_path
+
+    assert_select 'td', text: 'BTC'
+    assert_select 'td', text: 'USD'
+    assert_select 'td', text: I18n.t('tracker.types.buy')
+  end
+
+  # Same rule as the bot log: the amount held, what it cost, and the fee paid are all money.
+  test 'a transaction row states no amount, no value and no fee' do
+    at = create(:account_transaction, api_key: @api_key, exchange: @exchange, entry_type: :buy,
+                                      base_currency: 'BTC', base_amount: 0.5,
+                                      quote_currency: 'USD', quote_amount: 25_000.0,
+                                      fee_amount: 12.5, fee_currency: 'USD', transacted_at: 1.day.ago)
+
+    get tracker_path
+
+    cells = css_select("##{ActionView::RecordIdentifier.dom_id(at)} td").map { |td| td.text.strip }
+    assert_not_includes cells.join(' '), '0.5'
+    assert_not_includes cells.join(' '), '25000'
+    assert_not_includes cells.join(' '), '12.5'
+  end
+
+  test 'the transactions table drops those three columns and keeps the rest' do
+    create(:account_transaction, api_key: @api_key, exchange: @exchange, base_currency: 'BTC',
+                                 transacted_at: 1.day.ago)
+
+    get tracker_path
+
+    headers = css_select('.widget--table--tracker thead th').map { |th| th.text.strip }
+    assert_not_includes headers, I18n.t('tracker.columns.amount')
+    assert_not_includes headers, I18n.t('tracker.columns.quote_amount')
+    assert_not_includes headers, I18n.t('tracker.columns.fee')
+    assert_includes headers, I18n.t('tracker.columns.date')
+    assert_includes headers, I18n.t('tracker.columns.base')
+    assert_includes headers, I18n.t('tracker.columns.quote')
+    assert_includes headers, I18n.t('tracker.columns.bot')
+  end
+
+  test 'the table keeps every column when balances are shown' do
+    @user.update!(hide_balances: false)
+    create(:account_transaction, api_key: @api_key, exchange: @exchange, base_currency: 'BTC',
+                                 transacted_at: 1.day.ago)
+
+    get tracker_path
+
+    headers = css_select('.widget--table--tracker thead th').map { |th| th.text.strip }
+    assert_includes headers, I18n.t('tracker.columns.amount')
+    assert_includes headers, I18n.t('tracker.columns.quote_amount')
+    assert_includes headers, I18n.t('tracker.columns.fee')
+  end
+end


### PR DESCRIPTION
Follow-up to #230, which added the **Hide balances** preference but left the tracker stating balances outright — the one screen the toggle promised to cover and didn't.

## The portfolio, as allocation

The portfolio is the point of that page, so it stays; it is the values that go. Every holding keeps its share, its colour and its slice of the donut and states no value. The account total above it goes, having no percentage to fall back on the way a bot's P/L does.

The donut is handed the shares themselves rather than dollar values. It only ever needed proportions — it draws slices and labels them in percent — so this also keeps the portfolio out of the data attribute, not only off the page.

## The transactions table

The same rule as the bot log: no Amount, no Quote amount, no Fee. Date, type, both currencies and the linked bot stay.

## Two things the tracker made necessary

**The cross-tab refresh moved to its own stream.** #230 broadcast it on `:bot_updates`, which the tracker does not subscribe to; the preference was never a property of the bot screens. It now goes out on `:preferences`, and the three pages that state balances subscribe to it.

Deliberately not the layout: a Turbo refresh replaces the document, so a settings or setup page listening for one would throw away whatever the user had half-typed into an email, password or API-key form.

**Turbo's snapshot cache is cleared when a tab's rendered state flips.** Turbo restores a cached snapshot on Back without making a request, so turning the preference on left the balances one keypress away on any page rendered before the toggle. The check is keyed on the class the body actually came back with rather than on the click, because a tab that was never the one toggled holds stale snapshots too.

## Known limit

A tab that is asleep, or whose cable is reconnecting, misses the refresh broadcast and goes on showing what it last rendered until it is navigated. Closing that would cost a server round-trip every time any tab regains focus, which is a poor trade for a window in which nobody is looking at the tab.

The limits stated in #230 still apply: this is a visual privacy feature, not a confidentiality boundary.

## Tests

Covering the portfolio rendered as allocation with no values and no total, the shares handed to the donut in place of dollars, the three columns dropped from the transactions table, and which pages do and do not subscribe to the refresh.
