### PR TITLE
Reach every Binance deposit and withdrawal, and read the export the way the API is read

### DIFF
--- a/app/models/exchanges/binance.rb
+++ b/app/models/exchanges/binance.rb
@@ -497,35 +497,39 @@ class Exchanges::Binance < Exchange
     start_ms = start_time ? (start_time.to_f * 1000).to_i : nil
     entries = []
 
-    # Deposits
-    result = hm_client.deposit_history(start_time: start_ms)
-    return result if result.failure?
+    # Deposits and withdrawals. Binance answers these for at most 90 days per call, and for the LAST
+    # 90 days when given no window — so a full-history sync, which has no start, walks them in
+    # windows from the venue's opening; an incremental one is already floored to `ledger_window`
+    # by the caller and reaches the present in one call.
+    each_window(start_ms, days: 89, from: TRANSFER_HISTORY_FROM) do |window_start, window_end|
+      result = hm_client.deposit_history(start_time: window_start, end_time: window_end)
+      return result if result.failure?
 
-    Array(result.data).each do |dep|
-      next unless dep['status'] == 1
+      Array(result.data).each do |dep|
+        next unless dep['status'] == 1
 
-      entries << {
-        entry_type: :deposit, base_currency: dep['coin'], base_amount: dep['amount'].to_d,
-        quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil,
-        tx_id: dep['txId'], group_id: nil, description: nil,
-        transacted_at: Time.at(dep['insertTime'] / 1000.0).utc, raw_data: dep
-      }
-    end
+        entries << {
+          entry_type: :deposit, base_currency: dep['coin'], base_amount: dep['amount'].to_d,
+          quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil,
+          tx_id: dep['txId'], group_id: nil, description: nil,
+          transacted_at: Time.at(dep['insertTime'] / 1000.0).utc, raw_data: dep
+        }
+      end
 
-    # Withdrawals
-    result = hm_client.withdraw_history(start_time: start_ms)
-    return result if result.failure?
+      result = hm_client.withdraw_history(start_time: window_start, end_time: window_end)
+      return result if result.failure?
 
-    Array(result.data).each do |wd|
-      next unless wd['status'] == 6
+      Array(result.data).each do |wd|
+        next unless wd['status'] == 6
 
-      entries << {
-        entry_type: :withdrawal, base_currency: wd['coin'], base_amount: wd['amount'].to_d,
-        quote_currency: nil, quote_amount: nil,
-        fee_currency: wd['coin'], fee_amount: wd['transactionFee']&.to_d,
-        tx_id: wd['txId'] || wd['id'], group_id: nil, description: nil,
-        transacted_at: Time.parse(wd['applyTime']).utc, raw_data: wd
-      }
+        entries << {
+          entry_type: :withdrawal, base_currency: wd['coin'], base_amount: wd['amount'].to_d,
+          quote_currency: nil, quote_amount: nil,
+          fee_currency: wd['coin'], fee_amount: wd['transactionFee']&.to_d,
+          tx_id: wd['txId'] || wd['id'], group_id: nil, description: nil,
+          transacted_at: Time.parse(wd['applyTime']).utc, raw_data: wd
+        }
+      end
     end
 
     # Discover traded symbols and fetch spot trades
@@ -732,14 +736,28 @@ class Exchanges::Binance < Exchange
     @exchange_symbols_map
   end
 
+  # Where a full-history walk starts: Binance opened in July 2017, Convert in 2020. Nothing on this
+  # venue predates these, so a window before them is a call for nothing.
+  TRANSFER_HISTORY_FROM = Time.utc(2017, 7, 1)
+  CONVERT_HISTORY_FROM = Time.utc(2020, 1, 1)
+
+  # [start_ms, end_ms] windows of at most `days`, abutting, from `start_ms` — or from `from` when
+  # there is no start — up to now. The end is pinned once: a loop that re-reads the clock each turn
+  # never reaches it.
+  def each_window(start_ms, days:, from:)
+    window_start = start_ms || (from.to_f * 1000).to_i
+    window_end = (Time.now.utc.to_f * 1000).to_i
+    span = days * 24 * 60 * 60 * 1000
+    while window_start < window_end
+      chunk_end = [window_start + span, window_end].min
+      yield window_start, chunk_end
+      window_start = chunk_end
+    end
+  end
+
   def import_convert_trades(hm_client, start_ms, entries)
     # Convert API requires 30-day windows
-    window_start = start_ms || (Time.utc(2020, 1, 1).to_f * 1000).to_i
-    window_end = (Time.now.utc.to_f * 1000).to_i
-    thirty_days = 30 * 24 * 60 * 60 * 1000
-
-    while window_start < window_end
-      chunk_end = [window_start + thirty_days, window_end].min
+    each_window(start_ms, days: 30, from: CONVERT_HISTORY_FROM) do |window_start, chunk_end|
       result = hm_client.convert_trade_flow(start_time: window_start, end_time: chunk_end)
       break if result.failure?
 
@@ -759,7 +777,6 @@ class Exchanges::Binance < Exchange
           transacted_at: transacted_at, raw_data: conv
         }
       end
-      window_start = chunk_end
     end
   end
 

--- a/app/models/import/binance_csv.rb
+++ b/app/models/import/binance_csv.rb
@@ -174,6 +174,11 @@ class Import::BinanceCsv
 
   # Each spend paired with the nearest credit that has not been taken. Timestamped at the spend, so
   # the row sits where the money left.
+  #
+  # Always a SWAP pair, cash leg or not: `import_convert_trades` books every Convert as swap_out and
+  # swap_in without asking what was spent, and a file row dedups against a stored row only when the
+  # entry type matches — a Convert out of USDT read as a purchase never met the API's swap, and the
+  # coins arrived twice. Priced the same way as the API's, by the cash leg beside the coin leg.
   def convert_entries(rows)
     spent, received = rows.partition { |row| row[:change].negative? }
     received = received.sort_by { |row| row[:at] }
@@ -182,7 +187,7 @@ class Import::BinanceCsv
       next single_entry(out) unless match
 
       received.delete(match)
-      trade(out[:at], out, match, nil)
+      swap(out[:at], out, match, nil)
     end.flatten + received.map { |row| single_entry(row) }
   end
 

--- a/app/services/account_transaction_sync.rb
+++ b/app/services/account_transaction_sync.rb
@@ -132,21 +132,15 @@ class AccountTransactionSync
       # (user, exchange, key_type), so a user cannot register two trading keys for two accounts on
       # one venue. If that ever changes, telling them apart needs a sub-account identity the ledger
       # does not record — the key is not one, because the same account changes keys.
-      # The same SECOND, not the same instant. An exchange API timestamps to the millisecond and its
-      # own CSV export writes whole seconds — `22:58:17.200` and `22:58:17` are one fill, and
-      # compared exactly they are two, so every trade in the overlap between a file and a sync lands
-      # a second time.
-      #
-      # Bucketed rather than given a ±1s window, so it reads the same from either side: whichever of
-      # the two arrives first, both fall in the same bucket, and a row a full second later stays a
-      # row of its own.
-      second = entry[:transacted_at].change(usec: 0)
-      return scope.exists?(
-        entry_type: entry[:entry_type],
-        base_currency: entry[:base_currency],
-        base_amount: entry[:base_amount],
-        transacted_at: second...(second + 1.second)
-      )
+      # WITHIN A SECOND, not the same instant. An exchange API timestamps to the millisecond and its
+      # own CSV export writes whole seconds, rounded — `06:22:53.911` is `06:22:54` in the file — so
+      # compared exactly, or bucketed by second, every Convert in the overlap between a file and a
+      # sync lands a second time. Less than a full second apart is one event, from either side; a
+      # row a full second later stays a row of its own.
+      at = entry[:transacted_at]
+      return scope.where(entry_type: entry[:entry_type], base_currency: entry[:base_currency],
+                         base_amount: entry[:base_amount])
+                  .exists?(['transacted_at > ? AND transacted_at < ?', at - 1.second, at + 1.second])
     end
 
     # Only the STORED side is expanded to merged legs. A standalone leg arriving after its merged

--- a/test/models/exchanges/binance_get_ledger_test.rb
+++ b/test/models/exchanges/binance_get_ledger_test.rb
@@ -164,15 +164,51 @@ class Exchanges::BinanceGetLedgerTest < ActiveSupport::TestCase
     assert result.failure?
   end
 
-  test 'passes start_time as milliseconds' do
+  # An incremental sync is floored to the venue's window by the caller, so one call reaches the
+  # present: from the watermark, in milliseconds, once.
+  test 'passes start_time as milliseconds, once' do
     start_time = Time.utc(2026, 3, 20)
     hm_client = mock('honeymaker_client')
     stub_common(hm_client)
 
     expected_ms = (start_time.to_f * 1000).to_i
-    hm_client.expects(:deposit_history).with(has_entry(start_time: expected_ms)).returns(Result::Success.new([]))
-    hm_client.expects(:withdraw_history).with(has_entry(start_time: expected_ms)).returns(Result::Success.new([]))
+    hm_client.expects(:deposit_history).once.with(has_entry(start_time: expected_ms)).returns(Result::Success.new([]))
+    hm_client.expects(:withdraw_history).once.with(has_entry(start_time: expected_ms)).returns(Result::Success.new([]))
 
     @exchange.get_ledger(api_key: @api_key, start_time: start_time)
+  end
+
+  # Binance answers the deposit and withdrawal endpoints for at most 90 days per call, and for the
+  # LAST 90 days when asked for no window at all. A full-history sync used to ask exactly that, so
+  # every deposit and withdrawal older than three months was never fetched — while Convert, asked in
+  # 30-day windows, reached back years. A first sync now walks both in windows from the venue's
+  # opening to the present, and a 2021 withdrawal lands.
+  test 'a full-history sync walks deposits and withdrawals in windows back to the start' do
+    hm_client = mock('honeymaker_client')
+    stub_common(hm_client)
+    at = Time.utc(2021, 9, 20, 10, 10, 52)
+    old = { 'coin' => 'LTC', 'amount' => '0.249', 'status' => 6, 'transactionFee' => '0',
+            'applyTime' => '2021-09-20 10:10:52', 'txId' => 'abc' }
+    windows = Hash.new { |hash, key| hash[key] = [] }
+    %i[deposit_history withdraw_history].each do |endpoint|
+      hm_client.stubs(endpoint).with do |args|
+        windows[endpoint] << [args[:start_time], args[:end_time]]
+        true
+      end.returns(Result::Success.new([]))
+    end
+    hm_client.stubs(:withdraw_history)
+             .with { |args| args[:start_time] <= at.to_i * 1000 && args[:end_time] > at.to_i * 1000 }
+             .returns(Result::Success.new([old]))
+
+    result = @exchange.get_ledger(api_key: @api_key)
+
+    withdrawal = result.data.find { |e| e[:entry_type] == :withdrawal }
+    assert_equal 0.249.to_d, withdrawal[:base_amount], 'a 2021 withdrawal reached'
+    windows.each_value do |calls|
+      assert calls.all? { |from, to| to - from <= 90 * 24 * 3600 * 1000 }, 'no window wider than the venue allows'
+      assert_operator calls.first.first, :<=, Time.utc(2017, 7, 14).to_i * 1000, 'from the venue opening'
+      assert_in_delta Time.current.to_i * 1000, calls.last.last, 60_000, 'to the present'
+      assert calls.each_cons(2).all? { |(_, to), (from, _)| from == to }, 'windows abut, so nothing falls between'
+    end
   end
 end

--- a/test/models/import/binance_csv_test.rb
+++ b/test/models/import/binance_csv_test.rb
@@ -248,12 +248,30 @@ class Import::BinanceCsvTest < ActiveSupport::TestCase
       '1,2025-06-22 20:20:46,Spot,Binance Convert,USDT,-129.41567489,'
     )
 
-    entry = entries.sole
-    assert_equal :buy, entry[:entry_type]
-    assert_equal 'USDC', entry[:base_currency]
-    assert_equal 129.41567489.to_d, entry[:base_amount]
-    assert_equal 'USDT', entry[:quote_currency]
-    assert_equal 129.41567489.to_d, entry[:quote_amount]
+    assert_equal(%i[swap_out swap_in], entries.map { |e| e[:entry_type] })
+    assert_equal(%w[USDT USDC], entries.map { |e| e[:base_currency] })
+    assert_equal([129.41567489.to_d] * 2, entries.map { |e| e[:base_amount] })
+    assert_equal 1, entries.map { |e| e[:group_id] }.uniq.size, 'one trade, two legs'
+  end
+
+  # The adapter books EVERY Convert as a swap pair — `import_convert_trades` never asks whether a
+  # leg is cash — and a file row dedups against a stored row only when the entry type matches. A
+  # Convert out of USDT read as a `buy` therefore never met the API's `swap_in`, and the coins
+  # arrived twice. The cash leg beside the coin leg is still what prices it, exactly as for the API.
+  test 'a convert out of cash is the swap pair the adapter books, not a purchase' do
+    entries = parse(
+      '1,2021-09-20 09:22:54,Spot,Binance Convert,LTC,0.89568816,',
+      '1,2021-09-20 09:22:54,Spot,Binance Convert,USDT,-150,',
+      offset: '+03:00'
+    )
+
+    assert_equal(%i[swap_out swap_in], entries.map { |e| e[:entry_type] })
+    out, inn = entries
+    assert_equal ['USDT', 150.to_d], [out[:base_currency], out[:base_amount]]
+    assert_equal ['LTC', 0.89568816.to_d], [inn[:base_currency], inn[:base_amount]]
+    assert_nil inn[:quote_amount], 'no quote of its own: the cash leg beside it is the price'
+    assert_equal out[:group_id], inn[:group_id]
+    assert_equal Time.utc(2021, 9, 20, 6, 22, 54), inn[:transacted_at]
   end
 
   test 'two converts far apart are not paired with each other' do
@@ -264,8 +282,9 @@ class Import::BinanceCsvTest < ActiveSupport::TestCase
       '1,2024-02-17 20:07:21,Spot,Binance Convert,CHZ,-3,'
     )
 
-    assert_equal 3, entries.size, 'a purchase, and a swap of CHZ into BNB'
-    assert_equal 150.to_d, entries.find { |e| e[:base_currency] == 'LTC' }[:quote_amount]
+    assert_equal 4, entries.size, 'two swaps, two legs each'
+    assert_equal 2, entries.map { |e| e[:group_id] }.uniq.size
+    assert_equal 150.to_d, entries.find { |e| e[:base_currency] == 'USDT' }[:base_amount]
   end
 
   # Binance does not always write the coins a dust sweep consumed — five BNB credits, no Remark, and

--- a/test/services/account_transaction_sync_test.rb
+++ b/test/services/account_transaction_sync_test.rb
@@ -337,6 +337,27 @@ class AccountTransactionSyncTest < ActiveSupport::TestCase
     assert_equal 5, AccountTransaction.where(user: @user, exchange: @exchange).count
   end
 
+  # Binance's export writes whole seconds and ROUNDS: the Convert its API stamps at 06:22:53.911
+  # is 06:22:54 in the file. Bucketed by second those are two events, and the coins arrive twice.
+  # A row with no id is the same event as a stored one within a second of it, either way round;
+  # a full second later is still a row of its own.
+  test 'a file row on the rounded-up second is the stored API row' do
+    at = Time.utc(2021, 9, 20, 6, 22, 53, 911_000)
+    api = { entry_type: :swap_in, base_currency: 'LTC', base_amount: '0.89568816'.to_d,
+            quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil,
+            tx_id: 'quote-1-in', group_id: 'convert_quote-1', description: 'Convert',
+            transacted_at: at, raw_data: {} }
+    @exchange.stubs(:get_ledger).returns(Result::Success.new([api]))
+    AccountTransactionSync.new(@api_key).sync!
+
+    file = api.merge(tx_id: nil, group_id: 'swapcsv_1', description: nil, transacted_at: Time.utc(2021, 9, 20, 6, 22, 54))
+    rounded = AccountTransactionSync.new(@api_key).store!([file])
+    later = AccountTransactionSync.new(@api_key).store!([file.merge(transacted_at: at + 1.second)])
+
+    assert_equal({ imported: 0, duplicates: 1 }, rounded.slice(:imported, :duplicates), 'the same Convert')
+    assert_equal({ imported: 1, duplicates: 0 }, later.slice(:imported, :duplicates), 'a full second on: its own row')
+  end
+
   # Bybit returns an empty txID for internal transfers, and Gemini/Hyperliquid/BingX build their
   # tx_id with .to_s on a field that can be missing. A blank id identifies nothing, so it must fall
   # through to the nil-tx_id identity rather than collapsing every such row onto one '' key.

--- a/test/services/id_less_dedup_test.rb
+++ b/test/services/id_less_dedup_test.rb
@@ -71,12 +71,15 @@ class IdLessDedupTest < ActiveSupport::TestCase
     assert_equal 1, AccountTransaction.for_user(@user).count
   end
 
-  # Bucketed by second, so it reads the same from either side — whichever of the two arrives first.
-  test 'the whole of one second is the same fill, and the next second is not' do
+  # Within a second either way, so it reads the same from either side — whichever of the two arrives
+  # first. The file ROUNDS: `:17.9` is written as `:18`, which is why the next whole second is still
+  # that fill, and only more than a second away is a row of its own.
+  test 'within a second is the same fill, either way round, and more than a second away is not' do
     store(@old, [entry.merge(tx_id: 'A', transacted_at: @at + 0.9)])
 
-    assert_equal 0, store(@new, [entry])[:imported], 'still inside that second'
-    assert_equal 1, store(@new, [entry.merge(transacted_at: @at + 1.second)])[:imported], 'the next second is its own'
+    assert_equal 0, store(@new, [entry])[:imported], 'the second it was truncated to'
+    assert_equal 0, store(@new, [entry.merge(transacted_at: @at + 1.second)])[:imported], 'the second it was rounded to'
+    assert_equal 1, store(@new, [entry.merge(transacted_at: @at + 2.seconds)])[:imported], 'more than a second away is its own'
   end
 
   test 'it matches whichever precision was stored first' do


### PR DESCRIPTION
## Summary

Three defects that together left a Binance account's deposits and withdrawals out of the tracker, or in it twice.

### A first sync now reaches old deposits and withdrawals

Binance answers `deposit/hisrec` and `withdraw/history` for at most 90 days per call, and for the *last* 90 days when given no window. `Exchanges::Binance#get_ledger` asked exactly that on a full-history sync, so every deposit and withdrawal older than three months was never fetched — while Convert, already asked in 30-day windows, reached back years. The effect on the page: coins that arrived by Convert and later left by withdrawal looked as if they were still held, and the tracker had to assume they had "left" somewhere.

The first sync now walks both endpoints in abutting 89-day windows from the venue's opening (July 2017) to the present, through one `each_window` helper that Convert uses too. An incremental sync is unchanged: one call from the watermark, which the caller already floors to `ledger_window`.

### The CSV importer books a Convert the way the adapter does

`import_convert_trades` books every Convert as a `swap_out`/`swap_in` pair, cash leg or not. The importer read a Convert out of USDT as a `buy`. A file row with no id dedups against a stored row only when the entry type matches, so the same Convert landed twice — once as the API's swap, once as the file's purchase. The importer now emits the same swap pair; the cash leg beside the coin leg prices it exactly as it prices the API's.

### A file row on the rounded second is the stored row

The export writes whole seconds and *rounds*: a Convert the API stamps at `06:22:53.911` is `06:22:54` in the file. Id-less dedup bucketed by whole second, so the two never met. A row with no id now matches a stored row less than a second away, either way round; more than a second away is still its own row.

## Tests

- `test/models/exchanges/binance_get_ledger_test.rb` — a full-history sync walks deposits and withdrawals in abutting windows no wider than 90 days, from 2017 to now, and reaches a 2021 withdrawal; an incremental sync makes one call each.
- `test/models/import/binance_csv_test.rb` — a Convert out of cash is the adapter's swap pair (on the exact rows of a real export, with its UTC+3 offset); the existing Convert tests updated to the pair shape.
- `test/services/account_transaction_sync_test.rb`, `test/services/id_less_dedup_test.rb` — a file row on the rounded-up second dedups against the API row; within a second either way is one event; more than a second away is not.

Full suite: 4,649 runs, 0 failures. Rubocop clean.
