### PR TITLE
Finish the unfunded-cash inference

### DIFF
--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -28,7 +28,8 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
     # a price service — which is the only other thing that loads it.
     Tax::EcbFxRates.ensure_loaded!
     @user = User.find(user_id)
-    @transactions = AccountTransaction.for_user(@user).by_date_asc.includes(:linked_transaction, :inverse_link).to_a
+    @transactions = AccountTransaction.for_user(@user).by_date_asc
+                                      .includes(:exchange, :linked_transaction, :inverse_link).to_a
     return if @transactions.empty?
 
     @last_date = Date.current - 1
@@ -58,11 +59,14 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
         apply(balances, transaction)
         delta = contribution(transaction)
         delta.nil? ? invested_incomplete = true : invested += delta
-      end
-      # Once the whole day is applied: a fee that its own sale pays for, booked an hour earlier, is
-      # not an account that could not cover it.
-      unfunded_on(balances, date).each do |value|
-        value.nil? ? invested_incomplete = true : invested += value
+        # Once the whole EVENT is applied, so a fee its own sale pays for is not read as an account
+        # that could not cover it — but no later than that, or an afternoon sale would un-spend a
+        # morning the venue never funded.
+        next if same_event?(transaction, pending.first)
+
+        unfunded_on(balances, date).each do |value|
+          value.nil? ? invested_incomplete = true : invested += value
+        end
       end
       value, unpriced = value_on(balances, date)
       { user_id: @user.id, date: date, value_usd: value, invested_usd: invested,
@@ -99,6 +103,10 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
     end
     consume_fee(balances, transaction)
     apply_quote(balances, transaction)
+  end
+
+  def same_event?(transaction, following)
+    following.present? && transaction.group_id.present? && transaction.group_id == following.group_id
   end
 
   def acquired(transaction, amount)

--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -66,9 +66,10 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
         cash_moves(transaction).each { |currency, amount| cash[[transaction.exchange.name_id, currency]] += amount }
         delta = contribution(transaction)
         delta.nil? ? invested_incomplete = true : invested += delta
-        next unless closers.include?(transaction.id)
+        venue = closers[transaction.id]
+        next unless venue
 
-        unfunded_on(cash, balances, date).each do |value|
+        unfunded_on(cash, balances, venue, date).each do |value|
           value.nil? ? invested_incomplete = true : invested += value
         end
       end
@@ -111,11 +112,15 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
 
   # The transactions a shortfall may be read at, by id — see `UnfundedCash.closers`.
   def event_closers
-    closing = Tracker::UnfundedCash.closers(@transactions.map(&:group_id))
-    @transactions.each_with_index.filter_map { |transaction, index| transaction.id if closing.include?(index) }.to_set
+    closing = Tracker::UnfundedCash.closers(@transactions.map { |t| [t.exchange.name_id, t.group_id] })
+    @transactions.each_with_index.with_object({}) do |(transaction, index), closers|
+      closers[transaction.id] = closing[index] if closing[index]
+    end
   end
 
   def cash_moves(transaction)
+    return [] if Tracker::UnfundedCash.derivative?(transaction.tx_id)
+
     Tracker::UnfundedCash.moves(**transaction.slice(*Tracker::UnfundedCash::MOVE_KEYS).symbolize_keys)
   end
 
@@ -186,9 +191,11 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # Cash the ledger spent without ever seeing it arrive, valued on the day the deficit deepens: the
   # coins were bought with money whatever the venue reported. nil for a fiat deficit with no rate
   # that day — the figure cannot be stated, so the row says so.
-  def unfunded_on(cash, balances, date)
+  def unfunded_on(cash, balances, venue, date)
+    return [] if Tracker::UnfundedCash.lends_cash?(venue)
+
     cash.each_with_object([]) do |((exchange, symbol), balance), values|
-      next if Tracker::UnfundedCash.lends_cash?(exchange)
+      next unless exchange == venue
 
       shortfall = Tracker::UnfundedCash.shortfall(symbol, balance)
       next if shortfall.zero?

--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -47,6 +47,12 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # at the end of it are valued.
   def sweep(first_date)
     balances = Hash.new(0.to_d)
+    # Cash per VENUE, beside the balances the day is valued from: dollars at a broker cannot pay for
+    # an exchange's trade, and a broker's own deficit is borrowed rather than missing. Both readers
+    # of the ledger enumerate the moves with `UnfundedCash.moves`, so neither can hold a second
+    # opinion about what a row does to cash.
+    cash = Hash.new(0.to_d)
+    closers = event_closers
     invested = 0.to_d
     # An unpriced deposit or withdrawal leaves the money-in figure wrong from that day on, not just
     # on the day itself.
@@ -57,14 +63,12 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
       while pending.first && pending.first.transacted_at.to_date <= date
         transaction = pending.shift
         apply(balances, transaction)
+        cash_moves(transaction).each { |currency, amount| cash[[transaction.exchange.name_id, currency]] += amount }
         delta = contribution(transaction)
         delta.nil? ? invested_incomplete = true : invested += delta
-        # Once the whole EVENT is applied, so a fee its own sale pays for is not read as an account
-        # that could not cover it — but no later than that, or an afternoon sale would un-spend a
-        # morning the venue never funded.
-        next if same_event?(transaction, pending.first)
+        next unless closers.include?(transaction.id)
 
-        unfunded_on(balances, date).each do |value|
+        unfunded_on(cash, balances, date).each do |value|
           value.nil? ? invested_incomplete = true : invested += value
         end
       end
@@ -105,8 +109,14 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
     apply_quote(balances, transaction)
   end
 
-  def same_event?(transaction, following)
-    following.present? && transaction.group_id.present? && transaction.group_id == following.group_id
+  # The transactions a shortfall may be read at, by id — see `UnfundedCash.closers`.
+  def event_closers
+    closing = Tracker::UnfundedCash.closers(@transactions.map(&:group_id))
+    @transactions.each_with_index.filter_map { |transaction, index| transaction.id if closing.include?(index) }.to_set
+  end
+
+  def cash_moves(transaction)
+    Tracker::UnfundedCash.moves(**transaction.slice(*Tracker::UnfundedCash::MOVE_KEYS).symbolize_keys)
   end
 
   def acquired(transaction, amount)
@@ -176,26 +186,20 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # Cash the ledger spent without ever seeing it arrive, valued on the day the deficit deepens: the
   # coins were bought with money whatever the venue reported. nil for a fiat deficit with no rate
   # that day — the figure cannot be stated, so the row says so.
-  def unfunded_on(balances, date)
-    balances.each_with_object([]) do |(symbol, balance), values|
-      next if borrowable_currencies.include?(symbol)
+  def unfunded_on(cash, balances, date)
+    cash.each_with_object([]) do |((exchange, symbol), balance), values|
+      next if Tracker::UnfundedCash.lends_cash?(exchange)
 
       shortfall = Tracker::UnfundedCash.shortfall(symbol, balance)
       next if shortfall.zero?
 
-      # Added back, not just booked: the account really did hold that cash, and a sale that returns
-      # it later must land on a balance of zero rather than pay off a debt that was never owed.
+      # Added back to both, not just booked: the account really did hold that cash, so a sale that
+      # returns it lands on a balance of zero rather than paying off a debt that was never owed —
+      # and the day it was spent is valued with it present.
+      cash[[exchange, symbol]] += shortfall
       balances[symbol] += shortfall
       values << (STABLECOINS.include?(symbol) ? shortfall : fiat_value(symbol, shortfall, date))
     end
-  end
-
-  # The currencies a venue that lends settles in: at a broker, settled cash below zero is borrowed
-  # rather than missing, and the two cannot be told apart from a balance.
-  def borrowable_currencies
-    @borrowable_currencies ||= @transactions.select { |t| Tracker::UnfundedCash.lends_cash?(t.exchange.name_id) }
-                                            .flat_map { |t| [t.base_currency, t.quote_currency, t.fee_currency] }
-                                            .compact.select { |c| Tracker::UnfundedCash.cash?(c) }.to_set
   end
 
   # A negative balance is history we do not have — an exchange whose ledger window starts after the

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -21,10 +21,6 @@ module Tracker
     CACHE_TTL = 30.days
     FIAT = Tax::PriceService::FIAT_CURRENCIES
     STABLECOINS = Tax::PriceService::STABLECOINS
-    # What a row does to the balance of its base asset, for the entry types that touch it at all.
-    CASH_IN = %w[buy swap_in staking_reward lending_interest airdrop mining other_income deposit
-                 adjustment].freeze
-    CASH_OUT = %w[sell swap_out withdrawal fee lost withholding_tax].freeze
 
     # FIFO with the two things the tracker needs and a tax report does not.
     #
@@ -155,85 +151,36 @@ module Tracker
       #
       # And what it did not: cash spent that was never seen arriving. A venue that reports trades
       # but not the transfer behind them would otherwise show a portfolio bought for nothing, and a
-      # return on nothing is not a number anyone can read. `UnfundedCash` books only what deepens
-      # the deficit, so a venue that does report its funding is untouched.
+      # return on nothing is not a number anyone can read.
+      #
+      # Cash is pooled per VENUE, because that is where a deficit means anything: dollars sitting at
+      # a broker cannot pay for an exchange's trade, and a broker's own deficit is borrowed rather
+      # than missing.
       def contributions(rows, price_service)
         cash = Hash.new(0.to_d)
-        borrowable = borrowable_currencies(rows)
-        rows.slice_when { |before, after| event_of(before) != event_of(after) }.sum(0.to_d) do |event|
-          event.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
-          event.sum(0.to_d) { |row| contribution(row, price_service) } +
-            unfunded_contribution(cash, borrowable, event.last, price_service)
+        closes = UnfundedCash.closers(rows.map { |row| row[:group_id] })
+        rows.each_with_index.sum(0.to_d) do |row, index|
+          UnfundedCash.moves(**row.slice(*UnfundedCash::MOVE_KEYS))
+                      .each { |currency, amount| cash[[row[:exchange], currency]] += amount }
+          reported = contribution(row, price_service)
+          next reported unless closes.include?(index)
+
+          reported + unfunded_contribution(cash, row, price_service)
         end
       end
 
-      # One exchange EVENT, never a row and never a whole day. A venue that books a sale's fee on
-      # one leg and its proceeds on another shares a group id between them, and reading the fee
-      # alone looks like an account that could not pay it — while waiting for the end of the day
-      # would let an afternoon sale un-spend what the morning had to find first.
-      def event_of(row)
-        row[:group_id].presence || row.object_id
-      end
-
-      # The currencies a venue that lends settles in. Their deficits cannot be told apart from
-      # borrowing, so they are read as reported and nothing is inferred from them.
-      def borrowable_currencies(rows)
-        rows.select { |row| UnfundedCash.lends_cash?(row[:exchange]) }
-            .flat_map { |row| cash_moves(row).map(&:first) }.to_set
-      end
-
-      def unfunded_contribution(cash, borrowable, row, price_service)
-        cash.sum(0.to_d) do |currency, balance|
-          next 0.to_d if borrowable.include?(currency)
+      def unfunded_contribution(cash, row, price_service)
+        cash.sum(0.to_d) do |(exchange, currency), balance|
+          next 0.to_d if UnfundedCash.lends_cash?(exchange)
 
           shortfall = UnfundedCash.shortfall(currency, balance)
           next 0.to_d if shortfall.zero?
 
-          cash[currency] += shortfall
+          cash[[exchange, currency]] += shortfall
           next shortfall if STABLECOINS.include?(currency)
 
           price_service.convert_fiat(amount: shortfall, from: currency, to: 'USD',
                                      timestamp: row[:transacted_at])
-        end
-      end
-
-      # The cash one row moves, which is all a shortfall can be read from: the base leg when the
-      # base is itself cash (bank funding, a broker's dollar fee, a venue that books each leg of a
-      # trade as its own row), the quote leg of a single-row trade, and a fee charged in anything
-      # other than the base. The same moves PortfolioSnapshot's sweep applies to its balances.
-      def cash_moves(row)
-        type = row[:entry_type].to_s
-        fee = row[:fee_amount].to_d
-        moves = []
-        moves << [row[:fee_currency], -fee] if fee.positive? && row[:fee_currency] != row[:base_currency]
-        moves << [row[:quote_currency], quote_direction(type) * row[:quote_amount].to_d] if row[:quote_amount]
-        if row[:linked]
-          # The user's own transfer: the coins never left the tracked universe, so only the network
-          # fee is really gone. Scoped to one venue the rows arrive flattened and this never fires —
-          # there, the far leg is out of scope and the move is real.
-          moves << [row[:base_currency], -row[:transfer_fee_amount].to_d] if type == 'withdrawal'
-        elsif CASH_IN.include?(type) || CASH_OUT.include?(type)
-          amount = row[:base_amount].to_d
-          # A fee taken in the asset being acquired only shrinks what arrived; taken in the cash a
-          # trade spends, it leaves on top of what the row reports.
-          if row[:fee_currency] == row[:base_currency]
-            # Clamped, as the sweep clamps it: a fee larger than what arrived leaves nothing, it
-            # does not leave a hole for the inference to read as borrowed money.
-            amount = [amount - fee, 0.to_d].max if CASH_IN.include?(type)
-            # And on top only where the row is a settlement leg of its own — a trade that carries
-            # its own quote reports its base net, fee included.
-            amount += fee if UnfundedCash::FEE_ON_TOP.include?(type) && row[:quote_amount].blank?
-          end
-          moves << [row[:base_currency], CASH_IN.include?(type) ? amount : -amount]
-        end
-        moves.select { |currency, amount| UnfundedCash.cash?(currency) && !amount.zero? }
-      end
-
-      def quote_direction(type)
-        case type
-        when 'buy' then -1
-        when 'sell', 'return_of_capital' then 1
-        else 0
         end
       end
 

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -158,20 +158,28 @@ module Tracker
       # than missing.
       def contributions(rows, price_service)
         cash = Hash.new(0.to_d)
-        closes = UnfundedCash.closers(rows.map { |row| row[:group_id] })
+        closes = UnfundedCash.closers(rows.map { |row| [row[:exchange], row[:group_id]] })
         rows.each_with_index.sum(0.to_d) do |row, index|
-          UnfundedCash.moves(**row.slice(*UnfundedCash::MOVE_KEYS))
-                      .each { |currency, amount| cash[[row[:exchange], currency]] += amount }
+          cash_moves(row).each { |currency, amount| cash[[row[:exchange], currency]] += amount }
           reported = contribution(row, price_service)
-          next reported unless closes.include?(index)
+          venue = closes[index]
+          next reported unless venue
 
-          reported + unfunded_contribution(cash, row, price_service)
+          reported + unfunded_contribution(cash, venue, row, price_service)
         end
       end
 
-      def unfunded_contribution(cash, row, price_service)
+      def cash_moves(row)
+        return [] if UnfundedCash.derivative?(row[:tx_id])
+
+        UnfundedCash.moves(**row.slice(*UnfundedCash::MOVE_KEYS))
+      end
+
+      def unfunded_contribution(cash, venue, row, price_service)
+        return 0.to_d if UnfundedCash.lends_cash?(venue)
+
         cash.sum(0.to_d) do |(exchange, currency), balance|
-          next 0.to_d if UnfundedCash.lends_cash?(exchange)
+          next 0.to_d unless exchange == venue
 
           shortfall = UnfundedCash.shortfall(currency, balance)
           next 0.to_d if shortfall.zero?

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -160,11 +160,19 @@ module Tracker
       def contributions(rows, price_service)
         cash = Hash.new(0.to_d)
         borrowable = borrowable_currencies(rows)
-        rows.group_by { |row| row[:transacted_at].to_date }.sum(0.to_d) do |_date, day|
-          day.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
-          day.sum(0.to_d) { |row| contribution(row, price_service) } +
-            unfunded_contribution(cash, borrowable, day.last, price_service)
+        rows.slice_when { |before, after| event_of(before) != event_of(after) }.sum(0.to_d) do |event|
+          event.each { |row| cash_moves(row).each { |currency, amount| cash[currency] += amount } }
+          event.sum(0.to_d) { |row| contribution(row, price_service) } +
+            unfunded_contribution(cash, borrowable, event.last, price_service)
         end
+      end
+
+      # One exchange EVENT, never a row and never a whole day. A venue that books a sale's fee on
+      # one leg and its proceeds on another shares a group id between them, and reading the fee
+      # alone looks like an account that could not pay it — while waiting for the end of the day
+      # would let an afternoon sale un-spend what the morning had to find first.
+      def event_of(row)
+        row[:group_id].presence || row.object_id
       end
 
       # The currencies a venue that lends settles in. Their deficits cannot be told apart from
@@ -174,10 +182,6 @@ module Tracker
             .flat_map { |row| cash_moves(row).map(&:first) }.to_set
       end
 
-      # A DAY at a time, never a row: one exchange event reaches the ledger as several rows, in an
-      # order nobody controls — a venue that books a sale's fee on the crypto leg and its proceeds
-      # on the fiat leg would otherwise look, for the width of one row, like an account that could
-      # not pay its own fee.
       def unfunded_contribution(cash, borrowable, row, price_service)
         cash.sum(0.to_d) do |currency, balance|
           next 0.to_d if borrowable.include?(currency)

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -26,6 +26,14 @@ module Tracker
     # out of the inference entirely. Spot crypto venues cannot lend, which is where the missing
     # history actually is. Extend this list when a venue that lends is added.
     LENDS_CASH = %w[alpaca ibkr].freeze
+    # What a row does to the balance of its base asset, for the entry types that touch it at all.
+    BASE_IN = %w[buy swap_in staking_reward lending_interest airdrop mining other_income deposit
+                 adjustment].freeze
+    BASE_OUT = %w[sell swap_out withdrawal fee lost withholding_tax].freeze
+
+    # The row fields `moves` reads, so a caller holding an enriched row can hand it straight over.
+    MOVE_KEYS = %i[entry_type base_currency base_amount quote_currency quote_amount fee_currency
+                   fee_amount].freeze
 
     def self.lends_cash?(exchange)
       LENDS_CASH.include?(exchange.to_s)
@@ -42,5 +50,62 @@ module Tracker
 
       -balance
     end
+
+    # Which positions in an ordered ledger a shortfall may be read at.
+    #
+    # The legs of one exchange event share a group id and arrive in an order nobody controls, with
+    # unrelated rows free to fall between them — a sale's fee read before its own proceeds looks
+    # like an account that could not pay it. So the reading waits until every event that has opened
+    # has also closed. Everything else closes as itself, which is what keeps an afternoon sale from
+    # un-spending what the morning had to find first.
+    def self.closers(group_ids)
+      last = {}
+      group_ids.each_with_index { |group, index| last[group] = index if group.present? }
+      open = 0
+      seen = Set.new
+      group_ids.each_with_index.filter_map do |group, index|
+        open += 1 if group.present? && seen.add?(group)
+        open -= 1 if group.present? && last[group] == index
+        index if open.zero?
+      end.to_set
+    end
+
+    # The cash one ledger row moves: the base leg where the base is itself cash (bank funding, a
+    # broker's dollar fee, a venue that books each leg of a trade as its own row), the quote leg of
+    # a single-row trade, and a fee charged in anything other than the base.
+    #
+    # Both readers of the ledger call this — the tiles and the chart's history are the same figure
+    # read at two altitudes, and a second opinion about what a row does to cash is how they would
+    # come to disagree. A transfer between the user's own venues is an ordinary move here: it
+    # contributes nothing to the portfolio, but it certainly moves cash from one pot to the other.
+    def self.moves(entry_type:, base_currency:, base_amount:, quote_currency: nil, quote_amount: nil,
+                   fee_currency: nil, fee_amount: nil)
+      type = entry_type.to_s
+      fee = fee_amount.to_d
+      moves = []
+      moves << [fee_currency, -fee] if fee.positive? && fee_currency != base_currency
+      moves << [quote_currency, quote_direction(type) * quote_amount.to_d] if quote_amount
+      if BASE_IN.include?(type) || BASE_OUT.include?(type)
+        amount = base_amount.to_d
+        if fee_currency == base_currency
+          # A fee taken in the asset acquired only shrinks what arrived, and never past nothing.
+          amount = [amount - fee, 0.to_d].max if BASE_IN.include?(type)
+          # Taken in the cash a trade spends it leaves on top — but only where the row is a
+          # settlement leg of its own. A trade carrying its own quote reports its base net.
+          amount += fee if FEE_ON_TOP.include?(type) && quote_amount.blank?
+        end
+        moves << [base_currency, BASE_IN.include?(type) ? amount : -amount]
+      end
+      moves.select { |currency, amount| cash?(currency) && !amount.zero? }
+    end
+
+    def self.quote_direction(type)
+      case type
+      when 'buy' then -1
+      when 'sell', 'return_of_capital' then 1
+      else 0
+      end
+    end
+    private_class_method :quote_direction
   end
 end

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -51,23 +51,38 @@ module Tracker
       -balance
     end
 
-    # Which positions in an ordered ledger a shortfall may be read at.
+    # A derivatives row. A futures fill reserves margin: the notional it reports as its quote never
+    # left an account, and read as cash spent it would book a multiple of the position as money from
+    # outside. The realised P/L and funding fees of a futures wallet are the same story — a purse
+    # this ledger cannot see the whole of.
+    #
+    # ponytail: recognised by the id the importers give them (`futures-`, `usdt-futures-`,
+    # `coin-futures-`), because a row has no flag that says "contract" rather than "coin". Upgrade
+    # path: set one at import and read it here.
+    def self.derivative?(tx_id)
+      tx_id.to_s.include?('futures')
+    end
+
+    # Which positions in an ordered ledger a shortfall may be read at, and for which venue.
     #
     # The legs of one exchange event share a group id and arrive in an order nobody controls, with
     # unrelated rows free to fall between them — a sale's fee read before its own proceeds looks
-    # like an account that could not pay it. So the reading waits until every event that has opened
-    # has also closed. Everything else closes as itself, which is what keeps an afternoon sale from
-    # un-spending what the morning had to find first.
-    def self.closers(group_ids)
+    # like an account that could not pay it. So a venue is read only once its own open events have
+    # closed; what another venue is in the middle of is none of its business, and group ids are the
+    # venue's own anyway. Everything else closes as itself, which is what keeps an afternoon sale
+    # from un-spending what the morning had to find first.
+    def self.closers(entries)
       last = {}
-      group_ids.each_with_index { |group, index| last[group] = index if group.present? }
-      open = 0
+      entries.each_with_index { |(venue, group), index| last[[venue, group]] = index if group.present? }
+      open = Hash.new(0)
       seen = Set.new
-      group_ids.each_with_index.filter_map do |group, index|
-        open += 1 if group.present? && seen.add?(group)
-        open -= 1 if group.present? && last[group] == index
-        index if open.zero?
-      end.to_set
+      entries.each_with_index.with_object({}) do |((venue, group), index), closing|
+        if group.present?
+          open[venue] += 1 if seen.add?([venue, group])
+          open[venue] -= 1 if last[[venue, group]] == index
+        end
+        closing[index] = venue if open[venue].zero?
+      end
     end
 
     # The cash one ledger row moves: the base leg where the base is itself cash (bank funding, a

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -66,7 +66,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select '.data-grid__item .label', text: I18n.t('bot.details.stats.portfolio_value')
     assert_select '.data-grid__item .label', text: I18n.t('bot.dca_index.realised_pnl')
     assert_select '.data-grid__item .label', text: I18n.t('tracker.fees_paid')
-    assert_select '.data-grid__item__value', text: /\$33,020\.00/ # 30,000 in − 1,000 out + the 4,020 the venues spent without reporting its arrival
+    assert_select '.data-grid__item__value', text: /\$34,020\.00/ # 30,000 in − 1,000 out + the 5,020 each venue spent without reporting its arrival
     assert_select '.data-grid__item__value', text: /\$80,000\.00/
     assert_select '.data-grid__item__value.text-success', text: /1,000\.00/ # the ETH round-trip
     assert_select '.data-grid__item__value', text: /\$20\.00/
@@ -232,7 +232,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select 'tr.tracker-row td', text: 'ETH', count: 0
     assert_select '.tracker-positions tbody tr', 1
     assert_select '.data-grid__item__value', text: /\$80,000\.00/, count: 1 # whole portfolio, still
-    assert_select '.data-grid__item__value', text: /\$33,020\.00/, count: 1
+    assert_select '.data-grid__item__value', text: /\$34,020\.00/, count: 1
   end
 
   test 'a cold exchange-scoped ledger warms its own key' do
@@ -256,7 +256,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select '.tracker-positions td', text: /\$/, count: 0
     assert_select '.tracker-positions td.text-success', text: /\+25\.0%/, count: 1
     # The figures this page would otherwise print, in every form they could take.
-    assert_no_match(/80,000|60,000|33,020|30,020|20,013|20\.00 USD|4,000\.00|5,000\.00|1,000\.00/, response.body)
+    assert_no_match(/80,000|60,000|34,020|30,020|20,013|20\.00 USD|4,000\.00|5,000\.00|1,000\.00/, response.body)
   end
 
   # ── 10 · display currency ────────────────────────────────────────────────────────────────────

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -113,6 +113,17 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
     assert_equal [1_000.to_d] * 2, rows.map(&:invested_usd)
   end
 
+  test 'a round trip inside one day still books what it cost to open' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
+    create(:account_transaction, api_key: @key, entry_type: :sell, base_currency: 'BTC', base_amount: 1,
+                                 quote_currency: 'USDC', quote_amount: 30_000, transacted_at: @day.call(1) + 4.hours)
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+
+    travel_to(@day.call(3)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+
+    assert_equal [20_000.to_d] * 2, PortfolioSnapshot.for_user(@user).order(:date).pluck(:invested_usd)
+  end
+
   test 'a broker that lends is short because it lent: the sweep infers nothing from it' do
     alpaca = create(:alpaca_exchange)
     alpaca_key = create(:api_key, user: @user, exchange: alpaca)

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -56,6 +56,18 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
                  'the cash moved between the user\'s own venues — spending it is what would show where it came from'
   end
 
+  test 'a round trip inside one day still shows what it cost to open' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000,
+             at: @day.call(1))
+    tx(:sell, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 30_000,
+              at: @day.call(1) + 4.hours)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd,
+                 'the afternoon sale does not un-spend what the morning had to find first'
+  end
+
   test 'a venue that lends is short because it lent, not because history is missing' do
     alpaca = create(:alpaca_exchange)
     key = create(:api_key, user: @user, exchange: alpaca)
@@ -88,9 +100,9 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
 
   test 'a fee booked before the sale that pays for it does not invent a deficit' do
     tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000)
-    tx(:fee, day: 2, base_currency: 'USDC', base_amount: 78, at: @day.call(2))
+    tx(:fee, day: 2, base_currency: 'USDC', base_amount: 78, at: @day.call(2), group_id: 'sale-1')
     tx(:sell, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 30_000,
-              at: @day.call(2) + 1.hour)
+              at: @day.call(2) + 1.hour, group_id: 'sale-1')
 
     summary = Tracker::Ledger.for(@user)
 

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -46,14 +46,40 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
                  'the second buy spends the deposit; only the first one needed money from nowhere'
   end
 
-  test 'a linked cash transfer is not money from outside' do
+  test 'a linked cash transfer moves between the pots and is booked once, at the venue it left' do
     deposit = tx(:deposit, key: @key_kraken, day: 2, base_currency: 'USDC', base_amount: 1_000)
     tx(:withdrawal, day: 1, base_currency: 'USDC', base_amount: 1_000, linked_transaction: deposit)
 
     summary = Tracker::Ledger.for(@user)
 
-    assert_equal 0.to_d, summary.total_invested_usd,
-                 'the cash moved between the user\'s own venues — spending it is what would show where it came from'
+    assert_equal 1_000.to_d, summary.total_invested_usd,
+                 'the transfer itself contributes nothing; the venue it left never reported receiving it'
+  end
+
+  test 'a broker in the portfolio does not stop a spot venue from being read' do
+    alpaca = create(:alpaca_exchange)
+    alpaca_key = create(:api_key, user: @user, exchange: alpaca)
+    tx(:deposit, key: alpaca_key, day: 1, base_currency: 'USD', base_amount: 1)
+    tx(:buy, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USD', quote_amount: 20_000)
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_001.to_d, summary.total_invested_usd,
+                 'the dollar at the broker says nothing about the twenty thousand the exchange spent'
+  end
+
+  test 'a grouped event is read whole even with an unrelated row between its legs' do
+    tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 20_000,
+             at: @day.call(1))
+    tx(:fee, day: 2, base_currency: 'USDC', base_amount: 78, at: @day.call(2), group_id: 'sale-2')
+    tx(:staking_reward, day: 2, base_currency: 'ETH', base_amount: 1, at: @day.call(2) + 30.minutes)
+    tx(:sell, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 30_000,
+              at: @day.call(2) + 1.hour, group_id: 'sale-2')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd,
+                 'the fee and the sale are one event whatever landed between them'
   end
 
   test 'a round trip inside one day still shows what it cost to open' do

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -56,6 +56,31 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
                  'the transfer itself contributes nothing; the venue it left never reported receiving it'
   end
 
+  test 'a futures fill is notional, not cash spent' do
+    tx(:buy, day: 1, base_currency: 'BTCUSDT', base_amount: 1, quote_currency: 'USDT', quote_amount: 60_000,
+             tx_id: 'futures-1')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 0.to_d, summary.total_invested_usd,
+                 'a leveraged fill reserves margin — the notional it reports never left an account'
+  end
+
+  test 'a venue is read once its own events are closed, whatever another venue still has open' do
+    tx(:fee, key: @key_binance, at: @day.call(1), base_currency: 'USDC', base_amount: 1, group_id: 'g1')
+    tx(:buy, key: @key_kraken, at: @day.call(1) + 1.hour, base_currency: 'BTC', base_amount: 1,
+             quote_currency: 'USDC', quote_amount: 20_000)
+    tx(:sell, key: @key_kraken, at: @day.call(1) + 2.hours, base_currency: 'BTC', base_amount: 1,
+              quote_currency: 'USDC', quote_amount: 30_000)
+    tx(:sell, key: @key_binance, at: @day.call(1) + 3.hours, base_currency: 'BTC', base_amount: 1,
+              quote_currency: 'USDC', quote_amount: 5_000, group_id: 'g1')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 20_000.to_d, summary.total_invested_usd,
+                 'the buy at one venue is unfunded whether or not the other venue is mid-event'
+  end
+
   test 'a broker in the portfolio does not stop a spot venue from being read' do
     alpaca = create(:alpaca_exchange)
     alpaca_key = create(:api_key, user: @user, exchange: alpaca)


### PR DESCRIPTION
Follow-ups to #242, which merged while review was still finding things. Three defects in the
inference it introduced, none of them released yet.

**A futures fill is notional, not cash spent.** Bybit's ledger import pulls `category: 'linear'`
executions with `execValue` as a USDT quote, so a leveraged position booked its whole notional as
money from outside — a 10× position reads as ten times what funded it. Binance's futures income
rows (realised P/L, funding fees) are the same wallet seen from the other side. Derivatives are out
of the cash view entirely now.

**A day was the wrong unit.** A venue that funds nothing, bought from in the morning and sold out of
in the afternoon, ended the day in credit and reported nothing invested at all: a round trip that
cost real money looked free. The boundary is the exchange event, and a venue is read once its own
events have closed — group ids belong to the venue, and unrelated rows are free to land between the
legs of one.

**Cash is pooled per venue.** Dollars at a broker cannot pay for an exchange's trade. Worse, the
exemption that keeps a margin loan from being read as a contribution was written per currency, so a
single dollar of broker activity marked USD borrowable for the whole portfolio and a spot exchange
that never reported its funding was read as though it had. It is the venue that is exempt now, not
the currency. A transfer between the user's own venues moves cash from one pot to the other — it
contributes nothing to the portfolio, but it certainly moves.

Both readers of the ledger now enumerate a row's cash moves through one shared rule
(`Tracker::UnfundedCash.moves`) rather than each keeping its own opinion, which is the seam most of
these came through.

## Tests

- a round trip inside one day still shows what it cost to open (ledger and sweep)
- a broker in the portfolio does not stop a spot venue from being read
- a grouped event is read whole even with an unrelated row between its legs
- a venue is read once its own events are closed, whatever another venue still has open
- a linked cash transfer moves between the pots and is booked once, at the venue it left
- a futures fill is notional, not cash spent

Each fails without its change. Full suite: 4395 runs, 0 failures.

One figure in the page fixture moves with the per-venue pools, correctly: a withdrawal from a venue
whose own ledger showed no cash was being covered by another exchange's balance.
