### PR TITLE
Keep a request's time zone from following the request before it

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,14 @@
 class ApplicationController < ActionController::Base
   include SharedHelper
 
+  # Every request in the app zone, whatever the request before it left on this thread. `Time.zone`
+  # is thread-local and outlives the request that set it, so one caller's zone moved `Date.current`
+  # — and every zone-aware timestamp read back from the database — for everyone served by that
+  # thread afterwards. Declared first, so it wraps the rest of the chain. This is the guarantee
+  # ApplicationJob already gives the job side; views that want the user's zone ask for it
+  # explicitly (in_time_zone).
+  around_action { |_controller, action| Time.use_zone(Time.zone_default, &action) }
+
   before_action :redirect_to_setup_if_needed
   before_action :set_no_cache, if: :user_signed_in?
   around_action :switch_locale

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -113,10 +113,12 @@ module Tracker
 
       private
 
+      # `.utc`, because the timestamp is zone-aware: the same instant spells itself differently in
+      # every zone, and the reader (a request) is not guaranteed the zone the writer (a job) had.
       def cache_key(user, exchange)
         scope = transactions(user, exchange)
         "tracker_ledger_v2_#{user.id}_#{exchange&.id || 'all'}_" \
-          "#{scope.maximum(:updated_at)&.iso8601(6)}_#{scope.count}"
+          "#{scope.maximum(:updated_at)&.utc&.iso8601(6)}_#{scope.count}"
       end
 
       def transactions(user, exchange)

--- a/config/initializers/action_mcp_time_zone.rb
+++ b/config/initializers/action_mcp_time_zone.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# ActionMCP::Current sets Time.zone to the calling user's zone (ActionMCP::Current#user=) and never
+# puts it back. Current attributes are reset after every request; the thread-local zone is not one
+# of them, so on a single-threaded server the zone one MCP call left behind stayed on the thread
+# for every request after it. Reset it with the rest of the attributes.
+Rails.application.config.to_prepare do
+  ActionMCP::Current.resets { Time.zone = nil }
+end

--- a/test/controllers/request_time_zone_test.rb
+++ b/test/controllers/request_time_zone_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# `Time.zone` is thread-local and outlives the request that set it. ActionMCP sets it to the
+# calling user's zone (ActionMCP::Current#user=) and never puts it back, so one MCP call leaves
+# every later request on that thread reading the clock in a stranger's zone — permanently, on a
+# single-threaded server.
+#
+# Two things then go wrong, and both are covered here: a request's own `Date.current` moves, and
+# the tracker ledger's cache key — built from a zone-aware timestamp — stops matching the key the
+# warm-up job writes in the app zone, so the page never finds the ledger, enqueues the job again on
+# every load, and refreshes itself in a loop.
+class RequestTimeZoneTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  # +03:00, and one MCP call away from being this thread's zone.
+  ELSEWHERE = 'Tallinn'
+
+  setup do
+    create(:user, admin: true, setup_completed: true) # platform requires an admin to exist
+    @user = create(:user, setup_completed: true)
+    @api_key = create(:api_key, user: @user)
+    self.default_url_options = { locale: nil }
+    sign_in @user
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  teardown { Time.zone = Time.zone_default }
+
+  test 'a zone left on the thread does not follow the next request' do
+    # 01:00 the next day in Tallinn, still the 1st here.
+    travel_to Time.utc(2026, 8, 1, 22, 0) do
+      Time.zone = ELSEWHERE
+
+      get tracker_path
+
+      assert_response :success
+      assert_select 'input[name=?][value=?]', 'to', '2026-08-01'
+    end
+  end
+
+  test 'a ledger warmed by the job is found by a request on a thread left in another zone' do
+    create(:account_transaction, api_key: @api_key, transacted_at: Time.utc(2026, 8, 1, 12))
+    Tracker::LedgerJob.perform_now(@user.id)
+    Time.zone = ELSEWHERE
+
+    with_test_adapter do
+      assert_no_enqueued_jobs only: Tracker::LedgerJob do
+        get tracker_path
+      end
+    end
+
+    assert_response :success
+  end
+
+  private
+
+  # The suite runs on the Solid Queue adapter, which has nothing to assert against.
+  def with_test_adapter
+    base_adapter = ActiveJob::Base.queue_adapter
+    job_adapter = Tracker::LedgerJob.queue_adapter
+    test_adapter = ActiveJob::QueueAdapters::TestAdapter.new
+    ActiveJob::Base.queue_adapter = test_adapter
+    Tracker::LedgerJob.queue_adapter = test_adapter
+    yield
+  ensure
+    Tracker::LedgerJob.queue_adapter = job_adapter
+    ActiveJob::Base.queue_adapter = base_adapter
+  end
+end

--- a/test/mcp/current_time_zone_test.rb
+++ b/test/mcp/current_time_zone_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+# ActionMCP::Current sets Time.zone to the calling user's zone. Current attributes are reset after
+# every request — the thread-local zone has to go back with them, or it stays on the thread and
+# every request served by it afterwards reads the clock in a stranger's zone.
+class MCPCurrentTimeZoneTest < ActiveSupport::TestCase
+  teardown do
+    ActionMCP::Current.reset
+    Time.zone = Time.zone_default
+  end
+
+  test 'resetting the MCP request context puts the zone back' do
+    ActionMCP::Current.user = create(:user, time_zone: 'Tallinn')
+
+    assert_equal 'Tallinn', Time.zone.name, 'guard: the gem is still setting the zone from the user'
+
+    ActionMCP::Current.reset
+
+    assert_equal Time.zone_default, Time.zone
+  end
+end

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -26,6 +26,16 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
     HistoricalPrice.create!(asset: symbol, currency: 'USD', date: @day.call(day).to_date, price: usd)
   end
 
+  test 'a ledger warmed in the app zone is found from any other' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 20_000)
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+
+    Tracker::Ledger.compute!(@user)
+
+    assert_not_nil Time.use_zone('Tallinn') { Tracker::Ledger.cached(@user) },
+                   'the cache key must not move with the zone of whoever asks'
+  end
+
   test 'partial sell: FIFO remaining lots make the open position, realised is proceeds minus FIFO cost and fee' do
     tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 20_000)
     tx(:buy, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 30_000)


### PR DESCRIPTION
`Time.zone` is thread-local and outlives the request that sets it. `ActionMCP::Current#user=`
assigns the calling user's zone and never restores it, and current attributes are reset after every
request while the zone is not. On a single-threaded server that means one MCP call pins a zone on
the thread for every request served afterwards — `Date.current` moves, and so does every zone-aware
timestamp read back from the database.

The portfolio page is where it became visible. Its ledger cache key is built from the newest
transaction's `updated_at`, and the same instant spells itself differently in every zone. The key is
written by a background job (which normalises the zone) and read by a request (which had not), so
after an MCP call the page could no longer find the ledger it had just warmed: the figure tiles
stayed in their loading state, the warm-up job was enqueued again on every load, and each run
broadcast a refresh that reloaded the page a few seconds later — a loop that also closed any dialog
open at the time.

## Changes

- `ActionMCP::Current` now resets the zone along with the rest of its attributes, so the borrowed
  zone goes back at the end of the request that borrowed it.
- `ApplicationController` runs every action inside `Time.use_zone(Time.zone_default)` — the
  guarantee `ApplicationJob` already gives the job side. Views that want the user's zone keep
  asking for it explicitly with `in_time_zone`.
- The ledger cache key converts the timestamp to UTC before formatting it, so the key cannot depend
  on the zone of whoever computes it. `BotActivityFeed` already spells its cursor this way.

## Tests

- an MCP request context puts the zone back when it is reset
- a zone left on the thread does not follow the next request (its `Date.current` stays put)
- a ledger warmed by the job is found by a request whose thread was left in another zone, and no
  warm-up job is enqueued

Each fails without its change. Full suite: 4376 runs, 0 failures.
