### PR TITLE
Take the desktop boot script off the web, and stop preloading what the page already has

### DIFF
--- a/app/javascript/tauri_boot.js
+++ b/app/javascript/tauri_boot.js
@@ -1,5 +1,0 @@
-// Sets the desktop class while the head is still parsing, before the stylesheet
-// applies, so the chrome never paints in its browser form first. The main bundle
-// cannot do this: it is deferred, and its desktop module resolves several dynamic
-// imports before it gets there.
-if (window.__IS_TAURI__) document.documentElement.classList.add("tauri");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
-    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -9,7 +9,6 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
-    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 

--- a/app/views/layouts/guest.html.erb
+++ b/app/views/layouts/guest.html.erb
@@ -8,7 +8,6 @@
     <title><%= content_for?(:title) ? yield(:title) : t('meta.title') %></title>
     <%= render 'application/favicon' %>
 
-    <%= javascript_include_tag "tauri_boot" %>
     <%= stylesheet_link_tag 'application', media: 'all', "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,14 @@ module Deltabadger
     # Silence Chrome DevTools workspace requests
     config.middleware.use Middleware::ChromeDevtools
 
+    # Rails advertises every stylesheet_link_tag and javascript_include_tag asset in a
+    # Link: rel=preload response header. Turbo then fetches pages the browser already holds
+    # those assets for, so each visit starts preloads nothing consumes and the console fills
+    # with "preloaded but not used". The tags themselves already fetch what the page needs;
+    # the header only duplicates them, and it never covered application.js anyway — Rails
+    # omits type: "module" scripts from it.
+    config.action_view.preload_links_header = false
+
     # explicit app timezone
     config.time_zone = 'UTC'
     config.active_record.default_timezone = :utc

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "@tauri-apps/cli": "^2.10.1"
   },
   "scripts": {
-    "build": "bun build app/javascript/*.js --bundle --sourcemap=linked --format=esm --outdir=app/assets/builds --public-path=/assets/",
-    "build:watch": "bun build app/javascript/*.js --bundle --sourcemap=linked --format=esm --outdir=app/assets/builds --public-path=/assets/ --watch",
+    "build": "bun build app/javascript/application.js --bundle --sourcemap=linked --format=esm --outdir=app/assets/builds --public-path=/assets/",
+    "build:watch": "bun build app/javascript/application.js --bundle --sourcemap=linked --format=esm --outdir=app/assets/builds --public-path=/assets/ --watch",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,36 @@ const AR_PRIMARY_KEY: &str = "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY";
 const AR_DERIVATION_SALT: &str = "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT";
 const AR_EXTERNAL_MARKER: &str = "ACTIVE_RECORD_ENCRYPTION_KEYS_EXTERNAL";
 
+// Injected at document start in the desktop webview, before any page script and before the
+// stylesheet applies, so the chrome never paints in its browser form first.
+//
+// The desktop class has to come from here rather than from the page. script-src carries no
+// 'unsafe-inline', so a view cannot write the guard inline, and shipping it as an asset put a
+// desktop-only file in front of every browser page. A user script is not governed by the page
+// policy — the two flags below have always been set this way.
+//
+// The observer is not belt-and-braces. WKWebView and WebKitGTK inject at document start with
+// <html> already created, so the first call marks it; WebView2 injects before the HTML is
+// parsed at all, where documentElement is null. Waiting for DOMContentLoaded there would land
+// after the stylesheet, which is the flash this script exists to prevent — so the observer
+// takes the class the instant <html> is appended, still ahead of <head>.
+const INITIALIZATION_SCRIPT: &str = concat!(
+    "window.__TAURI_INTERNALS__ = true;",
+    "window.__IS_TAURI__ = true;",
+    "(function () {",
+    "  function mark() {",
+    "    if (!document.documentElement) { return false; }",
+    "    document.documentElement.classList.add('tauri');",
+    "    return true;",
+    "  }",
+    "  if (!mark()) {",
+    "    new MutationObserver(function (records, observer) {",
+    "      if (mark()) { observer.disconnect(); }",
+    "    }).observe(document, { childList: true });",
+    "  }",
+    "})();"
+);
+
 struct RailsServer(Mutex<Option<Child>>);
 
 enum RailsCommand {
@@ -634,7 +664,7 @@ pub fn run() {
                         .min_inner_size(320.0, 600.0)
                         .center()
                         .devtools(true)
-                        .initialization_script("window.__TAURI_INTERNALS__ = true; window.__IS_TAURI__ = true;");
+                        .initialization_script(INITIALIZATION_SCRIPT);
 
                         // The overlay title bar is the macOS look; both builder methods exist only
                         // on macOS in Tauri 2, so calling them unconditionally does not compile
@@ -812,5 +842,19 @@ mod tests {
         assert!(!app_data_dir.join(".secrets").exists());
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    // The desktop chrome hangs off html.tauri, and this script is the only thing that sets it:
+    // the web layouts ship no tauri asset, and the page policy forbids an inline block. If this
+    // string loses the class, the packaged app silently paints as a browser page.
+    #[test]
+    fn the_initialization_script_marks_the_document_as_desktop() {
+        assert!(INITIALIZATION_SCRIPT.contains("window.__IS_TAURI__ = true;"));
+        assert!(INITIALIZATION_SCRIPT.contains("window.__TAURI_INTERNALS__ = true;"));
+        assert!(INITIALIZATION_SCRIPT.contains("classList.add('tauri')"));
+        // The null-documentElement path is the Windows one, and it is the path that cannot be
+        // exercised from here — so what it hangs on is pinned instead.
+        assert!(INITIALIZATION_SCRIPT.contains("new MutationObserver"));
+        assert!(!INITIALIZATION_SCRIPT.contains("DOMContentLoaded"));
     }
 }

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -130,12 +130,6 @@ class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
     assert_select 'script:not([src])', false, 'the devise layout still has an inline block'
   end
 
-  test 'the desktop class is set by a script the policy allows' do
-    get '/en/login'
-
-    assert_select 'script[src*=?]', 'tauri_boot'
-  end
-
   # The source scanner in test/linting covers app/views. This covers what gems and
   # helpers render, which no source scan can see: every script that reaches the
   # browser is external or nonced, and no element arrives with an on* attribute.

--- a/test/integration/layout_assets_test.rb
+++ b/test/integration/layout_assets_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# What the layouts tell a browser to fetch. Both facts below were visible only in a console:
+# a desktop-only script sitting in every page's <head>, and preload headers for assets the
+# page already had.
+class LayoutAssetsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup { @admin = create(:user, admin: true, setup_completed: true) }
+
+  # The desktop guard is a Tauri initialization script now (src-tauri/src/lib.rs), so nothing
+  # tauri-shaped is fetched over the web. Matching the asset name rather than a tag keeps this
+  # honest if the file returns under a different include.
+  test 'no layout asks a browser for a tauri asset' do
+    signed_out_then_in do |path|
+      assert_no_match(/tauri/i, asset_urls.join(' '), "#{path} still fetches a tauri asset")
+    end
+  end
+
+  # config.action_view.preload_links_header is off: the header only duplicated the tags, and
+  # Turbo made every visit start preloads nothing consumed.
+  test 'no layout emits preload link headers' do
+    signed_out_then_in do |path|
+      assert_nil response.headers['Link'], "#{path} still advertises preloads"
+    end
+  end
+
+  private
+
+  # /en/login is requested before signing in: Devise redirects a signed-in user away from it,
+  # and a redirect body would satisfy either assertion while inspecting nothing.
+  def signed_out_then_in
+    get '/en/login'
+    assert_response :success, '/en/login did not render, so it proved nothing'
+    yield '/en/login'
+
+    sign_in @admin
+    ['/en/bots', '/en/tracker'].each do |path|
+      get path
+      assert_response :success, "#{path} did not render, so it proved nothing"
+      yield path
+    end
+  end
+
+  def asset_urls
+    css_select('script[src], link[href]').map { |node| node['src'] || node['href'] }
+  end
+end


### PR DESCRIPTION
Two things a browser console reported on every page load.

## A desktop-only script in every browser page

The desktop chrome hangs off `html.tauri`, and the class was set by `tauri_boot.js` — a two-line asset included by all three layouts, render-blocking by design so the class lands before the stylesheet applies. In a browser `window.__IS_TAURI__` is never set, so it did nothing but cost a request in the `<head>` of every page.

That flag already comes from a Tauri initialization script (`src-tauri/src/lib.rs`), which is where the class belongs. It moves there, the asset is deleted, and no tauri-shaped file is fetched over the web at all.

Injection timing differs by webview backend, and the difference decides whether this works:

| Backend | At injection | Path taken |
|---|---|---|
| WKWebView, WebKitGTK | `<html>` created | marked immediately |
| WebView2 | HTML not yet parsed, `documentElement` null | observer marks it the instant `<html>` is appended |

Waiting for `DOMContentLoaded` on the WebView2 path would land after the stylesheet — the flash this script exists to prevent — so a `MutationObserver` on `document` takes it earlier, still ahead of `<head>`.

The class cannot come from the page instead: `script-src` carries no `'unsafe-inline'`, and `test/linting/inline_javascript_test.rb` holds views to zero inline `<script>`. A user script is not governed by the page policy, which is why the two flags have always been set this way.

## Preload headers for assets the page already had

`preload_links_header` advertised every `stylesheet_link_tag` and `javascript_include_tag` asset in a `Link: rel=preload` response header. Turbo then fetched pages the browser already held those assets for, so each visit started preloads nothing consumed:

```
The resource …/application-….css was preloaded using link preload but not used
within a few seconds from the window's load event.
```

That fired for the stylesheet too, which is plainly in use. The tags already fetch what a page needs, and the header never covered `application.js` anyway — Rails omits `type: "module"` scripts from it. Turned off.

## Also

The bundler's entry-point glob built `app/javascript/tauri.js` as a standalone file no layout loads. That code belongs in the main bundle, which imports it; the duplicate and its source map were precompiled and shipped for nothing. The build now names its entry point.

## Tests

`test/integration/layout_assets_test.rb` pins both facts — no layout asks a browser for a tauri asset, no layout emits preload headers — across a signed-out and two signed-in pages. Both fail without the change.

The Rust side pins what the initialization script must contain, including the absence of the `DOMContentLoaded` fallback, since the Windows path it guards cannot be exercised from a test host.

The CSP test that asserted the desktop class arrives via an allowed `script[src]` is removed; the class no longer comes from the page.

4397 Rails tests, 3 Rust tests, green.
