### PR TITLE
A row the venue valued takes no stated value

### DIFF
--- a/app/controllers/tracker_controller.rb
+++ b/app/controllers/tracker_controller.rb
@@ -101,6 +101,10 @@ class TrackerController < ApplicationController
   # the tax report all inherit this without knowing it exists.
   def update_value
     transaction = AccountTransaction.for_user(current_user).find(params[:id])
+    # Amount and price of the row's own are the value: nothing to state, and a request that tries
+    # anyway is refused rather than stored and ignored.
+    return head :unprocessable_entity if transaction.venue_valued? && params[:value].present?
+
     # The box is labelled in the user's own currency; the ledger counts in USD. Convert on the way in
     # exactly as the view converts on the way out, or a figure typed in euro would be banked as
     # dollars.

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -157,14 +157,12 @@ module TrackerHelper
   # a figure this app computed in USD, and follows the page's own rule: converted at today's rate,
   # exactly like the tiles and the chart above it.
   def tracker_row_value(record, denomination)
-    stated = record.manual_value(:fiat_value)
-    return [denomination.convert(stated), :stated] if stated
-
     return cash_value(record, denomination) if money?(record.base_currency)
 
-    if record.quote_amount.present? && money?(record.quote_currency)
-      return sourced(in_display(record.quote_amount, record.quote_currency, record, denomination), :exchange)
-    end
+    return sourced(in_display(record.quote_amount, record.quote_currency, record, denomination), :exchange) if record.venue_valued?
+
+    stated = record.manual_value(:fiat_value)
+    return [denomination.convert(stated), :stated] if stated
 
     price = HistoricalPrice.lookup(asset: record.base_currency, currency: 'USD',
                                    date: record.transacted_at.to_date)

--- a/app/models/account_transaction.rb
+++ b/app/models/account_transaction.rb
@@ -39,9 +39,18 @@ class AccountTransaction < ApplicationRecord
     raise ArgumentError, "#{field} cannot be stated by hand" unless MANUAL_FIELDS.include?(field.to_s)
 
     number = parse_manual(value)
+    raise ArgumentError, 'a row the venue valued is not yours to state' if number && venue_valued?
+
     self.manual_values = (manual_values || {}).except(field.to_s)
     self.manual_values = manual_values.merge(field.to_s => number.to_s) if number
     number
+  end
+
+  # A row the venue itself valued: amount and price of its own, and the value is their product. A
+  # figure typed in front of it would leave the three columns no longer multiplying out, so such a
+  # row takes no stated value — not written, and not read if one was written before this rule.
+  def venue_valued?
+    quote_amount.present? && Tracker::UnfundedCash.cash?(quote_currency)
   end
 
   validates :base_currency, presence: true

--- a/app/models/tax/price_service.rb
+++ b/app/models/tax/price_service.rb
@@ -47,7 +47,7 @@ module Tax
         # A row the user has priced needs no price of ours, and must not be counted among the missing
         # ones — a report is not incomplete over a figure it was handed. Nor does a row the cash leg
         # beside it already values.
-        next if tx.respond_to?(:manual?) && tx.manual?(:fiat_value)
+        next if tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !tx.venue_valued?
         next if cash_leg_value(tx)
         next if tx.quote_currency == currency && tx.quote_amount.present?
         next if tx.quote_currency.present? && tx.quote_amount.present? &&
@@ -153,7 +153,7 @@ module Tax
           price_missing: price_missing,
           # A figure the user stated by hand rather than one the venue reported or we priced. Carried
           # through so the tax report can disclose it: a stated cost is defensible, a silent one is not.
-          stated_value: tx.respond_to?(:manual?) && tx.manual?(:fiat_value),
+          stated_value: tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !tx.venue_valued?,
           exchange: tx.exchange.name_id,
           linked: links.key?(tx.id) || linked_deposit_ids.include?(tx.id),
           transfer_fee_amount: transfer_fee_amount(tx, links, deposit_amounts)
@@ -406,22 +406,14 @@ module Tax
     end
 
     def resolve_fiat_value(record, currency)
-      # What the USER says it was worth, ahead of everything the app can work out — including the
-      # venue's own figure. This is the single point every consumer of a priced row passes through,
-      # so the tiles, the chart, the positions and the tax report inherit a stated value without
-      # knowing it exists. Stated in USD, like everything else behind the page.
-      stated = record.respond_to?(:manual_value) && record.manual_value(:fiat_value)
-      return convert_fiat(amount: stated, from: 'USD', to: currency, timestamp: record.transacted_at) if stated
-
       # `prefetch`/`add_coin_date` already refuses to price a fiat base. Report drops fiat rows before
       # the engines, so nothing reads this value; pricing it can only fabricate a missing-price warning
       # that marks the report incomplete over a number nobody consumes.
       return 0.to_d if FIAT_CURRENCIES.include?(record.base_currency)
 
+      # The venue's own figure first: amount and price of the row's own are the value, and nothing
+      # stands in front of them.
       return record.quote_amount.to_d if record.quote_currency == currency && record.quote_amount.present?
-
-      cash = cash_leg_value(record)
-      return cash if cash
 
       if record.quote_currency.present? && STABLECOINS.include?(record.quote_currency) && record.quote_amount.present?
         return convert_fiat(amount: record.quote_amount.to_d, from: 'USD', to: currency, timestamp: record.transacted_at)
@@ -431,6 +423,16 @@ module Tax
         return convert_fiat(amount: record.quote_amount.to_d, from: record.quote_currency, to: currency,
                             timestamp: record.transacted_at)
       end
+
+      # Then what the USER says it was worth, ahead of everything the app would have to guess. This
+      # is the single point every consumer of a priced row passes through, so the tiles, the chart,
+      # the positions and the tax report inherit a stated value without knowing it exists. Stated
+      # in USD, like everything else behind the page.
+      stated = record.respond_to?(:manual_value) && record.manual_value(:fiat_value)
+      return convert_fiat(amount: stated, from: 'USD', to: currency, timestamp: record.transacted_at) if stated
+
+      cash = cash_leg_value(record)
+      return cash if cash
 
       price = price_at(asset: record.base_currency, currency: currency, timestamp: record.transacted_at)
       price * record.base_amount.to_d

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -35,8 +35,10 @@
   <td><%= tracker_amount(tracker_row_price(at, value)) || '—' %></td>
   <% unless hide_money %>
     <td class="tracker-row__value tracker-row__value--<%= source || 'none' %>">
-      <%# A row whose base is money states a fact, not a guess — there is nothing here to fill in. %>
-      <% if source == :cash %>
+      <%# A row whose base is money, or whose amount and price the venue gave, states a fact, not a
+          guess — there is nothing here to fill in, and a box would only let the three money columns
+          stop multiplying out. %>
+      <% if %i[cash exchange].include?(source) %>
         <%= tracker_amount(shown) %>
       <% else %>
         <%= form_with url: value_tracker_transaction_path(at), method: :patch,

--- a/test/integration/tracker_manual_value_test.rb
+++ b/test/integration/tracker_manual_value_test.rb
@@ -26,8 +26,10 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
   # `form_with` writes a hidden _method field first — the typeable box is the number one.
   def input_for(record) = row_cell(record).first.css('input[type="number"]').first
 
-  # Priced by the venue: no placeholder, no mark, just the figure.
-  test 'a value the exchange reported stands as the exchange&apos;s' do
+  # Priced by the venue: amount and price of its own, and the value is their product. Nothing here
+  # is a guess, so there is nothing for a user to state — a box would only let the three columns
+  # stop multiplying out.
+  test 'a value the exchange reported stands as the exchange&apos;s, and is not a box' do
     bought = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
                                           entry_type: :buy, base_currency: 'BTC', base_amount: 1,
                                           quote_currency: 'USD', quote_amount: 20_000, transacted_at: @t)
@@ -35,7 +37,19 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     cell = row_cell(bought).first
 
     assert_includes cell['class'], 'tracker-row__value--exchange'
-    assert_equal '20000.0', cell.css('input[type="number"]').first['placeholder']
+    assert_empty cell.css('input'), 'nothing here for a user to state'
+    assert_equal '20,000.00', cell.text.strip
+  end
+
+  test 'a value the exchange reported is not the user&apos;s to state' do
+    bought = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
+                                          entry_type: :buy, base_currency: 'BTC', base_amount: 1,
+                                          quote_currency: 'USD', quote_amount: 20_000, transacted_at: @t)
+
+    patch value_tracker_transaction_path(id: bought.id), params: { value: '21000' }
+
+    assert_response :unprocessable_entity
+    assert_not bought.reload.manual?(:fiat_value)
   end
 
   # The case that made this necessary. The venue said nothing, so the figure is ours — and it is

--- a/test/models/manual_value_test.rb
+++ b/test/models/manual_value_test.rb
@@ -57,17 +57,21 @@ class ManualValueTest < ActiveSupport::TestCase
     assert_equal 99.to_d, enriched(record.reload)[:fiat_value], 'theirs, once stated'
   end
 
-  # It beats even what the venue reported: a user correcting a venue is the whole point of being
-  # able to state a value, and the row says plainly that they did.
-  test 'a stated value beats the exchange, and the row admits whose figure it is' do
+  # The venue's own amount and price ARE the value. A figure typed in front of them would leave
+  # amount, price and value on one row that no longer multiply out — the one thing the column
+  # promises — so a row the venue valued takes no stated value: not written, and not read if one
+  # was written before this rule.
+  test 'a row the venue valued is not the user\'s to state' do
     record = create(:account_transaction, api_key: @key, exchange: @binance, entry_type: :buy,
                                           base_currency: 'BTC', base_amount: 1, quote_currency: 'USD',
                                           quote_amount: 20_000, transacted_at: @at)
-    record.set_manual(:fiat_value, 21_000)
-    record.save!
 
-    assert_equal 21_000.to_d, enriched(record.reload)[:fiat_value]
-    assert record.reload.manual?(:fiat_value)
+    assert_raises(ArgumentError) { record.set_manual(:fiat_value, 21_000) }
+
+    record.update_column(:manual_values, { 'fiat_value' => '21000' }) # written before the rule
+    row = enriched(record.reload)
+    assert_equal 20_000.to_d, row[:fiat_value]
+    assert_not row[:stated_value]
   end
 
   test 'clearing it hands the row back to our own price' do


### PR DESCRIPTION
The Value column offered a box on every transaction row, including rows whose amount and price came from the venue itself. A figure typed there stood in front of the venue's own, so a row could carry two answers — amount and price that no longer multiplied out to the value the tiles, chart and tax report were built on.

A row the venue valued now states that product and nothing else: no input, a refused write (422), and any figure written before this rule is ignored and no longer reported as stated. A stated value stays possible only where the record has no price at all — a rebate in a coin with no chart, a token whose ticker resolves to nothing — where it is a fact the record lacks rather than a second answer, and the page marks it as the user's.
