### PR TITLE
Let the balances switch behave like a switch

### DIFF
--- a/app/assets/stylesheets/new/_toggle.sass
+++ b/app/assets/stylesheets/new/_toggle.sass
@@ -93,6 +93,11 @@
                 path
                     fill: var(--grass)
 
+// The LABEL is the menu row; the form around it only carries the submit, so it must not put a box
+// between the menu and its own item.
+.switch-row-form
+    display: contents
+
 input[type=checkbox]
     cursor: pointer
 .toggle-group

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -8,7 +8,14 @@ export default class extends Controller {
     this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
-  toggle() {
+  // Every click inside the wrapper bubbles to here, which is what closes the menu after picking an
+  // item — right for a link, wrong for a control the menu OWNS: flipping a switch is not choosing
+  // where to go, and the menu closing under the finger makes it unusable for a second flip.
+  // Marked elements opt out; the menu still closes on an outside click or on any item that leads
+  // somewhere.
+  toggle(event) {
+    if (event?.target?.closest?.("[data-dropdown-keep-open]")) return;
+
     this.wrapperTarget.classList.toggle("dropdown-wrapper--on");
     const isOpen = this.wrapperTarget.classList.contains("dropdown-wrapper--on");
 

--- a/app/views/layouts/navbar/_hide_balances_toggle.html.haml
+++ b/app/views/layouts/navbar/_hide_balances_toggle.html.haml
@@ -1,13 +1,18 @@
 -# A switch, not a link: the state IS the answer, so the row keeps one constant label and the
   toggle beside it says whether balances are hidden. Same `.toggle` the bot settings use.
 -#
+-# The row is a LABEL, so the whole line is the hit area — a menu row that only responds on its
+  last two centimetres reads as broken. data-dropdown-keep-open stops that click from closing the
+  menu on its way up; the form is display: contents so the label is still the menu's own row.
+-#
 -# The hidden field is what makes an unchecked box mean something — a checkbox posts nothing when
   it is off, and the action stores what was submitted rather than flipping what it finds.
 = form_with url: settings_update_hide_balances_path, method: :patch,
-            class: "#{item_class} #{item_class}--switch", data: { controller: "form--submit" } do
-  %span= t('links.hide_balances')
-  .toggle.toggle--small
-    = hidden_field_tag :hide_balances, "0"
-    = check_box_tag :hide_balances, "1", current_user.hide_balances?,
-                    data: { action: "change->form--submit#submit" }
-    .toggle__style
+            class: "switch-row-form", data: { controller: "form--submit" } do
+  %label{ class: "#{item_class} #{item_class}--switch", data: { dropdown_keep_open: true } }
+    %span= t('links.hide_balances')
+    .toggle.toggle--small
+      = hidden_field_tag :hide_balances, "0"
+      = check_box_tag :hide_balances, "1", current_user.hide_balances?,
+                      data: { action: "change->form--submit#submit" }
+      .toggle__style

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -1,4 +1,6 @@
-%input{ type: "checkbox", id: "hamburger" }
+-# Permanent for the same reason the settings menu is: the switch inside re-renders the page, and
+  the drawer is held open by this checkbox alone.
+%input{ type: "checkbox", id: "hamburger", data: { turbo_permanent: true } }
 
 .hamburger.hamburger__a
 .hamburger.hamburger__b
@@ -60,7 +62,11 @@
         = t('links.rules')
 
   .menu__section.menu__section--bottom
-    .dropdown-wrapper.dropdown-wrapper--bottom-left{ data: { controller: "dropdown", action: "click->dropdown#toggle", dropdown_target: "wrapper", dropdown_active_class: "menu__item--active" } }
+    -# Permanent: flipping the switch inside re-renders the page, and a menu that vanished mid-flip
+      would be a menu you had to reopen to change your mind. Turbo carries this element across the
+      visit, so it stays open and stays on the state the user just set. Nothing in it is page-
+      dependent, so keeping the old node costs nothing.
+    .dropdown-wrapper.dropdown-wrapper--bottom-left#settings-menu{ data: { turbo_permanent: true, controller: "dropdown", action: "click->dropdown#toggle", dropdown_target: "wrapper", dropdown_active_class: "menu__item--active" } }
       .menu__item.menu__button{ data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip', dropdown_target: "trigger" } }
         = render 'svg/24x24_sliders'
         .tooltip

--- a/test/controllers/settings/hide_balances_test.rb
+++ b/test/controllers/settings/hide_balances_test.rb
@@ -114,6 +114,36 @@ class Settings::HideBalancesTest < ActionDispatch::IntegrationTest
     assert_select '.menu-mobile form[action=?] .toggle', settings_update_hide_balances_path
   end
 
+  # The whole line is the control. A menu row that only answers on its last two centimetres reads
+  # as broken, so the row is a label and the click lands wherever it falls.
+  test 'the whole row is the hit area, not just the switch' do
+    get bots_path
+
+    assert_select 'form[action=?] label', settings_update_hide_balances_path do
+      assert_select 'input[type=checkbox][name=hide_balances]'
+      assert_select 'span', text: I18n.t('links.hide_balances')
+    end
+  end
+
+  # Flipping a switch is not choosing where to go: the menu has to survive the click, or a second
+  # flip means reopening it.
+  test 'the row opts out of the click that closes the menu' do
+    get bots_path
+
+    assert_select 'form[action=?] label[data-dropdown-keep-open]', settings_update_hide_balances_path
+    # ...but the items that DO lead somewhere still close it.
+    assert_select '.dropdown a.dropdown__item[data-dropdown-keep-open]', false
+  end
+
+  # The flip re-renders the page, and a menu that vanished mid-flip would be a menu you had to
+  # reopen to change your mind.
+  test 'the menus survive the re-render the switch causes' do
+    get bots_path
+
+    assert_select '#settings-menu[data-turbo-permanent]'
+    assert_select '#hamburger[data-turbo-permanent]'
+  end
+
   test 'signing out is still required to change anyone else\'s preference' do
     sign_out @user
 


### PR DESCRIPTION
Three things about the **Hide balances** menu row added in #232. It looked like a switch but did not behave like one.

## The whole line is the control

The row is a `<label>`, so a click anywhere along it flips the switch. A menu row that only answers on its last two centimetres reads as broken. The form around it is `display: contents`, so the label is still the menu's own row rather than a box inside one.

## Flipping it no longer closes the menu

Every click inside a dropdown bubbles up to the handler that closes it. That is right for an item that leads somewhere and wrong for a control the menu owns — the menu shut under the finger, so changing your mind meant reopening it.

`dropdown#toggle` now ignores clicks from inside `[data-dropdown-keep-open]`. Outside clicks still close the menu, and so do the items that actually navigate.

## The menu survives the re-render

The switch answers with a redirect, so the whole document comes back — and it took the open menu with it. The settings dropdown and the mobile drawer's checkbox are `data-turbo-permanent`, so Turbo carries them across the visit: the menu stays open, on the state just set. Nothing in either is page-dependent, so keeping the old node costs nothing.

## Verified

In the browser, not only in tests: clicking the label text flips it in both directions with the menu staying open, an outside click still closes the menu, and the links inside it are untouched.

Tests cover the row being a label, the opt-out attribute being on the row and not on the links, and both menus being permanent.
