### PR TITLE
Count interest on a loan as the price of money, not money

### DIFF
--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -119,7 +119,7 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   end
 
   def cash_moves(transaction)
-    return [] if Tracker::UnfundedCash.derivative?(transaction.tx_id)
+    return [] if Tracker::UnfundedCash.borrowed?(transaction.tx_id)
 
     Tracker::UnfundedCash.moves(**transaction.slice(*Tracker::UnfundedCash::MOVE_KEYS).symbolize_keys)
   end

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -170,7 +170,7 @@ module Tracker
       end
 
       def cash_moves(row)
-        return [] if UnfundedCash.derivative?(row[:tx_id])
+        return [] if UnfundedCash.borrowed?(row[:tx_id])
 
         UnfundedCash.moves(**row.slice(*UnfundedCash::MOVE_KEYS))
       end

--- a/app/models/tracker/unfunded_cash.rb
+++ b/app/models/tracker/unfunded_cash.rb
@@ -51,16 +51,19 @@ module Tracker
       -balance
     end
 
-    # A derivatives row. A futures fill reserves margin: the notional it reports as its quote never
-    # left an account, and read as cash spent it would book a multiple of the position as money from
-    # outside. The realised P/L and funding fees of a futures wallet are the same story — a purse
-    # this ledger cannot see the whole of.
+    # A row from a borrowed wallet — one whose funding this ledger only ever sees a corner of.
     #
-    # ponytail: recognised by the id the importers give them (`futures-`, `usdt-futures-`,
-    # `coin-futures-`), because a row has no flag that says "contract" rather than "coin". Upgrade
-    # path: set one at import and read it here.
-    def self.derivative?(tx_id)
-      tx_id.to_s.include?('futures')
+    # A futures fill reserves margin: the notional it reports as its quote never left an account,
+    # and read as cash spent it would book a multiple of the position as money from outside. Its
+    # realised P/L and funding fees are the same wallet from the other side, and interest on a
+    # margin loan is the price of money that was borrowed rather than money that was put in.
+    #
+    # ponytail: recognised by the ids the importers give them, because a row carries no flag saying
+    # which account it belongs to. Upgrade path: set one at import and read it here.
+    BORROWED_MARKERS = %w[futures margin-interest].freeze
+
+    def self.borrowed?(tx_id)
+      BORROWED_MARKERS.any? { |marker| tx_id.to_s.include?(marker) }
     end
 
     # Which positions in an ordered ledger a shortfall may be read at, and for which venue.

--- a/test/models/tracker/ledger_test.rb
+++ b/test/models/tracker/ledger_test.rb
@@ -66,6 +66,14 @@ class Tracker::LedgerTest < ActiveSupport::TestCase
                  'a leveraged fill reserves margin — the notional it reports never left an account'
   end
 
+  test 'interest on a margin loan is not new money' do
+    tx(:fee, day: 1, base_currency: 'USDT', base_amount: 25, tx_id: 'margin-interest-1-USDT')
+
+    summary = Tracker::Ledger.for(@user)
+
+    assert_equal 0.to_d, summary.total_invested_usd, 'paying for borrowed money is not putting money in'
+  end
+
   test 'a venue is read once its own events are closed, whatever another venue still has open' do
     tx(:fee, key: @key_binance, at: @day.call(1), base_currency: 'USDC', base_amount: 1, group_id: 'g1')
     tx(:buy, key: @key_kraken, at: @day.call(1) + 1.hour, base_currency: 'BTC', base_amount: 1,


### PR DESCRIPTION
One more from review, on top of #243.

A Binance margin account's interest reaches the ledger as a cash fee in the borrowed asset
(`import_margin_interest`, ids of the form `margin-interest-*`). Paying it leaves the cash balance
short, and a short balance is what the inference reads as money the user must have put in — so the
cost of borrowing was booked as fresh investment, and every later day carried it.

It belongs with the futures rows, which were excluded for the same reason: both are wallets this
ledger only ever sees a corner of, and a deficit in either says nothing about what came in from
outside. The predicate covering them is now `borrowed?`, matching both markers.

Forced liquidations are deliberately left alone. Their proceeds really do land in the account, and
dropping the credit would leave a phantom deficit for the next trade to be blamed for — an error in
the direction of claiming more was invested than really was, which is the direction that matters.

## Test

- interest on a margin loan is not new money

Fails without the change. Full suite: 4396 runs, 0 failures.
