### PR TITLE
A row with a cash leg beside it is the venue's figure too

### DIFF
--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -159,7 +159,11 @@ module TrackerHelper
   def tracker_row_value(record, denomination)
     return cash_value(record, denomination) if money?(record.base_currency)
 
-    return sourced(in_display(record.quote_amount, record.quote_currency, record, denomination), :exchange) if record.venue_valued?
+    return sourced(in_display(record.quote_amount, record.quote_currency, record, denomination), :exchange) if record.quoted?
+
+    if (cash = with_group(record).cash_counterpart)
+      return sourced(in_display(cash.base_amount, cash.base_currency, record, denomination), :exchange)
+    end
 
     stated = record.manual_value(:fiat_value)
     return [denomination.convert(stated), :stated] if stated
@@ -173,9 +177,35 @@ module TrackerHelper
   # the record, like Amount and Fee, never a figure worked out from a valuation. A row the venue
   # gave no price for shows none; its worth, if any, is the Value column's business.
   def tracker_row_price(record)
-    return unless record.venue_valued? && record.base_amount.to_d.positive?
+    return unless record.base_amount.to_d.positive?
 
-    "#{tracker_amount(record.quote_amount.to_d / record.base_amount.to_d)} #{record.quote_currency}"
+    if record.quoted?
+      "#{tracker_amount(record.quote_amount.to_d / record.base_amount.to_d)} #{record.quote_currency}"
+    elsif (cash = with_group(record).cash_counterpart)
+      "#{tracker_amount(cash.base_amount.to_d / record.base_amount.to_d)} #{cash.base_currency}"
+    end
+  end
+
+  # The page's rows hand their groups to each other in one query, so a row does not ask for its
+  # own. A row rendered on its own (a turbo stream) is not in the page's set and asks itself.
+  def with_group(record)
+    key = [record.exchange_id, record.group_id]
+    record.group_rows = tracker_row_groups[key] if record.group_id.present? && tracker_row_groups.key?(key)
+    record
+  end
+
+  def tracker_row_groups
+    @tracker_row_groups ||= begin
+      rows = (@account_transactions || []).to_a
+      keys = rows.filter_map { |row| [row.exchange_id, row.group_id] if row.group_id.present? }.uniq
+      if keys.empty?
+        {}
+      else
+        AccountTransaction.for_user(current_user)
+                          .where(exchange_id: keys.map(&:first).uniq, group_id: keys.map(&:last).uniq)
+                          .group_by { |row| [row.exchange_id, row.group_id] }
+      end
+    end
   end
 
   # A signed percentage, one decimal — the reading on every P/L cell on the page.

--- a/app/models/account_transaction.rb
+++ b/app/models/account_transaction.rb
@@ -46,11 +46,29 @@ class AccountTransaction < ApplicationRecord
     number
   end
 
-  # A row the venue itself valued: amount and price of its own, and the value is their product. A
-  # figure typed in front of it would leave the three columns no longer multiplying out, so such a
-  # row takes no stated value — not written, and not read if one was written before this rule.
+  # A row the venue itself valued: amount and price of its own, or a cash leg beside it in its group
+  # — a Convert into USDC says what the coins fetched as plainly as a quote would. Its worth is that
+  # figure, and a figure typed in front of it would leave the columns no longer multiplying out, so
+  # such a row takes no stated value — not written, and not read if one was written before this rule.
   def venue_valued?
+    quoted? || cash_counterpart.present?
+  end
+
+  def quoted?
     quote_amount.present? && Tracker::UnfundedCash.cash?(quote_currency)
+  end
+
+  # The cash row opposite this one in a two-leg group: a swap-out's cash in-leg, a swap-in's or a
+  # buy's cash out-leg. Two legs only — a sweep of many coins into one credit shares its cash out
+  # by the engine's own rule, which a row on its own cannot repeat. A page of rows hands the groups
+  # in (`group_rows=`); a row on its own asks for its group.
+  attr_writer :group_rows
+
+  def cash_counterpart
+    return @cash_counterpart if defined?(@cash_counterpart)
+
+    rows = group_rows
+    @cash_counterpart = rows.size == 2 ? rows.find { |row| row.id != id && Tracker::UnfundedCash.cash?(row.base_currency) && opposite?(row) } : nil
   end
 
   validates :base_currency, presence: true
@@ -114,6 +132,18 @@ class AccountTransaction < ApplicationRecord
   def linked? = linked_transaction_id.present? || inverse_link.present?
 
   private
+
+  IN_LEGS = %w[buy swap_in].freeze
+  OUT_LEGS = %w[sell swap_out].freeze
+
+  def group_rows
+    @group_rows ||= group_id.blank? ? [] : AccountTransaction.where(user_id: user_id, exchange_id: exchange_id, group_id: group_id).to_a
+  end
+
+  def opposite?(row)
+    (IN_LEGS.include?(entry_type) && OUT_LEGS.include?(row.entry_type)) ||
+      (OUT_LEGS.include?(entry_type) && IN_LEGS.include?(row.entry_type))
+  end
 
   def linked_transaction_is_valid
     linked = linked_transaction

--- a/app/models/tax/price_service.rb
+++ b/app/models/tax/price_service.rb
@@ -47,8 +47,8 @@ module Tax
         # A row the user has priced needs no price of ours, and must not be counted among the missing
         # ones — a report is not incomplete over a figure it was handed. Nor does a row the cash leg
         # beside it already values.
-        next if tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !tx.venue_valued?
         next if cash_leg_value(tx)
+        next if tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !tx.quoted?
         next if tx.quote_currency == currency && tx.quote_amount.present?
         next if tx.quote_currency.present? && tx.quote_amount.present? &&
                 (STABLECOINS.include?(tx.quote_currency) || FIAT_CURRENCIES.include?(tx.quote_currency))
@@ -153,7 +153,7 @@ module Tax
           price_missing: price_missing,
           # A figure the user stated by hand rather than one the venue reported or we priced. Carried
           # through so the tax report can disclose it: a stated cost is defensible, a silent one is not.
-          stated_value: tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !tx.venue_valued?,
+          stated_value: tx.respond_to?(:manual?) && tx.manual?(:fiat_value) && !valued_by_venue?(tx),
           exchange: tx.exchange.name_id,
           linked: links.key?(tx.id) || linked_deposit_ids.include?(tx.id),
           transfer_fee_amount: transfer_fee_amount(tx, links, deposit_amounts)
@@ -275,6 +275,12 @@ module Tax
 
     def cash_leg_value(transaction)
       @cash_legs&.dig(transaction.id, :fiat_value)
+    end
+
+    # By a quote of its own or by the cash leg beside it — without a query per row: the group
+    # context is already built.
+    def valued_by_venue?(transaction)
+      (transaction.respond_to?(:quoted?) && transaction.quoted?) || cash_leg_value(transaction).present?
     end
 
     # Where a legless row gets its value: the cash leg opposite it in its group. Kraken books every
@@ -436,15 +442,16 @@ module Tax
                             timestamp: record.transacted_at)
       end
 
+      # The cash leg beside it is the venue's figure too: what the coins fetched, or cost.
+      cash = cash_leg_value(record)
+      return cash if cash
+
       # Then what the USER says it was worth, ahead of everything the app would have to guess. This
       # is the single point every consumer of a priced row passes through, so the tiles, the chart,
       # the positions and the tax report inherit a stated value without knowing it exists. Stated
       # in USD, like everything else behind the page.
       stated = record.respond_to?(:manual_value) && record.manual_value(:fiat_value)
       return convert_fiat(amount: stated, from: 'USD', to: currency, timestamp: record.transacted_at) if stated
-
-      cash = cash_leg_value(record)
-      return cash if cash
 
       price = price_at(asset: record.base_currency, currency: currency, timestamp: record.transacted_at,
                        exchange: record.exchange)

--- a/test/integration/tracker_manual_value_test.rb
+++ b/test/integration/tracker_manual_value_test.rb
@@ -41,6 +41,29 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     assert_equal '20,000.00', cell.text.strip
   end
 
+  # A Convert into cash says what the coins fetched as plainly as a quote would: the cash leg beside
+  # the coin leg is its price and its value, and there is nothing here for a user to state either.
+  test 'a convert into cash is the venue&apos;s figure, and not a box' do
+    swapped_out = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
+                                               entry_type: :swap_out, base_currency: 'BNB', base_amount: 0.75,
+                                               quote_currency: nil, quote_amount: nil, group_id: 'convert-1',
+                                               transacted_at: @t)
+    create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
+                                 entry_type: :swap_in, base_currency: 'USDC', base_amount: 450,
+                                 quote_currency: nil, quote_amount: nil, group_id: 'convert-1', transacted_at: @t)
+
+    cell = row_cell(swapped_out).first
+    cells = css_select("##{ActionView::RecordIdentifier.dom_id(swapped_out)} td").map { |td| td.text.strip }
+
+    assert_includes cell['class'], 'tracker-row__value--exchange'
+    assert_empty cell.css('input'), 'nothing here for a user to state'
+    assert_equal '450.00', cell.text.strip
+    assert_includes cells, '600.00 USDC', 'what one BNB fetched, in what it fetched'
+
+    patch value_tracker_transaction_path(id: swapped_out.id), params: { value: '500' }
+    assert_response :unprocessable_entity
+  end
+
   test 'a value the exchange reported is not the user&apos;s to state' do
     bought = create(:account_transaction, user: @user, api_key: @key, exchange: @binance,
                                           entry_type: :buy, base_currency: 'BTC', base_amount: 1,

--- a/test/models/tax/price_service_swap_legs_test.rb
+++ b/test/models/tax/price_service_swap_legs_test.rb
@@ -140,16 +140,18 @@ class Tax::PriceServiceSwapLegsTest < ActiveSupport::TestCase
     assert_nil rows['ETH'][:fee_amount]
   end
 
-  test 'a stated value stands in front of the cash row' do
+  # The cash row IS the venue's figure: a typed value is neither written in front of it nor read
+  # if one was written before the rule.
+  test 'the cash row stands in front of a stated value' do
     leg(:sell, 'EUR', 1_000)
     bought = leg(:buy, 'BTC', 0.05)
-    bought.set_manual(:fiat_value, 999)
-    bought.save!
+    assert_raises(ArgumentError) { bought.set_manual(:fiat_value, 999) }
+    bought.update_column(:manual_values, { 'fiat_value' => '999' })
 
     rows, = enrich
 
-    assert_equal 999.to_d, rows['BTC'][:fiat_value]
-    assert rows['BTC'][:stated_value]
+    assert_equal 1_250.to_d, rows['BTC'][:fiat_value]
+    assert_not rows['BTC'][:stated_value]
   end
 
   # ── the order the ledger is walked in ────────────────────────────────────────────────────


### PR DESCRIPTION
A Convert into USDC says what the coins fetched as plainly as a quote would, and the ledger already values the coin leg from the cash leg. The page did not: it read only the row's own quote, so the coin leg showed an editable, chart-derived value on a row whose price and value were known — and a typed value stood in front of the cash leg in the figures.

A row with a cash leg opposite it in a two-leg group is now venue-valued: the page shows that leg as the row's price and value, in the cash currency; a typed value is refused; pricing takes the cash leg ahead of any value written before this rule. The page loads its rows' groups in one query; a row rendered on its own asks for its group.
