### PR TITLE
Keep the record's price in the venue's own currency

### DIFF
--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -169,13 +169,13 @@ module TrackerHelper
     sourced(price&.positive? ? denomination.convert(price.to_d * record.base_amount.to_d) : nil, :ours)
   end
 
-  # What one unit changed hands at, in the column's own unit — derived from the row's worth rather
-  # than computed a second way, so Price times Amount comes to Value by construction. Two adjacent
-  # money columns that do not multiply out is the same broken promise as two disagreeing totals.
-  def tracker_row_price(record, value)
-    return if value.nil? || !record.base_amount.to_d.positive?
+  # What one unit changed hands at, as the VENUE booked it, in the venue's own currency — a fact of
+  # the record, like Amount and Fee, never a figure worked out from a valuation. A row the venue
+  # gave no price for shows none; its worth, if any, is the Value column's business.
+  def tracker_row_price(record)
+    return unless record.venue_valued? && record.base_amount.to_d.positive?
 
-    value / record.base_amount.to_d
+    "#{tracker_amount(record.quote_amount.to_d / record.base_amount.to_d)} #{record.quote_currency}"
   end
 
   # A signed percentage, one decimal — the reading on every P/L cell on the page.

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -33,9 +33,10 @@
               <%# The same three figures the bot log drops: what was traded, what it cost, and what
                   was paid to trade it. The price is a market level, not a balance, and stays. %>
               <% unless hide_money %><th><%= t('tracker.columns.amount') %></th><% end %>
-              <%# Both money columns are written in ONE currency, so the unit is named here once
-                  rather than repeated on every row — and a bare number in the cell is unambiguous. %>
-              <th><%= t('tracker.columns.price') %> <small><%= current_user.denomination.unit %></small></th>
+              <%# Price is the venue's, in the venue's own currency per row, as Fee is. Value is the one
+                  column in the reader's currency, so its unit is named here once rather than on every
+                  row — and a bare number in that cell is unambiguous. %>
+              <th><%= t('tracker.columns.price') %></th>
               <% unless hide_money %>
                 <th><%= t('tracker.columns.quote_amount') %> <small><%= current_user.denomination.unit %></small></th>
                 <th><%= t('tracker.columns.fee') %></th>

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -3,11 +3,11 @@
     set up the page's instance variables. `User#denomination` memoises, so this costs one object. %>
 <% denomination = current_user.denomination %>
 <% asset = tracker_row_asset(at.base_currency) %>
-<%# What the row was worth, and whose figure it is. Our own price is the PLACEHOLDER: it is what the
-    figures are built on, shown rather than hidden, and a typed value replaces it. Clearing the box
-    hands the row back to us. Price is DERIVED from that same worth, so the two money columns are one
-    figure read two ways instead of two calculations that can disagree — and both are written in the
-    reader's own currency, which the header names once. %>
+<%# Amount, Price and Fee are the RECORD, in the venue's own currency per row. Value is the one
+    computed column, and the only one in the reader's own currency, which its header names once:
+    what the row was worth, and whose figure it is. Our own price is the PLACEHOLDER — what the
+    figures are built on, shown rather than hidden — and where the venue gave no price a typed
+    value replaces it; clearing the box hands the row back to us. %>
 <% value, source = tracker_row_value(at, denomination) %>
 <% shown = value&.round(2) %>
 <tr id="<%= dom_id(at) %>" class="tracker-row" data-order-filter-target="row" data-order-type="<%= tracker_row_types(at) %>">
@@ -32,7 +32,7 @@
   </td>
   <td class="text-left"><span class="tracker-row__asset"><% if asset %><%= render 'assets/logo', image_url: asset.image_url, color: asset.color %><% end %><%= at.base_currency %></span></td>
   <% unless hide_money %><td><%= tracker_amount(at.base_amount) %></td><% end %>
-  <td><%= tracker_amount(tracker_row_price(at, value)) || '—' %></td>
+  <td><%= tracker_row_price(at) || '—' %></td>
   <% unless hide_money %>
     <td class="tracker-row__value tracker-row__value--<%= source || 'none' %>">
       <%# A row whose base is money, or whose amount and price the venue gave, states a fact, not a

--- a/test/integration/tracker_manual_value_test.rb
+++ b/test/integration/tracker_manual_value_test.rb
@@ -122,9 +122,10 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     assert_includes row_cell(deposited).first['class'], 'tracker-row__value--none'
   end
 
-  # Two adjacent money columns that do not multiply out is the same broken promise as two
-  # disagreeing totals — so Price is READ OFF the value rather than computed a second way.
-  test 'price times amount comes to value, in that same unit' do
+  # Price is the RECORD — what the venue booked, in the venue's own currency — never a figure worked
+  # back from a valuation. A row the venue gave no price for shows none; its worth is the Value
+  # column's business, and that is where our own price stands as the placeholder.
+  test 'a row with no price of its own shows none; the value column carries our figure' do
     HistoricalPrice.store(asset: 'BTC', currency: 'USD', date: @t.to_date, price: 30_000)
     rebate = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
                                           entry_type: :airdrop, base_currency: 'BTC', base_amount: 0.5,
@@ -133,8 +134,22 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     get tracker_path
     cells = css_select("##{ActionView::RecordIdentifier.dom_id(rebate)} td").map { |td| td.text.strip }
 
-    assert_includes cells, '30,000.00', 'the price, in the column unit'
+    assert_includes cells, '—', 'no price of its own'
+    assert_not_includes cells, '30,000.00', 'ours is a valuation, not the record'
     assert_equal '15000.0', row_cell(rebate).first.css('input[type="number"]').first['placeholder']
+  end
+
+  test 'price is the venue\'s own, in the venue\'s own currency, whatever the page is shown in' do
+    Denomination.stubs(:for).returns(Denomination.new('EUR', '0.86'.to_d))
+    bought = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
+                                          entry_type: :buy, base_currency: 'BTC', base_amount: 0.5,
+                                          quote_currency: 'USDT', quote_amount: 25_000, transacted_at: @t)
+
+    get tracker_path
+    cells = css_select("##{ActionView::RecordIdentifier.dom_id(bought)} td").map { |td| td.text.strip }
+
+    assert_includes cells, '50,000.00 USDT', 'the record, not a conversion'
+    assert_select 'th', text: /\A#{I18n.t('tracker.columns.price')}\z/, count: 1
   end
 
   test 'a typed value is stored, marked as the user&apos;s, and shown in the box' do


### PR DESCRIPTION
The transactions table is a record: Amount, Price and Fee are what the venue booked, in the venue's own currency per row. Price had been worked back from the row's valuation and written in the reader's display currency — a second computed figure beside Value, and a rebate the venue never priced showed a price it never had.

Price is now the venue's own figure, the quote over the amount in the quote currency, as Fee already is; a row the venue gave no price for shows none. Value stays the one computed column and the only one in the reader's currency, so its header names the unit once.
