### PR TITLE
Make Hide balances an actual switch, and make it take effect

### DIFF
--- a/app/assets/stylesheets/new/_dropdown.sass
+++ b/app/assets/stylesheets/new/_dropdown.sass
@@ -117,6 +117,13 @@
         background: none // <button>
         width: 100%      // <button>
         color: var(--ash)
+        // Label left, switch right. The base item is a grid built for a single label; a row that
+        // carries a control needs the two ends held apart.
+        &--switch
+            display: flex
+            align-items: center
+            justify-content: space-between
+            gap: 2rem
         &--danger
             color: var(--berry)
             &:hover

--- a/app/assets/stylesheets/new/_menu-mobile.sass
+++ b/app/assets/stylesheets/new/_menu-mobile.sass
@@ -26,6 +26,12 @@
       top: -0.125rem
     path
       fill: var(--menulink)
+    // The switch sits beside its label, and the pair stays centred like every other row here.
+    &--switch
+      display: flex
+      align-items: center
+      justify-content: center
+      gap: 1.5rem
   &__button
     background: none
     border: none

--- a/app/assets/stylesheets/new/_toggle.sass
+++ b/app/assets/stylesheets/new/_toggle.sass
@@ -30,6 +30,27 @@
             border-radius: 50%
             transition: transform 0.3s
             box-shadow: var(--shadow-paper)
+    // Menu-sized. The default is built for a settings widget and is taller than a dropdown row;
+    // this keeps the same proportions at the row's own line-height, and does not grow on desktop
+    // the way the default does.
+    &--small
+        .toggle__style
+            width: 3rem !important
+            min-width: 3rem !important
+            height: 1.75rem !important
+            border-radius: 1rem
+            &::after
+                top: 0.25rem
+                left: 0.25rem
+                width: 1.25rem
+                height: 1.25rem
+        input[type="checkbox"]
+            width: 3rem !important
+            height: 1.75rem !important
+            &:checked
+                &~ .toggle__style
+                    &::after
+                        transform: translateX(1.25rem) !important
     &--vertical
         .toggle__style
             width: 3rem !important

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -92,16 +92,19 @@ class SettingsController < ApplicationController
     end
   end
 
-  # A toggle, so there is nothing submitted to trust — the action flips what is stored.
-  # It lives in the menu rather than on this page because it is a way of reading every screen,
-  # and the answer is a refresh for the same reason the currency select's is: it changes every
-  # figure on the page, not one frame. The broadcast carries that refresh to the account's other
-  # open tabs, which would otherwise keep the markup they were served before the flip — the
-  # layout subscribes every signed-in page to that stream.
+  # The switch in the menu posts its own state, so this stores what was submitted rather than
+  # flipping what it finds — two quick clicks can otherwise land out of order and leave the stored
+  # value disagreeing with the switch the user is looking at.
+  #
+  # A redirect, not a turbo-stream refresh: the preference changes a class on <body>, so the whole
+  # document has to come back. A refresh stream action is skipped whenever a visit is already in
+  # flight — which is exactly what submitting this form is — and the page would sit there still
+  # showing the old state until it was reloaded by hand. The broadcast carries the same re-render
+  # to the account's other open tabs on the pages that state balances.
   def update_hide_balances
-    current_user.update!(hide_balances: !current_user.hide_balances?)
+    current_user.update!(hide_balances: params[:hide_balances] == '1')
     Turbo::StreamsChannel.broadcast_refresh_to("user_#{current_user.id}", :preferences)
-    render turbo_stream: turbo_stream_page_refresh
+    redirect_back fallback_location: bots_path, status: :see_other
   end
 
   def update_password

--- a/app/views/layouts/navbar/_hide_balances_toggle.html.haml
+++ b/app/views/layouts/navbar/_hide_balances_toggle.html.haml
@@ -1,0 +1,13 @@
+-# A switch, not a link: the state IS the answer, so the row keeps one constant label and the
+  toggle beside it says whether balances are hidden. Same `.toggle` the bot settings use.
+-#
+-# The hidden field is what makes an unchecked box mean something — a checkbox posts nothing when
+  it is off, and the action stores what was submitted rather than flipping what it finds.
+= form_with url: settings_update_hide_balances_path, method: :patch,
+            class: "#{item_class} #{item_class}--switch", data: { controller: "form--submit" } do
+  %span= t('links.hide_balances')
+  .toggle.toggle--small
+    = hidden_field_tag :hide_balances, "0"
+    = check_box_tag :hide_balances, "1", current_user.hide_balances?,
+                    data: { action: "change->form--submit#submit" }
+    .toggle__style

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -24,8 +24,7 @@
   = link_to settings_account_path, class: "menu-mobile__item menu-mobile__item--account #{'menu-mobile__item--active' if current_page?(settings_account_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
     = t('links.account')
 
-  = button_to settings_update_hide_balances_path, method: :patch, class: "menu-mobile__item menu-mobile__button" do
-    = t(current_user.hide_balances? ? 'links.show_balances' : 'links.hide_balances')
+  = render 'layouts/navbar/hide_balances_toggle', item_class: 'menu-mobile__item'
 
   .menu-mobile__divider
   = button_to destroy_user_session_path, method: :delete, class: "menu-mobile__item menu-mobile__button", data: { turbo: false } do
@@ -69,10 +68,7 @@
       .dropdown
         = link_to t('links.connections'), settings_connect_path, class: "dropdown__item"
         = link_to t('links.account'), settings_account_path, class: "dropdown__item"
-        -# The label is the ACTION, not the state: an item that says what the click will do needs
-          no check mark, and there is no room for one in a dropdown that is otherwise all links.
-        = button_to settings_update_hide_balances_path, method: :patch, class: "dropdown__item" do
-          = t(current_user.hide_balances? ? 'links.show_balances' : 'links.hide_balances')
+        = render 'layouts/navbar/hide_balances_toggle', item_class: 'dropdown__item'
         .dropdown__item.dropdown__item--divider
         = button_to destroy_user_session_path, method: :delete, class: "dropdown__item dropdown__item--danger", data: { turbo: false } do
           = t('links.log_out')

--- a/test/controllers/settings/hide_balances_test.rb
+++ b/test/controllers/settings/hide_balances_test.rb
@@ -17,21 +17,46 @@ class Settings::HideBalancesTest < ActionDispatch::IntegrationTest
     assert_not @user.hide_balances?
   end
 
-  test 'the toggle turns hiding on and off again' do
-    patch settings_update_hide_balances_path
+  # The switch posts its own state rather than asking for a flip: two quick clicks can land out of
+  # order, and a flip would leave the stored value disagreeing with the switch on screen.
+  test 'the switch stores the state it posts' do
+    patch settings_update_hide_balances_path, params: { hide_balances: '1' }
     assert @user.reload.hide_balances?
 
-    patch settings_update_hide_balances_path
+    patch settings_update_hide_balances_path, params: { hide_balances: '0' }
     assert_not @user.reload.hide_balances?
   end
 
-  # The preference changes every figure on the page, not one frame, so the answer is a refresh —
-  # the same answer the display-currency select gives.
-  test 'the toggle answers with a page refresh' do
+  # An unchecked box posts nothing of its own — the hidden field beside it is what makes "off"
+  # reach the server at all.
+  test 'a post with no state at all reads as off' do
+    @user.update!(hide_balances: true)
+
     patch settings_update_hide_balances_path
 
-    assert_response :success
-    assert_match 'turbo-stream action="refresh"', @response.body
+    assert_not @user.reload.hide_balances?
+  end
+
+  # A redirect, not a turbo-stream refresh: the preference changes a class on <body>, so the whole
+  # document has to come back, and a refresh stream action is skipped while a visit is already in
+  # flight — which is exactly what submitting this form is. The page would sit on the old state
+  # until it was reloaded by hand.
+  test 'the switch sends the user back to the page they were on, re-rendered' do
+    patch settings_update_hide_balances_path,
+          params: { hide_balances: '1' }, headers: { 'Referer' => "http://www.example.com#{tracker_path}" }
+
+    assert_response :see_other
+    assert_redirected_to tracker_path
+  end
+
+  # The menu is on every page, so "back where you were" is whatever the browser reports — which
+  # makes this an open-redirect surface if it is taken at face value.
+  test 'a referer pointing somewhere else entirely is refused' do
+    patch settings_update_hide_balances_path,
+          params: { hide_balances: '1' }, headers: { 'Referer' => 'http://evil.example/steal' }
+
+    assert_redirected_to bots_path
+    assert @user.reload.hide_balances?
   end
 
   # ...and the user's OTHER open tabs have to hear about it too, or a second window keeps
@@ -67,17 +92,26 @@ class Settings::HideBalancesTest < ActionDispatch::IntegrationTest
     assert_select 'body.hide-balances'
   end
 
-  # The item says what the click will do, so there is no check state to read.
-  test 'the menu item offers the opposite of the current state' do
+  # A switch, so the row keeps one constant label and the control carries the state.
+  test 'the menu row is a switch that reflects the stored state' do
     get bots_path
-    assert_select 'form[action=?] button', settings_update_hide_balances_path,
-                  text: I18n.t('links.hide_balances')
+    assert_select 'form[action=?]', settings_update_hide_balances_path do
+      assert_select '.toggle input[type=checkbox][name=hide_balances]'
+      assert_select 'input[type=checkbox][checked]', false
+      assert_select 'span', text: I18n.t('links.hide_balances')
+    end
 
     @user.update!(hide_balances: true)
 
     get bots_path
-    assert_select 'form[action=?] button', settings_update_hide_balances_path,
-                  text: I18n.t('links.show_balances')
+    assert_select 'form[action=?] input[type=checkbox][checked]', settings_update_hide_balances_path
+  end
+
+  test 'both the desktop menu and the mobile one carry it' do
+    get bots_path
+
+    assert_select '.dropdown form[action=?] .toggle', settings_update_hide_balances_path
+    assert_select '.menu-mobile form[action=?] .toggle', settings_update_hide_balances_path
   end
 
   test 'signing out is still required to change anyone else\'s preference' do


### PR DESCRIPTION
Two fixes to the **Hide balances** control added in #230.

## It is a switch now

The menu row was a link-shaped item whose label flipped between "Hide balances" and "Show balances". It carries the same `.toggle` the bot settings use instead, so the state is visible without reading the label, and the label stays constant.

A `--small` modifier sizes the toggle to a menu row rather than a settings widget, and the row becomes a flex line with the label at one end and the switch at the other. Both the desktop dropdown and the mobile menu use the same partial.

The switch posts its own state rather than asking the server to flip what it finds: two quick clicks can land out of order, and a flip would leave the stored value disagreeing with the switch on screen. The hidden field beside the checkbox is what makes "off" reach the server at all — an unchecked box posts nothing.

## Clicking it takes effect

The action answered with a turbo-stream page refresh. Turbo skips a refresh stream action whenever a visit is already in flight, and submitting this form is exactly that, so the page sat on its old state until it was reloaded by hand.

It answers with `redirect_back` instead, which re-renders the whole document — which is what a class on `<body>` needs. Verified in the browser in both directions, on `/bots` and on `/tracker`.

`redirect_back` takes the browser's word for where "back" is, so a referer pointing at another host falls back to the dashboard rather than being followed. Pinned by a test.

## Tests

The state the switch posts in both directions, an empty post reading as off, the redirect and its foreign-host refusal, the switch reflecting the stored state, and both menus carrying it.
