### PR TITLE
Hold the tracker's tables still, and document what a stock broker has to supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ admin name and email on the setup page. You can also paste the code during setup
 later under Settings → Connect. A subscription is optional: without a claim, Deltabadger
 continues through the independent setup path and can use your own CoinGecko key.
 
+### Stocks and ETFs
+
+Crypto works out of the box. Stock trading needs two things your container cannot invent: the
+list of tradeable symbols, and prices for them. Which broker you can use follows directly from
+who supplies those.
+
+**Alpaca — available self-hosted.** An Alpaca API key provides the tradeable symbol list, live
+prices and chart history all at once, so a container can run stocks entirely on its own. An admin
+connects a key once under Settings → Connect (paper or live) to build the catalog. Syncing the
+full US catalog takes a few minutes; after that, stocks appear in the bot wizard. Each user then
+connects their own Alpaca key when creating a bot — the admin key only keeps the catalog fresh,
+and it is never used to place anyone's orders.
+
+**Interactive Brokers — hosted only.** IBKR is a broker, not a market-data provider: it publishes
+no free price feed and no price history, and its market data is a paid, per-exchange subscription
+tied to each account. A self-hosted container therefore has no source for the prices and charts the
+app needs, so the IBKR option stays hidden unless the container is connected to deltabadger.com
+market data. This is a data limitation, not a licensing one. Maybe we'll find a way around.
+
 
 ## Running with Tauri (macOS and Linux)
 

--- a/app/assets/stylesheets/new/_data-grid.sass
+++ b/app/assets/stylesheets/new/_data-grid.sass
@@ -1,13 +1,19 @@
 @use "../variables" as *
 
 .data-grid
+    // One row, as the cells themselves compute it: label + gap + value, plus the item's own padding.
+    // The row divider is painted by the container, so it has to be told the height the items decide.
+    // It sits just BELOW the boundary and never repeats: on a single-row grid the bar then starts
+    // exactly at the bottom edge and is clipped away, instead of underlining the last row.
+    --data-grid-row: calc(5.5rem + 2 * var(--ui-padding) / 1.33)
     text-align: right
     display: grid
     gap: 0
     grid-template-columns: repeat(2, 50%)
-    background-image: linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(to bottom, transparent, transparent calc(11.8rem), var(--widget-shadow-line) calc(11.8rem), var(--widget-shadow-line) calc(11.8rem + 0.25rem), transparent calc(11.8rem + 0.25rem))
-    background-size: 100% 100%, 100% calc(11.8rem + 0.25rem)
-    background-repeat: no-repeat, repeat-y
+    background-image: linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line))
+    background-size: 100% 100%, 100% 0.25rem
+    background-position: 0 0, 0 var(--data-grid-row)
+    background-repeat: no-repeat
     &--two-columns
         grid-template-columns: repeat(2, 50%) !important
         background-image: linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)) !important
@@ -15,14 +21,16 @@
             min-height: auto
     @container (min-width: 576px)
         grid-template-columns: repeat(3, 33%)
-        background-image: linear-gradient(to right, transparent, transparent calc(33.33% - 0.25rem), var(--widget-shadow-line) calc(33.33% - 0.25rem), var(--widget-shadow-line) calc(33.33%), transparent calc(33.33%)), linear-gradient(to right, transparent, transparent calc(66.66% - 0.25rem), var(--widget-shadow-line) calc(66.66% - 0.25rem), var(--widget-shadow-line) calc(66.66%), transparent calc(66.66%)), linear-gradient(to bottom, transparent, transparent calc(11.8rem), var(--widget-shadow-line) calc(11.8rem), var(--widget-shadow-line) calc(11.8rem + 0.25rem), transparent calc(11.8rem + 0.25rem))
-        background-size: 100% 100%, 100% 100%, 100% calc(11.8rem + 0.25rem)
-        background-repeat: no-repeat, no-repeat, repeat-y
+        background-image: linear-gradient(to right, transparent, transparent calc(33.33% - 0.25rem), var(--widget-shadow-line) calc(33.33% - 0.25rem), var(--widget-shadow-line) calc(33.33%), transparent calc(33.33%)), linear-gradient(to right, transparent, transparent calc(66.66% - 0.25rem), var(--widget-shadow-line) calc(66.66% - 0.25rem), var(--widget-shadow-line) calc(66.66%), transparent calc(66.66%)), linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line))
+        background-size: 100% 100%, 100% 100%, 100% 0.25rem
+        background-position: 0 0, 0 0, 0 var(--data-grid-row)
+        background-repeat: no-repeat
     @container (min-width: 768px)
         grid-template-columns: repeat(4, 25%)
-        background-image: linear-gradient(to right, transparent, transparent calc(25% - 0.25rem), var(--widget-shadow-line) calc(25% - 0.25rem), var(--widget-shadow-line) calc(25%), transparent calc(25%)), linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(to right, transparent, transparent calc(75% - 0.25rem), var(--widget-shadow-line) calc(75% - 0.25rem), var(--widget-shadow-line) calc(75%), transparent calc(75%)), linear-gradient(to bottom, transparent, transparent calc(11.8rem), var(--widget-shadow-line) calc(11.8rem), var(--widget-shadow-line) calc(11.8rem + 0.25rem), transparent calc(11.8rem + 0.25rem))
-        background-size: 100% 100%, 100% 100%, 100% 100%, 100% calc(11.8rem + 0.25rem)
-        background-repeat: no-repeat, no-repeat, no-repeat, repeat-y
+        background-image: linear-gradient(to right, transparent, transparent calc(25% - 0.25rem), var(--widget-shadow-line) calc(25% - 0.25rem), var(--widget-shadow-line) calc(25%), transparent calc(25%)), linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(to right, transparent, transparent calc(75% - 0.25rem), var(--widget-shadow-line) calc(75% - 0.25rem), var(--widget-shadow-line) calc(75%), transparent calc(75%)), linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line))
+        background-size: 100% 100%, 100% 100%, 100% 100%, 100% 0.25rem
+        background-position: 0 0, 0 0, 0 0, 0 var(--data-grid-row)
+        background-repeat: no-repeat
     &__item
         padding: calc(var(--ui-padding)/1.33) var(--ui-padding)
         position: relative

--- a/app/assets/stylesheets/new/_dropdown.sass
+++ b/app/assets/stylesheets/new/_dropdown.sass
@@ -110,7 +110,7 @@
         display: grid
         cursor: pointer
         line-height: 3rem
-        padding: 0.5rem 4rem 0.5rem 2.5rem
+        padding: 0.5rem 2.5rem
         text-align: left
         text-decoration: none !important
         border: none     // <button>

--- a/app/assets/stylesheets/new/_salert.sass
+++ b/app/assets/stylesheets/new/_salert.sass
@@ -1,5 +1,9 @@
 // flash messages
-#flash
+//
+// One bottom-right column. The #flash list inside it is turbo-permanent so a morph cannot drop a
+// message mid-read, and a page's own standing warning (yield :flash_extra) joins the same column
+// rather than starting a second stack on top of it.
+.flash-stack
   position: fixed
   bottom: 1rem
   right: 1rem
@@ -13,6 +17,11 @@
   max-width: 100%
   width: max-content
 
+  // Only a wrapper for the permanence flag — its messages are what stack.
+  #flash
+    display: contents
+
+#flash
   &__message
     animation: flash-appear 0.3s ease-out both
 

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -33,6 +33,7 @@
     // is room, and a lone + on a second line reads as a control that lost its label.
     > .filters
         flex-wrap: nowrap
+        gap: 1rem
     &__sync
         display: flex
         align-items: center

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -143,13 +143,11 @@
         &--rules,&--tracker
             max-width: calc(100vw - 2rem)
             @media (min-width: 768px)
-                max-height: calc(100vh - 14rem)
                 max-width: calc(100vw - 11rem)
             
         table
             margin-bottom: 0
             border-collapse: collapse
-            border-top: 1rem solid var(--washed)
             border-bottom: 1.5rem solid var(--washed)
         thead
             position: sticky
@@ -176,7 +174,7 @@
             z-index: 1
             font-size: 1.5rem
             text-transform: uppercase
-            padding: 1.5rem 0 1rem  var(--ui-padding)
+            padding: 2.5rem 0 1rem  var(--ui-padding)
         td
             padding: 0.75rem 0 0.75rem var(--ui-padding)
         td, th

--- a/app/javascript/controllers/order_filter_controller.js
+++ b/app/javascript/controllers/order_filter_controller.js
@@ -43,9 +43,27 @@ export default class extends Controller {
   // Fired by the shared `segmented` control, which owns the chip and the pressed state. This
   // only decides what the list shows.
   filter(event) {
+    this.lockColumns()
     this.currentValue = event.detail.value
     this.updateVisibility()
     this.updateHeader()
+  }
+
+  // A shrink-to-fit table measures its columns from the rows that are VISIBLE, so every tab used to
+  // move every column. Pin the widths the unfiltered table asks for, the first time it is filtered:
+  // by then it is on screen with its fonts settled, and still showing everything it has. A table
+  // that swaps its own headers (columnHeader) has no one set of columns to pin, so it keeps
+  // measuring itself.
+  lockColumns() {
+    if (this.locked || this.hasColumnHeaderTarget) return
+    this.locked = true
+
+    const table = this.element.querySelector("table")
+    const headers = table?.tHead?.rows[0]?.cells
+    if (!headers) return
+
+    for (const th of headers) th.style.width = `${th.getBoundingClientRect().width}px`
+    table.style.tableLayout = "fixed"
   }
 
   updateVisibility() {

--- a/app/models/stock_trading_settings.rb
+++ b/app/models/stock_trading_settings.rb
@@ -15,11 +15,17 @@ class StockTradingSettings
     MarketDataSettings.deltabadger?
   end
 
-  # IBKR is hosted-only: its catalog is data-api served. There is no self-hosted
-  # source (IBKR has no list-all-instruments endpoint and no free market data),
-  # so without the data API the connect wizard is a dead end. Gate on the actual
-  # feed (env), not the selected provider — a hosted DB later run self-hosted
-  # carries a stale 'deltabadger' provider row.
+  # IBKR is hosted-only: its catalog is data-api served, so without the data API the
+  # connect wizard is a dead end. Gate on the actual feed (env), not the selected
+  # provider — a hosted DB later run self-hosted carries a stale 'deltabadger' row.
+  #
+  # The reason is MARKET DATA, not the catalog. IBKR does expose a list-all endpoint
+  # (/trsrv/all-conids?exchange=&assetClass=), so a container holding a user's session
+  # could in principle build its own catalog. What it cannot get is prices: IBKR
+  # publishes no free feed and no history, and snapshot quotes need a paid per-exchange
+  # subscription on that account. Unlike Alpaca, whose one key supplies catalog, prices
+  # and candles alike (see Exchanges::Alpaca), IBKR is a broker only — every price
+  # method on Exchanges::Ibkr is a stub deferring to the data-api feed.
   def self.ibkr_available?
     MarketDataSettings.deltabadger_available?
   end

--- a/app/views/bots/wizard/_assets_syncing.html.erb
+++ b/app/views/bots/wizard/_assets_syncing.html.erb
@@ -1,7 +1,16 @@
-<%# Friendly empty state for the buyable-asset step when a venue is chosen but
-    its asset catalog has not finished syncing yet (self-hosted Alpaca enqueues
-    the sync on key validation, so exchange-first can briefly reach an empty
-    list). Shown instead of a blank picker. %>
+<%# Friendly empty state for the buyable-asset step when a venue is chosen but its
+    asset catalog has not finished syncing yet. Shown instead of a blank picker.
+
+    Today this is only reachable from the Settings path: an admin connects the
+    Alpaca key, Exchange::SyncAlpacaAssetsJob runs (minutes on a full US catalog),
+    and a picker opened meanwhile finds no tickers. Key validation in the wizard
+    does NOT enqueue that sync — nothing does but settings_controller#update_stocks
+    and the weekly cron — and a venue with no tickers is absent from the exchange
+    picker anyway (Bot::AssetConfigurable#available_exchanges_for_current_settings),
+    so the wizard cannot currently reach a half-synced venue on its own.
+
+    Note this state does not refresh itself: it sits inside the asset-picker frame,
+    which reloads only when the search form submits. %>
 <div class="assets-syncing">
   <%= t('bot.setup.assets_syncing') %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,9 +29,12 @@
 
     <div data-tauri-drag-region class="titlebar-drag-region"></div>
 
-    <div id="flash" data-turbo-permanent>
-      <%= render 'layouts/flash' %>
-      <%= render 'layouts/flash_syncing' if AppConfig.setup_sync_in_progress? %>
+    <div class="flash-stack">
+      <div id="flash" data-turbo-permanent>
+        <%= render 'layouts/flash' %>
+        <%= render 'layouts/flash_syncing' if AppConfig.setup_sync_in_progress? %>
+      </div>
+      <%= yield :flash_extra %>
     </div>
 
     <%= render 'layouts/navbar' %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -26,7 +26,7 @@
           <%= yield %>
         </div>
       </div>
-      <div id="flash">
+      <div id="flash" class="flash-stack">
         <%= render 'layouts/flash' %>
       </div>
 

--- a/app/views/tracker/index.html.erb
+++ b/app/views/tracker/index.html.erb
@@ -5,7 +5,8 @@
 <%= turbo_stream_from "user_#{current_user.id}", :preferences %>
 <%= turbo_stream_from "user_#{current_user.id}", :tax_report %>
 <%= turbo_stream_from "user_#{current_user.id}", :sync %>
-<%= render 'sync_warning', exchanges: @sync_failures %>
+<%# A standing warning about the user's data, not a line of the page: it belongs in the flash column. %>
+<% content_for :flash_extra do %><%= render 'sync_warning', exchanges: @sync_failures %><% end %>
 <% if @pending_report %>
   <div data-controller="auto-download" data-auto-download-url-value="<%= download_tax_report_tracker_path(country: @pending_report[:country], year: @pending_report[:year], report_scope: @pending_report[:report_scope]) %>"></div>
 <% end %>


### PR DESCRIPTION
Follow-on to #238 — three unrelated things that were sitting in the same working
tree, one commit each.

## The tracker's tables and warnings hold still

Four things on the page moved when they should not have.

- A **sync warning** is a standing statement about the user's data, not a line of the
  page it happens to be rendered from. It joins the flash column through
  `yield :flash_extra`, and the layout now wraps that around the turbo-permanent
  `#flash` list so both stack in one place instead of starting a second pile on top
  of it.
- A **shrink-to-fit table measures its columns from the rows that are visible**, so
  every filter tab shifted every column. `order-filter` now pins the widths the
  unfiltered table asks for, the first time it is filtered — by then it is on screen
  with its fonts settled and still showing everything it has. A table that swaps its
  own headers has no one set of columns to pin, so it goes on measuring itself.
- The **figure grid's row divider** was painted from a repeating background sized to a
  guess at the row height. It is one gradient now, positioned at the height the cells
  themselves compute, so a single-row grid is not underlined by a bar that had nowhere
  to repeat to.
- The **table widget's own `max-height`** fought the page's scroll on the desktop — two
  scrollbars for one list. The header keeps its air through padding instead.

## Why a broker is hosted-only

Documentation and comments only; no behaviour change.

The README said nothing about what it takes to trade stocks, and the two comments that
explained it were wrong about the reason. Which broker a self-hosted container can use
follows from who supplies the tradeable symbol list and the prices for it: one Alpaca
key supplies catalog, quotes and candles alike, so stocks run on their own. IBKR is a
broker and nothing else — no free feed, no history, snapshot quotes behind a paid
per-exchange subscription tied to the account.

The old comment blamed a missing list-all-instruments endpoint. That endpoint exists
(`/trsrv/all-conids`); market data is the constraint, and a reason that is wrong invites
someone to "fix" it.

The wizard's syncing empty state claimed key validation enqueues the Alpaca catalog
sync. It does not — only the settings action and the weekly cron do, and a venue with no
tickers is filtered out of the exchange picker anyway.

## Even padding on a dropdown item

The 4rem right gutter was room for a trailing mark no item carries, so every label sat
off-centre in its own row. Applies to every dropdown.

## Tests

`bin/rails test` — 4368 runs, 0 failures. Rubocop clean.
