### PR TITLE
Price a symbol as the coin it meant, where and when it was booked

### DIFF
--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -249,10 +249,12 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # whole history.
   def load_prices(first_date)
     @prices = {}
-    touched(first_date).each do |symbol, from|
-      asset = Asset.find_by(symbol: symbol)
-      key = STOCK_CATEGORIES.include?(asset&.category) ? "stock:#{symbol}" : symbol
-      fetch_missing(symbol, asset, from)
+    touched(first_date).each do |symbol, (from, exchange)|
+      # A stock is a stock only on a venue that trades them: a coin sharing a ticker with a stock is
+      # priced as the coin on a crypto venue.
+      stock = Asset.find_by(symbol: symbol, category: STOCK_CATEGORIES) if exchange.stock_venue?
+      key = stock ? "stock:#{symbol}" : symbol
+      fetch_missing(symbol, stock, exchange, from)
       observed = HistoricalPrice.where(asset: key, currency: 'USD', date: from..@last_date)
                                 .pluck(:date, :price).to_h
       last = nil
@@ -268,7 +270,8 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
     end
   end
 
-  # Cash needs no price, and a symbol nothing ever touched needs no window.
+  # Cash needs no price, and a symbol nothing ever touched needs no window. The venue that first
+  # touched a symbol is the one its coin is read off (`Tax::AssetIdentity`).
   def touched(first_date)
     dates = {}
     @transactions.each do |transaction|
@@ -276,24 +279,27 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
       [transaction.base_currency, transaction.quote_currency, transaction.fee_currency].compact.each do |symbol|
         next if FIAT.include?(symbol) || STABLECOINS.include?(symbol)
 
-        dates[symbol] ||= date
+        dates[symbol] ||= [date, transaction.exchange]
       end
     end
     dates
   end
 
-  # One range per symbol, and only when the table does not already cover it — both fetchers check
-  # that for themselves. A symbol with no asset row has nowhere to fetch from and stays unpriced.
-  def fetch_missing(symbol, asset, from)
-    if STOCK_CATEGORIES.include?(asset&.category)
+  # One range per coin, and only when the table does not already cover it — both fetchers check
+  # that for themselves. A symbol that changed coin is two ranges; a symbol nobody can name a coin
+  # for has nowhere to fetch from and stays unpriced.
+  def fetch_missing(symbol, stock, exchange, from)
+    if stock
       key = @user.api_keys.includes(:exchange).find { |api_key| api_key.exchange.tickers.exists?(base: symbol) }
       return unless key
 
       price_service.stock_price_range(exchange: key.exchange, api_key: key, symbol: symbol,
                                       from: from, to: @last_date)
-    elsif asset&.external_id.present?
-      price_service.fetch_price_range(coin_id: asset.external_id, symbol: symbol, currency: 'USD',
-                                      from: from, to: @last_date)
+    else
+      Tax::AssetIdentity.coin_ids_over(symbol, exchange: exchange, from: from, to: @last_date).each do |range, coin_id|
+        price_service.fetch_price_range(coin_id: coin_id, symbol: symbol, currency: 'USD',
+                                        from: range.begin, to: range.end)
+      end
     end
   end
 

--- a/app/models/tax/CLAUDE.md
+++ b/app/models/tax/CLAUDE.md
@@ -112,6 +112,20 @@ Semantics every engine follows:
   warns (`PriceService#resolve_row_value`) — nothing reads that value, and a failed lookup would
   banner the whole report as incomplete. Their fee is priced and warns as on any row.
 
+## Which Coin a Symbol Means
+
+`Tax::AssetIdentity` — `assets.symbol` is not unique, a venue's ticker is not a coin id, and a
+symbol can change coin over time (Terra's LUNA before May 2022 is today's LUNC; MATIC's history
+lives under the coin that became POL). Resolution, in order: a curated alias (dated where the
+symbol changed hands, scoped to a venue where its listing differs from the catalogue), what the
+VENUE lists under that symbol (`tickers.base_asset`), the coin of that symbol by market rank.
+Never a stock for a crypto venue; a stock first for a stock venue. `PriceService` asks per row
+(venue + day) and the backfill asks per span (`coin_ids_over` splits a range at a dated alias).
+Only aliases verified against the provider's coin records go in `ALIASES`; a symbol nobody can
+name a coin for stays unpriced rather than guessed. Prices are still stored by SYMBOL, so two
+coins sharing a ticker at the same time would share one price row — keying by coin id is the
+upgrade path.
+
 ## Price and FX Flow
 
 1. `PriceService#prefetch` — scans transactions, loads from the `historical_prices` table first

--- a/app/models/tax/asset_identity.rb
+++ b/app/models/tax/asset_identity.rb
@@ -1,0 +1,93 @@
+module Tax
+  # Which coin a symbol means — for pricing, per venue and per day.
+  #
+  # `assets.symbol` is not unique, a venue's ticker is not a coin id, and a symbol can change coin
+  # over time: Terra's LUNA before May 2022 is today's LUNC, and MATIC's history lives under the
+  # coin that became POL. The catalogue knows none of this, and `Asset.find_by(symbol:)` answered
+  # with whichever row came first — a stock for DAR, the wrong LIT, the new Terra for the old.
+  #
+  # So, in order: an alias, dated where the symbol changed hands and scoped where a venue's listing
+  # differs from the catalogue's; what the VENUE lists under that symbol, which is its own fact; the
+  # coin of that symbol by market rank. Never a stock for a crypto venue — and a stock first for a
+  # stock venue, which trades coins as well.
+  #
+  # ponytail: prices are still stored by SYMBOL (`historical_prices.asset`), so two coins sharing a
+  # ticker on two venues at the same time would share one price row. A dated alias never overlaps
+  # itself. Keying the table by coin id is the upgrade path.
+  module AssetIdentity
+    Alias = Data.define(:symbol, :coin, :exchange, :until)
+
+    # Verified against the provider's own coin records. `until` is the last day the alias holds;
+    # `exchange` a venue's `name_id` where only that venue's listing means this coin.
+    ALIASES = [
+      # Terra collapsed in May 2022: the chain relaunched as `terra-luna-2`, the original became LUNC.
+      Alias.new(symbol: 'LUNA', coin: 'terra-luna', exchange: nil, until: Date.new(2022, 5, 27)),
+      # MATIC migrated to POL; its whole history stays under the original id.
+      Alias.new(symbol: 'MATIC', coin: 'matic-network', exchange: nil, until: nil),
+      # Listed on Binance under a symbol the catalogue no longer carries, or carries as another coin.
+      Alias.new(symbol: 'LIT', coin: 'litentry', exchange: 'binance', until: nil),
+      Alias.new(symbol: 'GAL', coin: 'project-galaxy', exchange: 'binance', until: nil),
+      Alias.new(symbol: 'DAR', coin: 'mines-of-dalarnia', exchange: 'binance', until: nil),
+      Alias.new(symbol: 'PNT', coin: 'pnetwork', exchange: nil, until: nil),
+      Alias.new(symbol: 'BURGER', coin: 'burger-swap', exchange: nil, until: nil)
+    ].freeze
+
+    STOCK = 'Stock'.freeze
+    CRYPTO = 'Cryptocurrency'.freeze
+
+    class << self
+      def coin_id(symbol, exchange: nil, at: nil)
+        alias_coin(symbol, exchange: exchange, at: at) || catalogue_coin(symbol, exchange: exchange)
+      end
+
+      # The dated, venue-scoped answer; nil where no alias speaks. Cheap — no query — so a caller
+      # may ask per row and cache only `catalogue_coin`.
+      def alias_coin(symbol, exchange: nil, at: nil)
+        return if symbol.blank?
+
+        ALIASES.find { |entry| entry.symbol == symbol && venue_fits?(entry, exchange) && holds_on?(entry, at) }&.coin
+      end
+
+      # What the venue lists, then the catalogue by rank.
+      def catalogue_coin(symbol, exchange: nil)
+        return if symbol.blank?
+
+        (listed(symbol, exchange) || catalogued(symbol, exchange))&.external_id
+      end
+
+      # The coin ids a symbol means over a span of days, as [range, coin id] pairs: one pair unless
+      # a dated alias splits the span.
+      def coin_ids_over(symbol, exchange:, from:, to:)
+        cuts = ALIASES.select { |entry| entry.symbol == symbol && entry.until && venue_fits?(entry, exchange) }
+                      .map(&:until).select { |cut| cut >= from && cut < to }.sort
+        starts = [from] + cuts.map { |cut| cut + 1 }
+        ends = cuts + [to]
+        starts.zip(ends).filter_map do |first, last|
+          coin = coin_id(symbol, exchange: exchange, at: first)
+          [first..last, coin] if coin
+        end
+      end
+
+      private
+
+      def venue_fits?(entry, exchange)
+        entry.exchange.nil? || entry.exchange == exchange&.name_id
+      end
+
+      def holds_on?(entry, at)
+        entry.until.nil? || (at && at.to_date <= entry.until)
+      end
+
+      def listed(symbol, exchange)
+        asset = exchange&.tickers&.find_by(base: symbol)&.base_asset
+        asset if asset && (exchange.stock_venue? || asset.category == CRYPTO)
+      end
+
+      def catalogued(symbol, exchange)
+        assets = Asset.where(symbol: symbol).order(Arel.sql('market_cap_rank IS NULL, market_cap_rank'), :id).to_a
+        stock = assets.find { |asset| asset.category == STOCK } if exchange&.stock_venue?
+        stock || assets.find { |asset| asset.category == CRYPTO }
+      end
+    end
+  end
+end

--- a/app/models/tax/price_service.rb
+++ b/app/models/tax/price_service.rb
@@ -53,9 +53,9 @@ module Tax
         next if tx.quote_currency.present? && tx.quote_amount.present? &&
                 (STABLECOINS.include?(tx.quote_currency) || FIAT_CURRENCIES.include?(tx.quote_currency))
 
-        add_coin_date(coins_needed, tx.base_currency, tx.transacted_at)
+        add_coin_date(coins_needed, tx.base_currency, tx.transacted_at, tx.exchange)
         if tx.fee_amount.present? && tx.fee_amount.positive? && !STABLECOINS.include?(tx.fee_currency)
-          add_coin_date(coins_needed, tx.fee_currency, tx.transacted_at)
+          add_coin_date(coins_needed, tx.fee_currency, tx.transacted_at, tx.exchange)
         end
       end
 
@@ -64,19 +64,19 @@ module Tax
         add_coin_dates(coins_needed, 'BTC', all_dates) if all_dates.any?
       end
 
-      # Fetch each coin's full range in one API call
-      fetchable = coins_needed.select { |sym, _| asset_to_coingecko_id(sym) }
-      total_coins = fetchable.size
-      fetchable.each_with_index do |(symbol, info), index|
-        coin_id = asset_to_coingecko_id(symbol)
-        Rails.logger.info("[TaxReport] Fetching prices for #{symbol} (#{index + 1}/#{total_coins})")
+      # One call per COIN over its full range — a symbol that changed coin is two coins, each over
+      # the days it was that coin.
+      coins_needed.each_with_index do |((symbol, coin_id), info), index|
+        Rails.logger.info("[TaxReport] Fetching prices for #{symbol} (#{index + 1}/#{coins_needed.size})")
         fetch_price_range(coin_id: coin_id, symbol: symbol, currency: currency,
                           from: info[:min], to: info[:max])
-        on_progress&.call(index + 1, total_coins)
+        on_progress&.call(index + 1, coins_needed.size)
       end
     end
 
-    def price_at(asset:, currency:, timestamp:)
+    # `exchange` is where the row was booked: which coin a symbol means depends on the venue that
+    # listed it and the day it was booked (`Tax::AssetIdentity`).
+    def price_at(asset:, currency:, timestamp:, exchange: nil)
       return 1.to_d if asset == currency
       return stablecoin_rate(currency, timestamp) if STABLECOINS.include?(asset)
 
@@ -97,7 +97,7 @@ module Tax
       end
 
       # Fetch from CoinGecko
-      price = fetch_single_price(asset: asset, currency: currency, timestamp: timestamp)
+      price = fetch_single_price(asset: asset, currency: currency, timestamp: timestamp, exchange: exchange)
       if price.nil? || price.zero?
         @warnings << "#{asset}/#{currency} #{timestamp.to_date}"
         return 0.to_d
@@ -388,14 +388,20 @@ module Tax
       FIAT_CURRENCIES.include?(currency) || STABLECOINS.include?(currency)
     end
 
-    def add_coin_date(coins, symbol, timestamp)
+    # Keyed by symbol AND coin: a symbol that changed coin (`Tax::AssetIdentity`) is fetched as each
+    # coin over its own days. A symbol nobody can name a coin for is not fetched at all.
+    def add_coin_date(coins, symbol, timestamp, exchange = nil)
       return if symbol.blank? || FIAT_CURRENCIES.include?(symbol)
 
+      coin_id = coin_id_for(symbol, exchange, timestamp)
+      return unless coin_id
+
       date = timestamp.to_date
-      coins[symbol] ||= { min: date, max: date, dates: Set.new }
-      coins[symbol][:min] = date if date < coins[symbol][:min]
-      coins[symbol][:max] = date if date > coins[symbol][:max]
-      coins[symbol][:dates] << date
+      key = [symbol, coin_id]
+      coins[key] ||= { min: date, max: date, dates: Set.new }
+      coins[key][:min] = date if date < coins[key][:min]
+      coins[key][:max] = date if date > coins[key][:max]
+      coins[key][:dates] << date
     end
 
     def add_coin_dates(coins, symbol, dates)
@@ -403,6 +409,12 @@ module Tax
         date = d.is_a?(Date) ? d : d.to_date
         add_coin_date(coins, symbol, date.to_datetime)
       end
+    end
+
+    # The alias is a date's question and costs no query; the catalogue answer is cached per venue.
+    def coin_id_for(symbol, exchange, timestamp)
+      Tax::AssetIdentity.alias_coin(symbol, exchange: exchange, at: timestamp) ||
+        (@coin_ids ||= {})[[symbol, exchange&.id]] ||= Tax::AssetIdentity.catalogue_coin(symbol, exchange: exchange)
     end
 
     def resolve_fiat_value(record, currency)
@@ -434,7 +446,8 @@ module Tax
       cash = cash_leg_value(record)
       return cash if cash
 
-      price = price_at(asset: record.base_currency, currency: currency, timestamp: record.transacted_at)
+      price = price_at(asset: record.base_currency, currency: currency, timestamp: record.transacted_at,
+                       exchange: record.exchange)
       price * record.base_amount.to_d
     end
 
@@ -449,7 +462,8 @@ module Tax
       elsif STABLECOINS.include?(record.fee_currency)
         convert_fiat(amount: record.fee_amount.to_d, from: 'USD', to: currency, timestamp: record.transacted_at)
       else
-        price = price_at(asset: record.fee_currency, currency: currency, timestamp: record.transacted_at)
+        price = price_at(asset: record.fee_currency, currency: currency, timestamp: record.transacted_at,
+                         exchange: record.exchange)
         price * record.fee_amount.to_d
       end
     end
@@ -504,8 +518,8 @@ module Tax
     # prices that were fetched anyway, so `fetch_price_range` stores them on the way past and the
     # next row on a neighbouring date costs nothing — which is also why this delegates rather than
     # keeping a second, subtly different fetch-and-store of its own.
-    def fetch_single_price(asset:, currency:, timestamp:)
-      coin_id = asset_to_coingecko_id(asset)
+    def fetch_single_price(asset:, currency:, timestamp:, exchange: nil)
+      coin_id = coin_id_for(asset, exchange, timestamp)
       return nil unless coin_id
 
       date = timestamp.to_date
@@ -553,11 +567,6 @@ module Tax
       raise Tax::EcbFxRates::MissingRate, "#{from}/#{to} #{timestamp.to_date}" unless btc_from.positive? && btc_to.positive?
 
       btc_to / btc_from
-    end
-
-    def asset_to_coingecko_id(symbol)
-      @asset_id_cache ||= {}
-      @asset_id_cache[symbol] ||= Asset.find_by(symbol: symbol)&.external_id
     end
   end
 end

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -319,4 +319,22 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
     assert_equal 30_000.to_d, last.invested_usd, 'the 10,000 lot left, not half of 40,000'
     assert_equal Tracker::Ledger.for(@user).total_invested_usd, last.invested_usd
   end
+
+  test 'a symbol that changed coin is fetched as each coin over its own days' do
+    create(:asset, symbol: 'LUNA', name: 'Terra', external_id: 'terra-luna-2', category: 'Cryptocurrency')
+    tx(:other_income, day: 0, base_currency: 'LUNA', base_amount: 1, quote_currency: nil, quote_amount: nil,
+                      transacted_at: Time.utc(2022, 5, 20, 12))
+    tx(:other_income, day: 0, base_currency: 'LUNA', base_amount: 1, quote_currency: nil, quote_amount: nil,
+                      transacted_at: Time.utc(2022, 6, 5, 12))
+    # The ledger's own pricing fetches per row-date on the way; the sweep's ranges are the two below.
+    Tax::PriceService.any_instance.stubs(:fetch_price_range)
+    Tax::PriceService.any_instance.expects(:fetch_price_range)
+                     .with(coin_id: 'terra-luna', symbol: 'LUNA', currency: 'USD',
+                           from: Date.new(2022, 5, 20), to: Date.new(2022, 5, 27)).once
+    Tax::PriceService.any_instance.expects(:fetch_price_range)
+                     .with(coin_id: 'terra-luna-2', symbol: 'LUNA', currency: 'USD',
+                           from: Date.new(2022, 5, 28), to: Date.new(2022, 6, 10)).once
+
+    travel_to(Time.utc(2022, 6, 11, 12)) { PortfolioSnapshot::BackfillJob.perform_now(@user.id) }
+  end
 end

--- a/test/models/tax/asset_identity_test.rb
+++ b/test/models/tax/asset_identity_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+# Which coin a symbol means. `assets.symbol` is not unique, a venue's ticker is not a coin id, and
+# a symbol can change coin over time — and the price a row gets is only as right as that answer.
+class Tax::AssetIdentityTest < ActiveSupport::TestCase
+  setup do
+    @binance = create(:binance_exchange)
+    @kraken = create(:kraken_exchange)
+    @alpaca = create(:alpaca_exchange)
+  end
+
+  def coin(symbol, external_id, category: 'Cryptocurrency', rank: nil)
+    create(:asset, symbol: symbol, name: external_id, external_id: external_id, category: category, market_cap_rank: rank)
+  end
+
+  test 'a crypto venue never means a stock' do
+    coin('XYZ', 'alpaca_xyz', category: 'Stock')
+
+    assert_nil Tax::AssetIdentity.coin_id('XYZ', exchange: @binance)
+
+    coin('XYZ', 'xyz-coin')
+    assert_equal 'xyz-coin', Tax::AssetIdentity.coin_id('XYZ', exchange: @binance)
+  end
+
+  test 'a stock venue means the stock first, and the coin where there is no stock' do
+    coin('AAA', 'aaa-coin')
+    coin('AAA', 'alpaca_aaa', category: 'Stock')
+    coin('BBB', 'bbb-coin')
+
+    assert_equal 'alpaca_aaa', Tax::AssetIdentity.coin_id('AAA', exchange: @alpaca)
+    assert_equal 'bbb-coin', Tax::AssetIdentity.coin_id('BBB', exchange: @alpaca)
+  end
+
+  test 'what the venue lists under a symbol is what it means there; elsewhere, the coin by rank' do
+    big = coin('XYZ', 'xyz-big', rank: 5)
+    small = coin('XYZ', 'xyz-small', rank: 900)
+    create(:ticker, exchange: @binance, base_asset: small, quote_asset: create(:asset, symbol: 'USDT', name: 'Tether'))
+
+    assert_equal 'xyz-small', Tax::AssetIdentity.coin_id('XYZ', exchange: @binance), 'Binance lists the small one'
+    assert_equal 'xyz-big', Tax::AssetIdentity.coin_id('XYZ', exchange: @kraken)
+    assert_equal 'xyz-big', Tax::AssetIdentity.coin_id('XYZ')
+    assert_equal big.external_id, Tax::AssetIdentity.coin_id('XYZ')
+  end
+
+  test 'a symbol that changed coin means the coin it was that day' do
+    coin('LUNA', 'terra-luna-2')
+
+    assert_equal 'terra-luna', Tax::AssetIdentity.coin_id('LUNA', exchange: @binance, at: Time.utc(2021, 9, 10))
+    assert_equal 'terra-luna-2', Tax::AssetIdentity.coin_id('LUNA', exchange: @binance, at: Time.utc(2025, 6, 22))
+    assert_equal 'terra-luna-2', Tax::AssetIdentity.coin_id('LUNA', exchange: @binance), 'no day asked: the coin it is'
+    assert_equal [[Date.new(2021, 9, 1)..Date.new(2022, 5, 27), 'terra-luna'],
+                  [Date.new(2022, 5, 28)..Date.new(2025, 6, 30), 'terra-luna-2']],
+                 Tax::AssetIdentity.coin_ids_over('LUNA', exchange: @binance, from: Date.new(2021, 9, 1), to: Date.new(2025, 6, 30))
+  end
+
+  test 'a symbol the catalogue dropped means its successor' do
+    assert_equal 'matic-network', Tax::AssetIdentity.coin_id('MATIC', exchange: @binance, at: Time.utc(2021, 7, 1))
+  end
+
+  test 'an alias scoped to a venue speaks only there' do
+    coin('LIT', 'lighter', rank: 77)
+
+    assert_equal 'litentry', Tax::AssetIdentity.coin_id('LIT', exchange: @binance)
+    assert_equal 'lighter', Tax::AssetIdentity.coin_id('LIT', exchange: @kraken)
+  end
+end

--- a/test/models/tax/price_service_identity_test.rb
+++ b/test/models/tax/price_service_identity_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# The price a row gets is only as right as the coin its symbol is taken to mean.
+class Tax::PriceServiceIdentityTest < ActiveSupport::TestCase
+  setup do
+    Tax::EcbFxRates.stubs(:ensure_loaded!)
+    @user = create(:user)
+    @binance = create(:binance_exchange)
+    @key = create(:api_key, user: @user, exchange: @binance)
+  end
+
+  def row(symbol, at)
+    create(:account_transaction, api_key: @key, exchange: @binance, entry_type: :other_income, base_currency: symbol,
+                                 base_amount: 1, quote_currency: nil, quote_amount: nil, transacted_at: at)
+  end
+
+  def enrich
+    Tax::PriceService.new.enrich(AccountTransaction.for_user(@user).order(:transacted_at).to_a, currency: 'USD')
+  end
+
+  test 'a symbol that changed coin is fetched as each coin over its own days' do
+    create(:asset, symbol: 'LUNA', name: 'Terra', external_id: 'terra-luna-2', category: 'Cryptocurrency')
+    row('LUNA', Time.utc(2021, 9, 10, 12))
+    row('LUNA', Time.utc(2025, 6, 22, 12))
+    prices = { 'terra-luna' => [[Time.utc(2021, 9, 10).to_i * 1000, 40]],
+               'terra-luna-2' => [[Time.utc(2025, 6, 22).to_i * 1000, 0.2]] }
+    fetched = []
+    MarketData.stubs(:get_historical_price_range).with do |args|
+      fetched << args[:coin_id]
+      true
+    end.returns(Result::Success.new('prices' => prices['terra-luna']))
+    MarketData.stubs(:get_historical_price_range).with { |args| args[:coin_id] == 'terra-luna-2' }
+              .returns(Result::Success.new('prices' => prices['terra-luna-2']))
+
+    rows = enrich
+
+    assert_equal %w[terra-luna terra-luna-2], fetched.sort, 'the 2021 row is Terra Classic, the 2025 row the relaunched chain'
+    assert_equal([40.to_d, 0.2.to_d], rows.map { |r| r[:fiat_value] })
+  end
+
+  test 'a coin is never priced off a stock that shares its ticker' do
+    create(:asset, symbol: 'XYZ', name: 'XYZ Inc', external_id: 'alpaca_xyz', category: 'Stock')
+    row('XYZ', Time.utc(2024, 1, 5, 12))
+    MarketData.expects(:get_historical_price_range).never
+
+    rows = enrich
+
+    assert rows.sole[:price_missing], 'unpriced, honestly — not priced as a share of XYZ Inc'
+  end
+end


### PR DESCRIPTION
`Asset.find_by(symbol:)` answered with whichever row came first — a stock for a ticker a coin shares, the wrong coin among two that share a symbol, the relaunched Terra for a 2021 LUNA row, nothing at all for MATIC. Every such row was priced at zero and reported as missing a price it could never have found.

`Tax::AssetIdentity` says which coin a symbol means, per venue and per day: a curated alias first (dated where the symbol changed hands, scoped to a venue where its listing differs from the catalogue, and only where verified against the provider's own coin records), then what the venue itself lists under that symbol, then the coin of that symbol by market rank. Never a stock for a crypto venue; a stock first for a stock venue, which trades coins as well.

Pricing asks per row; the chart's backfill asks per span and splits a range at a dated alias, so a symbol that changed coin is fetched as each coin over its own days. A symbol nobody can name a coin for stays unpriced rather than guessed.
