### PR TITLE
Count the money a venue never reported receiving

### DIFF
--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -46,6 +46,7 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # at the end of it are valued.
   def sweep(first_date)
     balances = Hash.new(0.to_d)
+    unfunded = Tracker::UnfundedCash.new
     invested = 0.to_d
     # An unpriced deposit or withdrawal leaves the money-in figure wrong from that day on, not just
     # on the day itself.
@@ -58,6 +59,11 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
         apply(balances, transaction)
         delta = contribution(transaction)
         delta.nil? ? invested_incomplete = true : invested += delta
+      end
+      # Once the whole day is applied: a fee that its own sale pays for, booked an hour earlier, is
+      # not an account that could not cover it.
+      unfunded_on(balances, unfunded, date).each do |value|
+        value.nil? ? invested_incomplete = true : invested += value
       end
       value, unpriced = value_on(balances, date)
       { user_id: @user.id, date: date, value_usd: value, invested_usd: invested,
@@ -107,9 +113,19 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   def consume_fee(balances, transaction)
     fee = transaction.fee_amount.to_d
     return unless fee.positive? && transaction.fee_currency.present?
-    return if transaction.fee_currency == transaction.base_currency
+    return if transaction.fee_currency == transaction.base_currency && !cash_leg?(transaction)
 
     balances[transaction.fee_currency] -= fee
+  end
+
+  # A venue that books each leg of a trade as its own row charges the fee on the cash leg, on top of
+  # the amount it reports: the "already net" rule above is about the asset being sold, and cash is
+  # not being sold — it is paying. Reading it the other way leaves the account holding money it has
+  # already spent, and disagreeing with the ledger about how much came in to spend it.
+  def cash_leg?(transaction)
+    return false if ACQUISITIONS.include?(transaction.entry_type.to_sym)
+
+    FIAT.include?(transaction.base_currency) || STABLECOINS.include?(transaction.base_currency)
   end
 
   # The cash side of a single-row trade. Kraken books each leg as its own row with no quote, so
@@ -147,6 +163,18 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
 
     price = @prices.dig(symbol, date)
     price && (direction * amount * price)
+  end
+
+  # Cash the ledger spent without ever seeing it arrive, valued on the day the deficit deepens: the
+  # coins were bought with money whatever the venue reported. nil for a fiat deficit with no rate
+  # that day — the figure cannot be stated, so the row says so.
+  def unfunded_on(balances, unfunded, date)
+    balances.each_with_object([]) do |(symbol, balance), values|
+      shortfall = unfunded.shortfall(symbol, balance)
+      next if shortfall.zero?
+
+      values << (STABLECOINS.include?(symbol) ? shortfall : fiat_value(symbol, shortfall, date))
+    end
   end
 
   # A negative balance is history we do not have — an exchange whose ledger window starts after the

--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -46,7 +46,6 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # at the end of it are valued.
   def sweep(first_date)
     balances = Hash.new(0.to_d)
-    unfunded = Tracker::UnfundedCash.new
     invested = 0.to_d
     # An unpriced deposit or withdrawal leaves the money-in figure wrong from that day on, not just
     # on the day itself.
@@ -62,7 +61,7 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
       end
       # Once the whole day is applied: a fee that its own sale pays for, booked an hour earlier, is
       # not an account that could not cover it.
-      unfunded_on(balances, unfunded, date).each do |value|
+      unfunded_on(balances, date).each do |value|
         value.nil? ? invested_incomplete = true : invested += value
       end
       value, unpriced = value_on(balances, date)
@@ -123,9 +122,9 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # not being sold — it is paying. Reading it the other way leaves the account holding money it has
   # already spent, and disagreeing with the ledger about how much came in to spend it.
   def cash_leg?(transaction)
-    return false if ACQUISITIONS.include?(transaction.entry_type.to_sym)
+    return false unless Tracker::UnfundedCash::FEE_ON_TOP.include?(transaction.entry_type.to_s)
 
-    FIAT.include?(transaction.base_currency) || STABLECOINS.include?(transaction.base_currency)
+    Tracker::UnfundedCash.cash?(transaction.base_currency)
   end
 
   # The cash side of a single-row trade. Kraken books each leg as its own row with no quote, so
@@ -168,11 +167,14 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # Cash the ledger spent without ever seeing it arrive, valued on the day the deficit deepens: the
   # coins were bought with money whatever the venue reported. nil for a fiat deficit with no rate
   # that day — the figure cannot be stated, so the row says so.
-  def unfunded_on(balances, unfunded, date)
+  def unfunded_on(balances, date)
     balances.each_with_object([]) do |(symbol, balance), values|
-      shortfall = unfunded.shortfall(symbol, balance)
+      shortfall = Tracker::UnfundedCash.shortfall(symbol, balance)
       next if shortfall.zero?
 
+      # Added back, not just booked: the account really did hold that cash, and a sale that returns
+      # it later must land on a balance of zero rather than pay off a debt that was never owed.
+      balances[symbol] += shortfall
       values << (STABLECOINS.include?(symbol) ? shortfall : fiat_value(symbol, shortfall, date))
     end
   end

--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -123,6 +123,7 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # already spent, and disagreeing with the ledger about how much came in to spend it.
   def cash_leg?(transaction)
     return false unless Tracker::UnfundedCash::FEE_ON_TOP.include?(transaction.entry_type.to_s)
+    return false if transaction.quote_currency.present? # a trade with its own quote reports it net
 
     Tracker::UnfundedCash.cash?(transaction.base_currency)
   end
@@ -169,6 +170,8 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # that day — the figure cannot be stated, so the row says so.
   def unfunded_on(balances, date)
     balances.each_with_object([]) do |(symbol, balance), values|
+      next if borrowable_currencies.include?(symbol)
+
       shortfall = Tracker::UnfundedCash.shortfall(symbol, balance)
       next if shortfall.zero?
 
@@ -177,6 +180,14 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
       balances[symbol] += shortfall
       values << (STABLECOINS.include?(symbol) ? shortfall : fiat_value(symbol, shortfall, date))
     end
+  end
+
+  # The currencies a venue that lends settles in: at a broker, settled cash below zero is borrowed
+  # rather than missing, and the two cannot be told apart from a balance.
+  def borrowable_currencies
+    @borrowable_currencies ||= @transactions.select { |t| Tracker::UnfundedCash.lends_cash?(t.exchange.name_id) }
+                                            .flat_map { |t| [t.base_currency, t.quote_currency, t.fee_currency] }
+                                            .compact.select { |c| Tracker::UnfundedCash.cash?(c) }.to_set
   end
 
   # A negative balance is history we do not have — an exchange whose ledger window starts after the

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -158,12 +158,11 @@ module Tracker
       # return on nothing is not a number anyone can read. `UnfundedCash` books only what deepens
       # the deficit, so a venue that does report its funding is untouched.
       def contributions(rows, price_service)
-        unfunded = UnfundedCash.new
         cash = Hash.new(0.to_d)
         rows.group_by { |row| row[:transacted_at].to_date }.sum(0.to_d) do |_date, day|
           day.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
           day.sum(0.to_d) { |row| contribution(row, price_service) } +
-            unfunded_contribution(cash, unfunded, day.last, price_service)
+            unfunded_contribution(cash, day.last, price_service)
         end
       end
 
@@ -171,10 +170,12 @@ module Tracker
       # order nobody controls — a venue that books a sale's fee on the crypto leg and its proceeds
       # on the fiat leg would otherwise look, for the width of one row, like an account that could
       # not pay its own fee.
-      def unfunded_contribution(cash, unfunded, row, price_service)
+      def unfunded_contribution(cash, row, price_service)
         cash.sum(0.to_d) do |currency, balance|
-          shortfall = unfunded.shortfall(currency, balance)
+          shortfall = UnfundedCash.shortfall(currency, balance)
           next 0.to_d if shortfall.zero?
+
+          cash[currency] += shortfall
           next shortfall if STABLECOINS.include?(currency)
 
           price_service.convert_fiat(amount: shortfall, from: currency, to: 'USD',
@@ -199,10 +200,12 @@ module Tracker
           moves << [row[:base_currency], -row[:transfer_fee_amount].to_d] if type == 'withdrawal'
         elsif CASH_IN.include?(type) || CASH_OUT.include?(type)
           amount = row[:base_amount].to_d
-          # A fee taken in the asset being acquired only shrinks what arrived; taken in the cash the
-          # trade spends it leaves on top of it. The "sales are already net" rule is about the asset
-          # being sold, not about the cash paying for it.
-          amount += CASH_IN.include?(type) ? -fee : fee if row[:fee_currency] == row[:base_currency]
+          # A fee taken in the asset being acquired only shrinks what arrived; taken in the cash a
+          # trade spends, it leaves on top of what the row reports.
+          if row[:fee_currency] == row[:base_currency]
+            amount -= fee if CASH_IN.include?(type)
+            amount += fee if UnfundedCash::FEE_ON_TOP.include?(type)
+          end
           moves << [row[:base_currency], CASH_IN.include?(type) ? amount : -amount]
         end
         moves.select { |currency, amount| UnfundedCash.cash?(currency) && !amount.zero? }

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -21,6 +21,10 @@ module Tracker
     CACHE_TTL = 30.days
     FIAT = Tax::PriceService::FIAT_CURRENCIES
     STABLECOINS = Tax::PriceService::STABLECOINS
+    # What a row does to the balance of its base asset, for the entry types that touch it at all.
+    CASH_IN = %w[buy swap_in staking_reward lending_interest airdrop mining other_income deposit
+                 adjustment].freeze
+    CASH_OUT = %w[sell swap_out withdrawal fee lost withholding_tax].freeze
 
     # FIFO with the two things the tracker needs and a tax report does not.
     #
@@ -117,7 +121,7 @@ module Tracker
       # every zone, and the reader (a request) is not guaranteed the zone the writer (a job) had.
       def cache_key(user, exchange)
         scope = transactions(user, exchange)
-        "tracker_ledger_v2_#{user.id}_#{exchange&.id || 'all'}_" \
+        "tracker_ledger_v3_#{user.id}_#{exchange&.id || 'all'}_" \
           "#{scope.maximum(:updated_at)&.utc&.iso8601(6)}_#{scope.count}"
       end
 
@@ -143,11 +147,73 @@ module Tracker
         rows.reject { |row| FIAT.include?(row[:base_currency]) }
       end
 
-      # Money in from OUTSIDE. Buys, sells and swaps move nothing: they rearrange what is already
-      # here. A linked transfer cancels itself. Everything else is a deposit or a withdrawal, valued
-      # on the day it moved.
+      # Money in from OUTSIDE, of two kinds.
+      #
+      # What the venue reported: a deposit or a withdrawal, valued on the day it moved. Buys, sells
+      # and swaps move nothing — they rearrange what is already here — and a linked transfer cancels
+      # itself.
+      #
+      # And what it did not: cash spent that was never seen arriving. A venue that reports trades
+      # but not the transfer behind them would otherwise show a portfolio bought for nothing, and a
+      # return on nothing is not a number anyone can read. `UnfundedCash` books only what deepens
+      # the deficit, so a venue that does report its funding is untouched.
       def contributions(rows, price_service)
-        rows.sum(0.to_d) { |row| contribution(row, price_service) }
+        unfunded = UnfundedCash.new
+        cash = Hash.new(0.to_d)
+        rows.group_by { |row| row[:transacted_at].to_date }.sum(0.to_d) do |_date, day|
+          day.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
+          day.sum(0.to_d) { |row| contribution(row, price_service) } +
+            unfunded_contribution(cash, unfunded, day.last, price_service)
+        end
+      end
+
+      # A DAY at a time, never a row: one exchange event reaches the ledger as several rows, in an
+      # order nobody controls — a venue that books a sale's fee on the crypto leg and its proceeds
+      # on the fiat leg would otherwise look, for the width of one row, like an account that could
+      # not pay its own fee.
+      def unfunded_contribution(cash, unfunded, row, price_service)
+        cash.sum(0.to_d) do |currency, balance|
+          shortfall = unfunded.shortfall(currency, balance)
+          next 0.to_d if shortfall.zero?
+          next shortfall if STABLECOINS.include?(currency)
+
+          price_service.convert_fiat(amount: shortfall, from: currency, to: 'USD',
+                                     timestamp: row[:transacted_at])
+        end
+      end
+
+      # The cash one row moves, which is all a shortfall can be read from: the base leg when the
+      # base is itself cash (bank funding, a broker's dollar fee, a venue that books each leg of a
+      # trade as its own row), the quote leg of a single-row trade, and a fee charged in anything
+      # other than the base. The same moves PortfolioSnapshot's sweep applies to its balances.
+      def cash_moves(row)
+        type = row[:entry_type].to_s
+        fee = row[:fee_amount].to_d
+        moves = []
+        moves << [row[:fee_currency], -fee] if fee.positive? && row[:fee_currency] != row[:base_currency]
+        moves << [row[:quote_currency], quote_direction(type) * row[:quote_amount].to_d] if row[:quote_amount]
+        if row[:linked]
+          # The user's own transfer: the coins never left the tracked universe, so only the network
+          # fee is really gone. Scoped to one venue the rows arrive flattened and this never fires —
+          # there, the far leg is out of scope and the move is real.
+          moves << [row[:base_currency], -row[:transfer_fee_amount].to_d] if type == 'withdrawal'
+        elsif CASH_IN.include?(type) || CASH_OUT.include?(type)
+          amount = row[:base_amount].to_d
+          # A fee taken in the asset being acquired only shrinks what arrived; taken in the cash the
+          # trade spends it leaves on top of it. The "sales are already net" rule is about the asset
+          # being sold, not about the cash paying for it.
+          amount += CASH_IN.include?(type) ? -fee : fee if row[:fee_currency] == row[:base_currency]
+          moves << [row[:base_currency], CASH_IN.include?(type) ? amount : -amount]
+        end
+        moves.select { |currency, amount| UnfundedCash.cash?(currency) && !amount.zero? }
+      end
+
+      def quote_direction(type)
+        case type
+        when 'buy' then -1
+        when 'sell', 'return_of_capital' then 1
+        else 0
+        end
       end
 
       def contribution(row, price_service)

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -159,19 +159,29 @@ module Tracker
       # the deficit, so a venue that does report its funding is untouched.
       def contributions(rows, price_service)
         cash = Hash.new(0.to_d)
+        borrowable = borrowable_currencies(rows)
         rows.group_by { |row| row[:transacted_at].to_date }.sum(0.to_d) do |_date, day|
           day.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
           day.sum(0.to_d) { |row| contribution(row, price_service) } +
-            unfunded_contribution(cash, day.last, price_service)
+            unfunded_contribution(cash, borrowable, day.last, price_service)
         end
+      end
+
+      # The currencies a venue that lends settles in. Their deficits cannot be told apart from
+      # borrowing, so they are read as reported and nothing is inferred from them.
+      def borrowable_currencies(rows)
+        rows.select { |row| UnfundedCash.lends_cash?(row[:exchange]) }
+            .flat_map { |row| cash_moves(row).map(&:first) }.to_set
       end
 
       # A DAY at a time, never a row: one exchange event reaches the ledger as several rows, in an
       # order nobody controls — a venue that books a sale's fee on the crypto leg and its proceeds
       # on the fiat leg would otherwise look, for the width of one row, like an account that could
       # not pay its own fee.
-      def unfunded_contribution(cash, row, price_service)
+      def unfunded_contribution(cash, borrowable, row, price_service)
         cash.sum(0.to_d) do |currency, balance|
+          next 0.to_d if borrowable.include?(currency)
+
           shortfall = UnfundedCash.shortfall(currency, balance)
           next 0.to_d if shortfall.zero?
 
@@ -203,8 +213,12 @@ module Tracker
           # A fee taken in the asset being acquired only shrinks what arrived; taken in the cash a
           # trade spends, it leaves on top of what the row reports.
           if row[:fee_currency] == row[:base_currency]
-            amount -= fee if CASH_IN.include?(type)
-            amount += fee if UnfundedCash::FEE_ON_TOP.include?(type)
+            # Clamped, as the sweep clamps it: a fee larger than what arrived leaves nothing, it
+            # does not leave a hole for the inference to read as borrowed money.
+            amount = [amount - fee, 0.to_d].max if CASH_IN.include?(type)
+            # And on top only where the row is a settlement leg of its own — a trade that carries
+            # its own quote reports its base net, fee included.
+            amount += fee if UnfundedCash::FEE_ON_TOP.include?(type) && row[:quote_amount].blank?
           end
           moves << [row[:base_currency], CASH_IN.include?(type) ? amount : -amount]
         end

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -1,0 +1,36 @@
+module Tracker
+  # The money a ledger spends but never saw arrive.
+  #
+  # An exchange that reports trades but not the transfer that paid for them leaves a cash balance in
+  # deficit: coins bought with money that, as far as the record goes, never existed. The deepest
+  # deficit a currency reaches is the least outside money consistent with that record, so every new
+  # low is money in, on the day it is reached. A deposit that later covers the deficit lifts the
+  # balance without setting a new low — which is what keeps a venue that DOES report its funding
+  # untouched, and a late-arriving deposit from being counted twice.
+  #
+  # Cash only. A crypto balance in deficit is a missing acquisition rather than missing funding, and
+  # what those coins cost is not a question a balance can answer: the day stays `partial` instead.
+  class UnfundedCash
+    FIAT = Tax::PriceService::FIAT_CURRENCIES
+    STABLECOINS = Tax::PriceService::STABLECOINS
+
+    def self.cash?(currency)
+      FIAT.include?(currency) || STABLECOINS.include?(currency)
+    end
+
+    def initialize
+      @lows = Hash.new(0.to_d)
+    end
+
+    # What this balance needs from outside beyond everything already needed, in the currency's own
+    # units. Zero unless the balance is a new low — everything above one has already been paid for.
+    def shortfall(currency, balance)
+      return 0.to_d unless self.class.cash?(currency)
+      return 0.to_d unless balance < @lows[currency]
+
+      deepened = @lows[currency] - balance
+      @lows[currency] = balance
+      deepened
+    end
+  end
+end

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -2,35 +2,36 @@ module Tracker
   # The money a ledger spends but never saw arrive.
   #
   # An exchange that reports trades but not the transfer that paid for them leaves a cash balance in
-  # deficit: coins bought with money that, as far as the record goes, never existed. The deepest
-  # deficit a currency reaches is the least outside money consistent with that record, so every new
-  # low is money in, on the day it is reached. A deposit that later covers the deficit lifts the
-  # balance without setting a new low — which is what keeps a venue that DOES report its funding
-  # untouched, and a late-arriving deposit from being counted twice.
+  # deficit: coins bought with money that, as far as the record goes, never existed. A deficit is
+  # therefore money from outside, booked on the day it appears — and the caller adds it back, so the
+  # account carries on from zero. That second half matters as much as the first: the inferred
+  # funding is cash that really was there, and a sale that returns it must not be swallowed paying
+  # off a debt the account never had.
+  #
+  # A venue that DOES report its funding never goes into deficit, so nothing here touches it, and a
+  # deposit that arrives after the trades it paid for is booked once — as the deposit it is.
   #
   # Cash only. A crypto balance in deficit is a missing acquisition rather than missing funding, and
   # what those coins cost is not a question a balance can answer: the day stays `partial` instead.
-  class UnfundedCash
+  module UnfundedCash
     FIAT = Tax::PriceService::FIAT_CURRENCIES
     STABLECOINS = Tax::PriceService::STABLECOINS
+    # Where a fee charged in the cash of the row it sits on is charged ON TOP of the amount that row
+    # reports. The rule elsewhere — that a fee in the asset being sold is already netted out — is
+    # about the asset being sold; cash is not being sold, it is paying. Acquisitions net their own
+    # fee out of what arrived, and a linked withdrawal's fee is the difference between its legs.
+    FEE_ON_TOP = %w[sell swap_out].freeze
 
     def self.cash?(currency)
       FIAT.include?(currency) || STABLECOINS.include?(currency)
     end
 
-    def initialize
-      @lows = Hash.new(0.to_d)
-    end
+    # What this balance needs from outside, in the currency's own units. The caller books it as money
+    # in AND adds it to the balance.
+    def self.shortfall(currency, balance)
+      return 0.to_d unless cash?(currency) && balance.negative?
 
-    # What this balance needs from outside beyond everything already needed, in the currency's own
-    # units. Zero unless the balance is a new low — everything above one has already been paid for.
-    def shortfall(currency, balance)
-      return 0.to_d unless self.class.cash?(currency)
-      return 0.to_d unless balance < @lows[currency]
-
-      deepened = @lows[currency] - balance
-      @lows[currency] = balance
-      deepened
+      -balance
     end
   end
 end

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -21,6 +21,15 @@ module Tracker
     # about the asset being sold; cash is not being sold, it is paying. Acquisitions net their own
     # fee out of what arrived, and a linked withdrawal's fee is the difference between its legs.
     FEE_ON_TOP = %w[sell swap_out].freeze
+    # Venues whose settled cash runs below zero by design. A deficit there is borrowed — a margin
+    # buy is not a transfer the venue forgot to mention — so the currencies they settle in are left
+    # out of the inference entirely. Spot crypto venues cannot lend, which is where the missing
+    # history actually is. Extend this list when a venue that lends is added.
+    LENDS_CASH = %w[alpaca ibkr].freeze
+
+    def self.lends_cash?(exchange)
+      LENDS_CASH.include?(exchange.to_s)
+    end
 
     def self.cash?(currency)
       FIAT.include?(currency) || STABLECOINS.include?(currency)

--- a/db/migrate/20260824140000_rebuild_portfolio_snapshots_for_unfunded_cash.rb
+++ b/db/migrate/20260824140000_rebuild_portfolio_snapshots_for_unfunded_cash.rb
@@ -1,0 +1,13 @@
+# The invested figure on a snapshot now includes the cash a venue spent without ever reporting where
+# it came from, and a row already written cannot know that. Snapshots are derived from the ledger
+# and the price table, so the cheapest correct migration is to drop them: the tracker rebuilds the
+# history it finds missing the next time the page is opened.
+class RebuildPortfolioSnapshotsForUnfundedCash < ActiveRecord::Migration[8.1]
+  def up
+    execute 'DELETE FROM portfolio_snapshots'
+  end
+
+  def down
+    # Nothing to restore: the rows are derived, and the sweep writes them again.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_140000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -66,7 +66,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select '.data-grid__item .label', text: I18n.t('bot.details.stats.portfolio_value')
     assert_select '.data-grid__item .label', text: I18n.t('bot.dca_index.realised_pnl')
     assert_select '.data-grid__item .label', text: I18n.t('tracker.fees_paid')
-    assert_select '.data-grid__item__value', text: /\$29,000\.00/ # 30,000 in − 1,000 out
+    assert_select '.data-grid__item__value', text: /\$33,020\.00/ # 30,000 in − 1,000 out + the 4,020 the venues spent without reporting its arrival
     assert_select '.data-grid__item__value', text: /\$80,000\.00/
     assert_select '.data-grid__item__value.text-success', text: /1,000\.00/ # the ETH round-trip
     assert_select '.data-grid__item__value', text: /\$20\.00/
@@ -232,7 +232,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select 'tr.tracker-row td', text: 'ETH', count: 0
     assert_select '.tracker-positions tbody tr', 1
     assert_select '.data-grid__item__value', text: /\$80,000\.00/, count: 1 # whole portfolio, still
-    assert_select '.data-grid__item__value', text: /\$29,000\.00/, count: 1
+    assert_select '.data-grid__item__value', text: /\$33,020\.00/, count: 1
   end
 
   test 'a cold exchange-scoped ledger warms its own key' do
@@ -256,7 +256,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select '.tracker-positions td', text: /\$/, count: 0
     assert_select '.tracker-positions td.text-success', text: /\+25\.0%/, count: 1
     # The figures this page would otherwise print, in every form they could take.
-    assert_no_match(/80,000|60,000|29,000|30,020|20,013|20\.00 USD|4,000\.00|5,000\.00|1,000\.00/, response.body)
+    assert_no_match(/80,000|60,000|33,020|30,020|20,013|20\.00 USD|4,000\.00|5,000\.00|1,000\.00/, response.body)
   end
 
   # ── 10 · display currency ────────────────────────────────────────────────────────────────────

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -113,6 +113,23 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
     assert_equal [1_000.to_d] * 2, rows.map(&:invested_usd)
   end
 
+  test 'a broker that lends is short because it lent: the sweep infers nothing from it' do
+    alpaca = create(:alpaca_exchange)
+    alpaca_key = create(:api_key, user: @user, exchange: alpaca)
+    create(:asset, symbol: 'QQQM', external_id: 'QQQM.US', category: 'ETF')
+    create(:account_transaction, api_key: alpaca_key, entry_type: :deposit, base_currency: 'USD',
+                                 base_amount: 10_000, quote_currency: nil, quote_amount: nil,
+                                 transacted_at: @day.call(1))
+    create(:account_transaction, api_key: alpaca_key, entry_type: :buy, base_currency: 'QQQM', base_amount: 10,
+                                 quote_currency: 'USD', quote_amount: 20_000, transacted_at: @day.call(2))
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(4)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    assert_equal [10_000.to_d] * 3, PortfolioSnapshot.for_user(@user).order(:date).pluck(:invested_usd),
+                 'the margin loan that bought the rest is not money the user put in'
+  end
+
   test 'a symbol with no price at all makes its days partial, never a zero-valued holding' do
     seed_ledger
     seed_prices

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -88,6 +88,31 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
                  'the chart and the tile read the same ledger and must not disagree about it'
   end
 
+  test 'inferred funding is cash that is really there: selling it back reads as a gain' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 20_000)
+    tx(:sell, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 30_000)
+    (1..3).each { |n| price('BTC', n, 25_000) }
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(4)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    rows = PortfolioSnapshot.for_user(@user).order(:date).to_a
+    assert_equal [25_000, 30_000, 30_000].map(&:to_d), rows.map(&:value_usd),
+                 'the dollars the sale returns are not swallowed by the deficit the buy left behind'
+    assert_equal [20_000.to_d] * 3, rows.map(&:invested_usd)
+  end
+
+  test 'a fee inside a cash deposit leaves the account once' do
+    tx(:deposit, day: 1, base_currency: 'USD', base_amount: 1_000, fee_amount: 10, fee_currency: 'USD')
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(3)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    rows = PortfolioSnapshot.for_user(@user).order(:date).to_a
+    assert_equal [990.to_d] * 2, rows.map(&:value_usd), '1,000 arrived less the 10 it cost to arrive'
+    assert_equal [1_000.to_d] * 2, rows.map(&:invested_usd)
+  end
+
   test 'a symbol with no price at all makes its days partial, never a zero-valued holding' do
     seed_ledger
     seed_prices

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -60,6 +60,34 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
     assert rows.none?(&:partial)
   end
 
+  test 'cash the ledger never saw arrive is money in, on the day it was spent' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 10_000)
+    (1..3).each { |n| price('BTC', n, 10_000) }
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(4)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    rows = PortfolioSnapshot.for_user(@user).order(:date).to_a
+    assert_equal [10_000.to_d] * 3, rows.map(&:invested_usd),
+                 'the coins were bought with money, whatever the venue chose to report'
+  end
+
+  test 'a venue that books the cash leg as its own row: the sweep and the ledger agree on money in' do
+    FxRate.create!(currency: 'USD', date: @d0 + 1, rate: 1) # 1 EUR = 1 USD
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: nil, quote_amount: nil, group_id: 'trade-1')
+    tx(:sell, day: 1, base_currency: 'EUR', base_amount: 10_000, quote_currency: nil, quote_amount: nil,
+              fee_amount: 26, fee_currency: 'EUR', group_id: 'trade-1')
+    price('BTC', 1, 10_000)
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(2)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    assert_equal 10_026.to_d, PortfolioSnapshot.for_user(@user).order(:date).last.invested_usd,
+                 'the fee left the account on top of the 10,000 the venue reported spending'
+    assert_equal 10_026.to_d, Tracker::Ledger.for(@user).total_invested_usd,
+                 'the chart and the tile read the same ledger and must not disagree about it'
+  end
+
   test 'a symbol with no price at all makes its days partial, never a zero-valued holding' do
     seed_ledger
     seed_prices

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -26,6 +26,57 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
     HistoricalPrice.create!(asset: symbol, currency: 'USD', date: @day.call(day).to_date, price: usd)
   end
 
+  test 'cash spent that the ledger never saw arrive is money in' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd,
+                 'the venue reported the trade and not the transfer that paid for it'
+  end
+
+  test 'a deposit that covers an earlier deficit is not counted twice' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+    tx(:deposit, day: 2, base_currency: 'USDC', base_amount: 20_000)
+    tx(:buy, day: 3, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 40_000.to_d, summary.total_invested_usd,
+                 'the second buy spends the deposit; only the first one needed money from nowhere'
+  end
+
+  test 'a linked cash transfer is not money from outside' do
+    deposit = tx(:deposit, key: @key_kraken, day: 2, base_currency: 'USDC', base_amount: 1_000)
+    tx(:withdrawal, day: 1, base_currency: 'USDC', base_amount: 1_000, linked_transaction: deposit)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 0.to_d, summary.total_invested_usd,
+                 'the cash moved between the user\'s own venues — spending it is what would show where it came from'
+  end
+
+  test 'a fee booked before the sale that pays for it does not invent a deficit' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+    tx(:fee, day: 2, base_currency: 'USDC', base_amount: 78, at: @day.call(2))
+    tx(:sell, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 30_000,
+              at: @day.call(2) + 1.hour)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd,
+                 'the day ends nearly 10k up — the fee came out of the sale, not out of nowhere'
+  end
+
+  test 'a venue that reports its funding books the deposit and nothing more' do
+    tx(:deposit, day: 1, base_currency: 'USDC', base_amount: 20_000)
+    tx(:buy, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd
+  end
+
   test 'a ledger warmed in the app zone is found from any other' do
     tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 20_000)
     Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
@@ -55,7 +106,8 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
     assert_equal 9_990.to_d, summary.realised_pnl_usd
     assert_equal 10.to_d, summary.fees_usd
     assert_empty summary.round_trips
-    assert_equal 0.to_d, summary.total_invested_usd, 'buys and sells are internal — nothing came in from outside'
+    assert_equal 50_000.to_d, summary.total_invested_usd,
+                 'the buys spent dollars this venue never reported receiving; the sale returns some of them'
   end
 
   test 'a sell that empties the lots closes a round-trip and leaves no position' do
@@ -117,7 +169,7 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
     btc = summary.positions.sole
     assert_equal 1.to_d, btc.quantity
     assert_equal 20_000.to_d, btc.cost_usd, 'the lot travelled with its cost'
-    assert_equal 0.to_d, summary.total_invested_usd
+    assert_equal 20_000.to_d, summary.total_invested_usd, 'the transfer contributes nothing; the buy behind it was funded from outside'
     assert_equal 0.to_d, summary.realised_pnl_usd
   end
 
@@ -159,7 +211,8 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
     assert_equal 0.6.to_d, btc.quantity
     assert_equal 12_000.to_d, btc.cost_usd, 'the coins left at their FIFO cost — the holdings card shows what the exchange still holds'
     assert_equal 0.to_d, summary.realised_pnl_usd
-    assert_equal(-10_000.to_d, summary.total_invested_usd, '0.4 BTC at the day\'s 25k went somewhere untracked')
+    assert_equal 10_000.to_d, summary.total_invested_usd,
+                 '20k came in to buy the coin, 0.4 BTC at the day\'s 25k went somewhere untracked'
   end
 
   test 'scoped to one exchange, a coin that moved venues shows on the venue it is on, and the venues\' money-in reflects the move' do
@@ -174,7 +227,8 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
 
     assert_empty on_binance.positions
     assert_equal 0.to_d, on_binance.realised_pnl_usd, 'a transfer out is not a sale'
-    assert_equal(-28_000.to_d, on_binance.total_invested_usd, 'per venue the outbound leg is money leaving, at the day\'s price')
+    assert_equal(-8_000.to_d, on_binance.total_invested_usd,
+                 'per venue: 20k of unreported funding in, the outbound leg out at the day\'s price')
     assert_equal 30_000.to_d, on_kraken.total_invested_usd
     kraken_btc = on_kraken.positions.sole
     assert_equal 1.to_d, kraken_btc.quantity

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -56,6 +56,36 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
                  'the cash moved between the user\'s own venues — spending it is what would show where it came from'
   end
 
+  test 'a venue that lends is short because it lent, not because history is missing' do
+    alpaca = create(:alpaca_exchange)
+    key = create(:api_key, user: @user, exchange: alpaca)
+    tx(:deposit, key: key, day: 1, base_currency: 'USD', base_amount: 10_000)
+    tx(:buy, key: key, day: 2, base_currency: 'QQQM', base_amount: 10, quote_currency: 'USD', quote_amount: 20_000)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 10_000.to_d, summary.total_invested_usd,
+                 'settled cash goes negative on borrowed money at a broker; a loan is not a contribution'
+  end
+
+  test 'a single-row trade that sells cash keeps the already-net fee rule' do
+    tx(:sell, day: 1, base_currency: 'USDT', base_amount: 1_000, quote_currency: 'TRY', quote_amount: 30_000,
+              fee_amount: 5, fee_currency: 'USDT')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 1_000.to_d, summary.total_invested_usd,
+                 'the fee is on top only where the row is a settlement leg with no quote of its own'
+  end
+
+  test 'a cash deposit whose fee exceeds it arrives at zero rather than in deficit' do
+    tx(:deposit, day: 1, base_currency: 'USDC', base_amount: 5, fee_amount: 10, fee_currency: 'USDC')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 5.to_d, summary.total_invested_usd, 'nothing was borrowed to pay that fee'
+  end
+
   test 'a fee booked before the sale that pays for it does not invent a deficit' do
     tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
     tx(:fee, day: 2, base_currency: 'USDC', base_amount: 78, at: @day.call(2))


### PR DESCRIPTION
"Total invested" is money that arrived from outside: deposits in, withdrawals out, everything else
a rearrangement of what is already there. That definition assumes the venue says when money
arrived, and plenty of them do not — an exchange that reports trades but not the transfer behind
them, or whose history window opens after the funding did, leaves an account that appears to have
bought its coins with nothing.

The figure is then zero for that entire era: the tiles read zero, and the chart prints `—` for
every day of it, because a return on nothing is not a number anyone can read. It is most visible on
crypto venues, where a portfolio can predate the oldest transfer the API will admit to.

## The rule

A cash balance that goes into deficit is the record telling us what it left out. The deepest
deficit a currency reaches is the least outside money consistent with everything the venue did
report, so each new low is booked as money in, on the day it is reached.

A deposit that later covers the deficit lifts the balance without setting a new low — which is what
leaves a venue that does report its funding exactly where it was, and stops a late-arriving deposit
from being counted twice.

Cash only. A crypto balance in deficit is a missing acquisition rather than missing funding, and
what those coins cost is not a question a balance can answer: those days stay `partial`, as before.

Cash is pooled per venue, because that is where a deficit means anything: dollars at a broker
cannot pay for an exchange's trade. A transfer between the user's own venues moves cash from one
pot to the other — it contributes nothing to the portfolio, but it certainly moves.

Derivatives are left out of the cash view entirely. A futures fill reserves margin — the notional it
books as its quote never left an account — and its realised P/L and funding fees belong to a wallet
this ledger only sees a corner of.

Nothing is inferred at a venue that lends. A broker runs settled cash below zero by design, and a
margin loan read as a contribution would be booked as money in and then valued as cash on hand,
twice over — so the currencies those venues settle in are left out of the inference entirely.

Measured at exchange events, never per row and never per day. A venue is read once its OWN events
have closed — group ids are the venue's own, and one exchange being mid-event says nothing about
another — so a sale's fee and its proceeds are read together however many
unrelated rows land between them — and two events on one day stay two facts, so a venue bought from
in the morning and sold out of in the afternoon does not end the day looking like it cost nothing.

## Two readers, one figure

The tiles read `Tracker::Ledger`; the chart's history is swept by `PortfolioSnapshot::BackfillJob`.
They walk different data and had to be taught the same rule, so a test pins them against each other
on the shape that used to divide them: a venue booking the cash leg of a trade as its own row. That
also fixed a real disagreement — a fee charged in the cash a trade spends now leaves the sweep's
cash balance too. The "sales are already net" rule is about the asset being sold, not about the
cash paying for it.

Snapshots already written cannot know any of this, and today's row would step away from the ones
behind it, so a migration drops them: they are derived from the ledger and the price table, and the
tracker rebuilds the history it finds missing. The ledger cache namespace moves to v3 for the same
reason — a warm entry would otherwise serve the old figure for up to 30 days.

## Known limits

A lending venue is exempt whole rather than per instrument. Alpaca crypto is non-marginable and
could in principle be inferred, but the codebase's own way of telling marginable from not is
explicitly approximate, and brokers report their cash movements anyway — so the exemption costs
close to nothing, while guessing wrong would book a margin loan as a contribution.

A settlement currency outside the tax service's fiat list (TRY, BRL, ZAR and friends, which some
venues quote against) is not treated as cash here, so a deficit in one infers nothing and those
accounts keep the figure they have today. Widening that list means widening what the tax engine
considers fiat, which is a change of its own.

## Tests

- cash spent that the ledger never saw arrive is money in
- a deposit that covers an earlier deficit is not counted twice
- a venue that reports its funding books the deposit and nothing more
- a fee booked before the sale that pays for it does not invent a deficit
- a linked transfer between the user's own venues is not money from outside
- the sweep and the ledger agree on money in for a venue that books the cash leg separately
- the sweep books it on the day it was spent
- inferred funding is cash that is really there: selling it back reads as a gain, not a loss
- a fee inside a cash deposit leaves the account once
- a venue that lends is short because it lent, not because history is missing (ledger and sweep)
- a single-row trade that sells cash keeps the already-net fee rule
- a cash deposit whose fee exceeds it arrives at zero rather than in deficit
- a round trip inside one day still shows what it cost to open (ledger and sweep)
- a broker in the portfolio does not stop a spot venue from being read
- a grouped event is read whole even with an unrelated row between its legs
- a linked cash transfer moves between the pots and is booked once, at the venue it left
- a futures fill is notional, not cash spent
- a venue is read once its own events are closed, whatever another venue still has open

Each fails without its change. Full suite: 4395 runs, 0 failures.
