### PR TITLE
Keep a symbol's coin straight at the edges

### DIFF
--- a/app/models/tax/CLAUDE.md
+++ b/app/models/tax/CLAUDE.md
@@ -122,7 +122,10 @@ VENUE lists under that symbol (`tickers.base_asset`), the coin of that symbol by
 Never a stock for a crypto venue; a stock first for a stock venue. `PriceService` asks per row
 (venue + day) and the backfill asks per span (`coin_ids_over` splits a range at a dated alias).
 Only aliases verified against the provider's coin records go in `ALIASES`; a symbol nobody can
-name a coin for stays unpriced rather than guessed. Prices are still stored by SYMBOL, so two
+name a coin for stays unpriced rather than guessed. Adding an alias means adding a migration that
+clears the dates it speaks for (`20260825200000_refetch_prices_under_their_coin.rb` is the shape):
+storage is insert-only, so a price fetched under the former identity would stand forever. The
+one-day fallback window is clipped at a dated alias for the same reason. Prices are still stored by SYMBOL, so two
 coins sharing a ticker at the same time would share one price row — keying by coin id is the
 upgrade path.
 

--- a/app/models/tax/methods/pvct.rb
+++ b/app/models/tax/methods/pvct.rb
@@ -27,6 +27,8 @@ module Tax
         @contaminated = false
 
         balances = Hash.new(0.to_d) # asset => amount held
+        # Where each holding was booked, for the coin its symbol means there.
+        @venue_of = {}
         total_acquisition_cost = 0.to_d
         disposals = []
 
@@ -35,6 +37,7 @@ module Tax
           amount = tx[:base_amount]
           fiat_value = tx[:fiat_value] || 0.to_d
           entry = tx[:entry_type].to_sym
+          @venue_of[asset] ||= tx[:exchange]
 
           case entry
           when :buy, :staking_reward, :lending_interest, :airdrop, :mining, :other_income
@@ -186,7 +189,8 @@ module Tax
             @contaminated = true if rate.zero?
             total += amount * rate
           else
-            price = @price_service&.price_at(asset: asset, currency: @currency, timestamp: timestamp) || 0.to_d
+            price = @price_service&.price_at(asset: asset, currency: @currency, timestamp: timestamp,
+                                             exchange: @venue_of[asset]) || 0.to_d
             @contaminated = true if price.zero?
             total += amount * price
           end

--- a/app/models/tax/methods/wealth_snapshot.rb
+++ b/app/models/tax/methods/wealth_snapshot.rb
@@ -42,12 +42,15 @@ module Tax
 
       def build_balances(transactions, cutoff)
         balances = Hash.new(0.to_d)
+        # Where each holding was booked, for the coin its symbol means there.
+        @venue_of = {}
 
         transactions.each do |tx|
           next if tx[:transacted_at] >= cutoff
 
           asset = tx[:base_currency]
           amount = tx[:base_amount]
+          @venue_of[asset] ||= tx[:exchange]
 
           case tx[:entry_type].to_sym
           when :buy, :swap_in, :deposit, :staking_reward, :lending_interest, :airdrop, :mining, :other_income
@@ -68,7 +71,8 @@ module Tax
                     @price_service&.convert_fiat(amount: 1.to_d, from: 'USD', to: @currency,
                                                  timestamp: snapshot_date) || 1.to_d
                   else
-                    @price_service&.price_at(asset: asset, currency: @currency, timestamp: snapshot_date) || 0.to_d
+                    @price_service&.price_at(asset: asset, currency: @currency, timestamp: snapshot_date,
+                                             exchange: @venue_of&.dig(asset)) || 0.to_d
                   end
 
           {

--- a/app/models/tax/price_service.rb
+++ b/app/models/tax/price_service.rb
@@ -413,8 +413,17 @@ module Tax
 
     # The alias is a date's question and costs no query; the catalogue answer is cached per venue.
     def coin_id_for(symbol, exchange, timestamp)
+      exchange = venue(exchange)
       Tax::AssetIdentity.alias_coin(symbol, exchange: exchange, at: timestamp) ||
         (@coin_ids ||= {})[[symbol, exchange&.id]] ||= Tax::AssetIdentity.catalogue_coin(symbol, exchange: exchange)
+    end
+
+    # A venue handed over as a record, or named — an enriched row carries only its `name_id`, and
+    # the engines that value a holding at a date have nothing else to say where it was booked.
+    def venue(exchange)
+      return exchange unless exchange.is_a?(String) || exchange.is_a?(Symbol)
+
+      (@venues ||= {})[exchange.to_s] ||= Exchange.find_by(type: "Exchanges::#{exchange.to_s.camelize}")
     end
 
     def resolve_fiat_value(record, currency)
@@ -519,15 +528,21 @@ module Tax
     # next row on a neighbouring date costs nothing — which is also why this delegates rather than
     # keeping a second, subtly different fetch-and-store of its own.
     def fetch_single_price(asset:, currency:, timestamp:, exchange: nil)
-      coin_id = coin_id_for(asset, exchange, timestamp)
-      return nil unless coin_id
-
       date = timestamp.to_date
       # Anchored on the END, so a recent date whose window would run past today is widened backwards
       # instead of being narrowed under the threshold. Tomorrow has no price and never will.
       to = [date + SINGLE_PRICE_WINDOW, Date.current].min
-      fetch_price_range(coin_id: coin_id, symbol: asset, currency: currency,
-                        from: to - (SINGLE_PRICE_WINDOW * 2), to: to)
+      from = to - (SINGLE_PRICE_WINDOW * 2)
+      # And never across the day a symbol changed coin: the window is clipped to the coin's own
+      # days, or Terra Classic's prices would be stored as LUNA's for days after the relaunch, and
+      # storage being insert-only, the right coin could never replace them. A window cut short by
+      # the boundary behind it runs forward instead, so the archive still sees a span it answers.
+      range, coin_id = Tax::AssetIdentity.coin_ids_over(asset, exchange: venue(exchange), from: from, to: to)
+                                         .find { |days, _| days.cover?(date) }
+      return nil unless coin_id
+
+      last = range.end == to ? [range.begin + (SINGLE_PRICE_WINDOW * 2), Date.current].min : range.end
+      fetch_price_range(coin_id: coin_id, symbol: asset, currency: currency, from: range.begin, to: last)
       @price_cache["#{asset}/#{currency}/#{date}"]&.to_d&.nonzero?
     end
 

--- a/app/models/tracker/reconciliation.rb
+++ b/app/models/tracker/reconciliation.rb
@@ -84,7 +84,7 @@ module Tracker
       def acquisition(user, symbol, quantity)
         first = rows(user, symbol).minimum(:transacted_at)
         on = (first || Time.current) - 1.second
-        price = market_price(symbol, on)
+        price = market_price(symbol, on, reconciling_exchange(user, symbol))
 
         Proposal.new(symbol: symbol, kind: :acquisition, quantity: quantity, on: on,
                      market_price: price, market_cost: price && (price * quantity),
@@ -137,8 +137,9 @@ module Tracker
         earned > bought ? :earned : :bought
       end
 
-      def market_price(symbol, on)
-        price = Tax::PriceService.new.price_at(asset: symbol, currency: 'USD', timestamp: on)
+      # Priced as the coin this VENUE means by the symbol: Binance's LIT is not Kraken's.
+      def market_price(symbol, on, exchange)
+        price = Tax::PriceService.new.price_at(asset: symbol, currency: 'USD', timestamp: on, exchange: exchange)
         price&.positive? ? price : nil
       end
 

--- a/db/migrate/20260825200000_refetch_prices_under_their_coin.rb
+++ b/db/migrate/20260825200000_refetch_prices_under_their_coin.rb
@@ -1,0 +1,19 @@
+# A price stored under a symbol stays: storage is insert-only and a covered date is never fetched
+# again. Prices fetched before `Tax::AssetIdentity` were fetched under whichever asset row came
+# first — the relaunched Terra for 2021 LUNA, the wrong LIT — so every date an alias now speaks for
+# is cleared, to be fetched under the coin the symbol meant. The ledgers are asked to recompute
+# once the gaps are filled again.
+class RefetchPricesUnderTheirCoin < ActiveRecord::Migration[8.1]
+  def up
+    Tax::AssetIdentity::ALIASES.each do |entry|
+      scope = HistoricalPrice.where(asset: entry.symbol)
+      scope = scope.where(date: ..entry.until) if entry.until
+      scope.delete_all
+    end
+    AccountTransaction.distinct.pluck(:user_id).each { |user_id| Tracker::LedgerJob.perform_later(user_id) }
+  end
+
+  def down
+    # Nothing to restore: the rows are reference data, and the next report fetches them again.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_200000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/migrations/refetch_prices_under_their_coin_test.rb
+++ b/test/migrations/refetch_prices_under_their_coin_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260825200000_refetch_prices_under_their_coin.rb')
+
+# Prices fetched before the symbol's coin was resolved by venue and day were fetched under whichever
+# asset row came first, and storage being insert-only they would stand forever.
+class RefetchPricesUnderTheirCoinTest < ActiveSupport::TestCase
+  test 'every date an alias speaks for is cleared, and nothing else' do
+    price('LUNA', Date.new(2022, 5, 1))
+    kept_luna = price('LUNA', Date.new(2022, 6, 1))
+    price('MATIC', Date.new(2021, 7, 1))
+    kept_btc = price('BTC', Date.new(2021, 7, 1))
+    Tracker::LedgerJob.stubs(:perform_later)
+
+    ActiveRecord::Migration.suppress_messages { RefetchPricesUnderTheirCoin.new.up }
+
+    assert_equal [kept_btc.id, kept_luna.id].sort, HistoricalPrice.pluck(:id).sort
+  end
+
+  def price(symbol, date)
+    HistoricalPrice.create!(asset: symbol, currency: 'USD', date: date, price: 1)
+  end
+end

--- a/test/models/tax/methods/pvct_test.rb
+++ b/test/models/tax/methods/pvct_test.rb
@@ -10,7 +10,7 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
     # Buy 1 BTC for 10000 EUR, portfolio grows to 50000
     # Sell 0.5 BTC for 25000 EUR
     # gain = 25000 - (10000 * 25000 / 50000) = 25000 - 5000 = 20000
-    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything).returns(50_000.to_d)
+    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything).returns(50_000.to_d)
     @price_service.stubs(:convert_fiat).returns(1.to_d)
 
     transactions = [
@@ -38,7 +38,7 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
     # Buy 1 BTC for 10 000 EUR plus a 50 EUR fee, portfolio grows to 50 000.
     # Sell 0.5 BTC for 25 000 EUR.
     # gain = 25 000 - (10 050 * 25 000 / 50 000) = 25 000 - 5 025 = 19 975
-    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything).returns(50_000.to_d)
+    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything).returns(50_000.to_d)
     @price_service.stubs(:convert_fiat).returns(1.to_d)
 
     transactions = [
@@ -58,10 +58,10 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
 
   test 'cross-asset acquisition fee does not duplicate cost already in the PVCT numerator' do
     @price_service.stubs(:price_at)
-                  .with(asset: 'BTC', currency: 'EUR', timestamp: anything)
+                  .with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything)
                   .returns(40_000.to_d)
     @price_service.stubs(:price_at)
-                  .with(asset: 'BNB', currency: 'EUR', timestamp: anything)
+                  .with(asset: 'BNB', currency: 'EUR', timestamp: anything, exchange: anything)
                   .returns(100.to_d)
     @price_service.stubs(:convert_fiat).returns(1.to_d)
 
@@ -104,7 +104,7 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
   end
 
   test 'total acquisition cost reduces after each disposal' do
-    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything).returns(20_000.to_d)
+    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything).returns(20_000.to_d)
 
     transactions = [
       { entry_type: :buy, base_currency: 'BTC', base_amount: 1.to_d,
@@ -161,10 +161,10 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
 
   test 'a zero-priced portfolio holding marks the disposal incomplete' do
     @price_service.stubs(:price_at)
-                  .with(asset: 'BTC', currency: 'EUR', timestamp: anything)
+                  .with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything)
                   .returns(0.to_d)
     @price_service.stubs(:price_at)
-                  .with(asset: 'ETH', currency: 'EUR', timestamp: anything)
+                  .with(asset: 'ETH', currency: 'EUR', timestamp: anything, exchange: anything)
                   .returns(2_000.to_d)
 
     transactions = [
@@ -337,7 +337,7 @@ class Tax::Methods::PvctTest < ActiveSupport::TestCase
   # is also the numerator of the allocation ratio: (C-f)(1 - A/V), never C - A·C/V - f. PVCT printed
   # the fee in its own column and subtracted it from neither.
   test 'a disposal fee is deducted from the prix de cession, not just from the gain' do
-    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything).returns(50_000.to_d)
+    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything).returns(50_000.to_d)
     @price_service.stubs(:convert_fiat).returns(1.to_d)
 
     transactions = [

--- a/test/models/tax/methods/wealth_snapshot_test.rb
+++ b/test/models/tax/methods/wealth_snapshot_test.rb
@@ -7,7 +7,7 @@ class Tax::Methods::WealthSnapshotTest < ActiveSupport::TestCase
   end
 
   test 'builds portfolio snapshot from transactions' do
-    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything).returns(50_000.to_d)
+    @price_service.stubs(:price_at).with(asset: 'BTC', currency: 'EUR', timestamp: anything, exchange: anything).returns(50_000.to_d)
     @price_service.stubs(:convert_fiat).returns(1.to_d)
 
     transactions = [

--- a/test/models/tax/price_service_identity_test.rb
+++ b/test/models/tax/price_service_identity_test.rb
@@ -47,4 +47,40 @@ class Tax::PriceServiceIdentityTest < ActiveSupport::TestCase
 
     assert rows.sole[:price_missing], 'unpriced, honestly — not priced as a share of XYZ Inc'
   end
+
+  # The one-day fallback fetches a window around the day, and a window that crossed the day the
+  # symbol changed coin would store one coin's prices under the other's days — for good, since
+  # storage is insert-only.
+  test 'a fallback window never crosses the day a symbol changed coin' do
+    create(:asset, symbol: 'LUNA', name: 'Terra', external_id: 'terra-luna-2', category: 'Cryptocurrency')
+    fetched = []
+    MarketData.stubs(:get_historical_price_range).with do |args|
+      fetched << [args[:coin_id], args[:from].to_date, args[:to].to_date]
+      true
+    end.returns(Result::Success.new('prices' => []))
+    service = Tax::PriceService.new
+
+    service.price_at(asset: 'LUNA', currency: 'USD', timestamp: Time.utc(2022, 5, 20, 12), exchange: @binance)
+    service.price_at(asset: 'LUNA', currency: 'USD', timestamp: Time.utc(2022, 5, 30, 12), exchange: @binance)
+
+    before, after = fetched
+    assert_equal 'terra-luna', before[0]
+    assert_operator before[2], :<=, Date.new(2022, 5, 28), 'Terra Classic stops at the relaunch'
+    assert_equal 'terra-luna-2', after[0]
+    assert_equal Date.new(2022, 5, 28), after[1], 'and the relaunched chain starts there'
+    assert_operator after[2] - after[1], :>=, 120, 'cut short behind, the window runs forward instead'
+  end
+
+  test 'a venue named rather than handed over still means its coin' do
+    create(:asset, symbol: 'LIT', name: 'Lighter', external_id: 'lighter', category: 'Cryptocurrency', market_cap_rank: 77)
+    fetched = []
+    MarketData.stubs(:get_historical_price_range).with do |args|
+      fetched << args[:coin_id]
+      true
+    end.returns(Result::Success.new('prices' => []))
+
+    Tax::PriceService.new.price_at(asset: 'LIT', currency: 'USD', timestamp: Time.utc(2022, 1, 5), exchange: 'binance')
+
+    assert_equal ['litentry'], fetched
+  end
 end

--- a/test/models/tracker/reconciliation_test.rb
+++ b/test/models/tracker/reconciliation_test.rb
@@ -212,4 +212,20 @@ class Tracker::ReconciliationTest < ActiveSupport::TestCase
 
     assert_no_difference('AccountTransaction.count') { propose }
   end
+
+  # Priced as the coin this VENUE means by the symbol.
+  test 'the proposal prices the coin the venue means' do
+    create(:asset, symbol: 'LIT', name: 'Lighter', external_id: 'lighter', category: 'Cryptocurrency', market_cap_rank: 77)
+    tx(:sell, day: 2, base_currency: 'LIT', base_amount: 5, quote_currency: 'USDT', quote_amount: 10)
+    fetched = []
+    MarketData.stubs(:get_historical_price_range).with do |args|
+      fetched << args[:coin_id]
+      true
+    end.returns(Result::Success.new('prices' => []))
+
+    Tracker::Reconciliation.propose(@user, 'LIT')
+
+    assert_includes fetched, 'litentry'
+    assert_not_includes fetched, 'lighter'
+  end
 end


### PR DESCRIPTION
Three ways the coin a symbol resolves to could still be lost after #252.

The one-day fallback fetched a 121-day window under the coin of the day asked for, so a lookup just before Terra's relaunch would have stored Terra Classic's prices under LUNA for days after it — permanently, since price storage is insert-only. The window is now clipped at a dated alias; a window cut short behind runs forward instead, so the archive still sees a span it answers.

The reconciliation proposal and the wealth-snapshot and PVCT engines valued a holding with no venue, so a Binance LIT would have been priced as the higher-ranked coin of that ticker. Every caller now says where the holding was booked; a venue may be named rather than handed over, since an enriched row carries only its name.

Prices fetched before any of this were fetched under whichever asset row came first. A migration clears every date an alias now speaks for, to be fetched under the coin the symbol meant, and asks the ledgers to recompute.
