### PR TITLE
Value cash as cash, and match a bot order to its fill

### DIFF
--- a/app/services/account_balance/sync.rb
+++ b/app/services/account_balance/sync.rb
@@ -1,4 +1,7 @@
 class AccountBalance::Sync
+  # Cash, by the asset table's own reckoning. Everything else is something with a market price.
+  CASH_CATEGORIES = %w[Fiat Currency].freeze
+
   # Returned in Result::Success.data. Tells the caller which assets were synced
   # and whether pricing could be refreshed for any of them.
   Summary = Struct.new(:synced, :priced_fresh, :priced_stale, :unpriced, :pricing_error, keyword_init: true) do
@@ -25,6 +28,13 @@ class AccountBalance::Sync
 
     assets = assets_by_id.values
 
+    # Cash is not an asset to look up: a dollar is worth a dollar, and anything else converts. It
+    # is resolved FIRST and excluded from every feed below, because `usd` is also a CoinGecko coin
+    # id — a micro-cap token — and a cash balance priced through the market comes back worth a
+    # fraction of a cent, taking the account's whole value with it. Decided by CATEGORY, never by
+    # symbol: a security can be ticker'd USD and still be a security.
+    cash_prices = cash_prices_for(assets)
+
     # Ask the exchange for any USD prices it can quote directly (e.g. Alpaca
     # for stocks). Only the remaining external_ids round-trip through
     # MarketData, and the exchange's quotes win in the merge.
@@ -32,7 +42,7 @@ class AccountBalance::Sync
     override_prices = override_result.success? ? override_result.data : {}
     override_error  = override_result.failure? ? Array(override_result.errors).first.to_s : nil
 
-    remaining_ids = assets.map(&:external_id).compact - override_prices.keys
+    remaining_ids = assets.map(&:external_id).compact - override_prices.keys - cash_prices.keys
     if remaining_ids.any?
       market_result = MarketData.get_prices(coin_ids: remaining_ids, currency: 'usd')
       market_prices = market_result.success? ? market_result.data : {}
@@ -42,7 +52,7 @@ class AccountBalance::Sync
       market_error  = nil
     end
 
-    fresh_prices  = market_prices.merge(override_prices)
+    fresh_prices  = market_prices.merge(override_prices).merge(cash_prices)
     pricing_error = [override_error, market_error].compact.join('; ').presence
 
     synced_at = Time.current
@@ -98,5 +108,19 @@ class AccountBalance::Sync
                           unpriced: unpriced,
                           pricing_error: pricing_error
                         ))
+  end
+
+  private
+
+  # external_id => USD per unit, for the cash rows only. A currency we cannot get a rate for is
+  # left out rather than guessed at — the row then falls through to the stale/unpriced path like
+  # any other, which is what the tracker's `partial` flag exists to report.
+  def cash_prices_for(assets)
+    assets.select { |asset| CASH_CATEGORIES.include?(asset.category) }.filter_map do |asset|
+      next [asset.external_id, 1.to_d] if asset.symbol == 'USD'
+
+      rate = Utilities::Currency.exchange_rate(from: asset.symbol, to: 'USD')
+      [asset.external_id, rate.data.to_d] if rate.success?
+    end.to_h
   end
 end

--- a/app/services/account_transaction_sync.rb
+++ b/app/services/account_transaction_sync.rb
@@ -137,10 +137,19 @@ class AccountTransactionSync
     )
   end
 
+  # A bot order and a ledger row are the same event under two ids, and which id the row carries is
+  # the venue's choice. Binance names the trade after the order; Alpaca books one FILL activity per
+  # partial fill, ids it after the fill, and names the order beside it — so matching on `tx_id`
+  # alone left every Alpaca row unlinked, and the bot column empty for the whole history.
+  #
+  # `tx_id` first: it is the row's own identity, and a venue that uses the order id there means it.
+  # Several fills of one order all point at that order, which is what the reader wants to see.
   def match_bot_transaction!(at)
-    return unless at.tx_id.present?
+    ids = [at.tx_id, (at.raw_data['order_id'] if at.raw_data.is_a?(Hash))].compact_blank
+    return if ids.empty?
 
-    bot_tx = Transaction.find_by(external_id: at.tx_id, exchange: @exchange)
+    candidates = Transaction.where(external_id: ids, exchange: @exchange).index_by(&:external_id)
+    bot_tx = ids.filter_map { |id| candidates[id] }.first
     at.bot_transaction = bot_tx if bot_tx
   end
 end

--- a/db/migrate/20260824130000_link_stored_fills_to_bot_orders.rb
+++ b/db/migrate/20260824130000_link_stored_fills_to_bot_orders.rb
@@ -1,0 +1,25 @@
+class LinkStoredFillsToBotOrders < ActiveRecord::Migration[8.1]
+  # A bot order and a ledger row are the same event under two ids, and a fill-keyed venue names the
+  # order beside the row rather than in it. The matcher only ever ran on INSERT, and a re-sync skips
+  # a row it already has — so fixing the matcher reaches nothing already stored, and the bot column
+  # would stay empty for the whole history. Relink once, from the order id each fill has been
+  # carrying in `raw_data` all along.
+  #
+  # `update_columns`: this changes no figure, only what a row points at, and bumping `updated_at`
+  # would invalidate every cached tracker ledger for nothing.
+  def up
+    AccountTransaction.where(transaction_id: nil).find_each(batch_size: 500) do |account_transaction|
+      raw = account_transaction.raw_data
+      order_id = raw['order_id'] if raw.is_a?(Hash)
+      next if order_id.blank?
+
+      order = Transaction.find_by(external_id: order_id, exchange_id: account_transaction.exchange_id)
+      account_transaction.update_columns(transaction_id: order.id) if order
+    end
+  end
+
+  def down
+    # Not reversible in any useful sense: a link this made is indistinguishable from one the sync
+    # made, and dropping both would empty the column again.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_130000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/services/account_balance/sync_test.rb
+++ b/test/services/account_balance/sync_test.rb
@@ -36,6 +36,51 @@ class AccountBalance::SyncTest < ActiveSupport::TestCase
     assert_not_nil btc_bal.priced_at
   end
 
+  # A dollar is worth a dollar. `usd` is ALSO a CoinGecko coin id — a micro-cap token — so a cash
+  # balance looked up like any other asset came back at a fraction of a cent, and took the whole
+  # account's value down with it.
+  test 'cash is valued at its exchange rate, never through the market feed' do
+    usd = create(:asset, :usd)
+    @exchange.stubs(:get_balances).returns(Result::Success.new(
+                                             usd.id => { free: 84_914.to_d, locked: 0 },
+                                             @btc.id => { free: 1.to_d, locked: 0 }
+                                           ))
+    # The feed is asked about bitcoin and nothing else: a coin id that happens to spell a currency
+    # must never reach it.
+    MarketData.expects(:get_prices).with(coin_ids: ['bitcoin'], currency: 'usd')
+              .returns(Result::Success.new('bitcoin' => 50_000.0))
+
+    AccountBalance::Sync.new(@api_key).sync!
+
+    cash = AccountBalance.find_by(user: @user, asset: usd)
+    assert_equal 1.to_d, cash.usd_price
+    assert_equal 84_914.to_d, cash.usd_value
+    assert_not_nil cash.priced_at
+  end
+
+  test 'cash in another currency is valued at the day\'s rate' do
+    eur = create(:asset, :eur)
+    @exchange.stubs(:get_balances).returns(Result::Success.new(eur.id => { free: 1_000.to_d, locked: 0 }))
+    Utilities::Currency.stubs(:exchange_rate).with(from: 'EUR', to: 'USD').returns(Result::Success.new(1.1))
+    MarketData.expects(:get_prices).never
+
+    AccountBalance::Sync.new(@api_key).sync!
+
+    assert_equal 1_100.to_d, AccountBalance.find_by(user: @user, asset: eur).usd_value
+  end
+
+  # A ticker is not a category: ProShares Ultra Semiconductors trades as USD, and it is a security
+  # with a price like any other.
+  test 'a security that merely spells a currency is still priced by the market' do
+    usd_stock = create(:asset, symbol: 'USD', external_id: 'USD.US', category: 'Stock')
+    @exchange.stubs(:get_balances).returns(Result::Success.new(usd_stock.id => { free: 2.to_d, locked: 0 }))
+    MarketData.stubs(:get_prices).returns(Result::Success.new('USD.US' => 90.0))
+
+    AccountBalance::Sync.new(@api_key).sync!
+
+    assert_equal 180.to_d, AccountBalance.find_by(user: @user, asset: usd_stock).usd_value
+  end
+
   test 'reuses stored price as stale fallback when fresh pricing fails' do
     # Seed a previous successful sync
     @exchange.stubs(:get_balances).returns(Result::Success.new(

--- a/test/services/account_transaction_sync_test.rb
+++ b/test/services/account_transaction_sync_test.rb
@@ -216,6 +216,23 @@ class AccountTransactionSyncTest < ActiveSupport::TestCase
     assert_equal bot_tx, at.bot_transaction
   end
 
+  # A broker whose ledger is keyed by FILL is the normal case, not the exception: Alpaca's activity
+  # id (`20260821095224541::82693d41-…`) is not the order id the bot placed, so matching on tx_id
+  # alone left every single row unlinked. One order can fill many times, and each fill points at
+  # the order that made it.
+  test 'matches a bot order through the fill it produced' do
+    bot = create(:dca_single_asset, user: @user, exchange: @exchange, with_api_key: false)
+    bot_tx = create(:transaction, bot: bot, exchange: @exchange, external_id: 'order-7')
+    fills = [@ledger_entries.first.merge(tx_id: 'fill-a', raw_data: { 'order_id' => 'order-7' }),
+             @ledger_entries.first.merge(tx_id: 'fill-b', raw_data: { 'order_id' => 'order-7' })]
+    @exchange.stubs(:get_ledger).returns(Result::Success.new(fills))
+
+    AccountTransactionSync.new(@api_key).sync!
+
+    linked = %w[fill-a fill-b].map { |id| AccountTransaction.find_by(tx_id: id).bot_transaction }
+    assert_equal [bot_tx, bot_tx], linked
+  end
+
   test 'does not match non-trade entries to bot transactions' do
     bot = create(:dca_single_asset, user: @user, exchange: @exchange, with_api_key: false)
     create(:transaction, bot: bot, exchange: @exchange, external_id: 'deposit-1')


### PR DESCRIPTION
Two defects that predate the tracker redesign but that the redesign made visible —
one of them badly.

## Cash was valued as the coin that shares its name

A balance row is priced by looking its asset up through the market feed, keyed on
`external_id`. The dollar's `external_id` is `usd` — which is **also a CoinGecko coin
id**, belonging to a micro-cap token worth about a tenth of a cent. A cash balance
therefore came back valued at roughly a thousandth of its face:

```
USD  qty=84,914.03  usd_price=0.00114209  usd_value=96.98
```

Cash is usually the largest line in an account, so this took the whole portfolio's
value down with it. Nothing flagged it: the price was fresh, the sync reported success,
and the only way to notice was to have something to compare the total against.

That is exactly what the redesigned tracker now puts beside it — "total invested" — and
why the page read **−83 %** with holdings that were individually up.

Cash is now resolved before any feed is asked, and excluded from all of them. A dollar
is one dollar; another currency converts at its rate; a currency with no rate is left
unpriced rather than guessed at. The decision is by **category**, never by symbol — a
security can be ticker'd `USD` and still be a security, and the test pins that.

Stored rows heal on the next balance sync, which overwrites the price.

## A bot order and its fill never matched

`match_bot_transaction!` compared the ledger row's `tx_id` with the bot order's
`external_id`. Those are the same value on a venue that names a trade after the order.
A broker that books one activity per **partial fill** names the row after the fill
(`20260821095224541::82693d41-…`) and puts the order id beside it — so nothing matched,
and the Bot column was empty for every row of an account whose orders were all placed
by bots. Measured on a live ledger: 0 of 1303 rows linked, while `raw_data['order_id']`
matched a bot order on 463 of 483 sampled.

The matcher now tries the row's own id first — a venue that puts the order id there
means it — and the order id it names second. Several fills of one order all point at
that order.

Because the matcher only ever ran on INSERT and a re-sync skips a row it already has,
fixing it reaches nothing already stored; a migration relinks stored rows once. It uses
`update_columns` on purpose: this changes no figure, only what a row points at, and
every cached tracker ledger keys on `updated_at`.

## Tests

`bin/rails test` — 4372 runs, 0 failures. Rubocop clean. Four new tests: cash at face,
cash in another currency, a security that merely spells a currency, and a bot order
matched through its fills.
