### PR TITLE
Write the manual into the repository, and make the README its table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Deltabadger
 
-[![Docker Build](https://github.com/deltabadger/deltabadger/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/deltabadger/deltabadger/actions/workflows/docker-publish.yml)
-[![Docker Image](https://img.shields.io/badge/ghcr.io-deltabadger%2Fdeltabadger-blue?logo=docker)](https://github.com/deltabadger/deltabadger/pkgs/container/deltabadger)
-[![License](https://img.shields.io/github/license/deltabadger/deltabadger)](LICENSE)
+[![Docker Build](https://github.com/deltabadger/deltabadger/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/deltabadger/deltabadger/actions/workflows/docker-publish.yml) [![Docker Image](https://img.shields.io/badge/ghcr.io-deltabadger%2Fdeltabadger-blue?logo=docker)](https://github.com/deltabadger/deltabadger/pkgs/container/deltabadger) [![License](https://img.shields.io/github/license/deltabadger/deltabadger)](LICENSE)
 
 [Deltabadger](https://deltabadger.com) is a one-stop-shop for investors in crypto and stocks:
 
@@ -13,377 +11,107 @@ No other tool offers this unique combination:
 * **MCP Server** to connect your exchange accounts to Claude or Claw
 * **Crypto Tax Reporting** tool with no transaction limits
 
-For tax-reporting, and some more advanced features you'll need a free Coingecko account for market data.
+For tax-reporting, and some more advanced features you'll need a free CoinGecko account for market data.
 
-### Quick Start
+## Quick start
 
-Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for your operating system, and make sure it's running, then run Deltabadger with a single command:
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for your operating system, make sure it's running, then:
 
 ```bash
 docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage ghcr.io/deltabadger/deltabadger:latest standalone
 ```
 
-That's it! Access the app at `http://localhost:3737`.
+Open `http://localhost:3737`. See the [manual](#manual) for Docker Compose, the desktop app, Umbrel, and everything else.
 
-### Self-Hosted plan
+## Manual
 
-If you have a Deltabadger.com Self-Hosted subscription, copy the one-time connect code from
-your dashboard and pass it when you first start the container:
+### Getting started
 
-```bash
-docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage -e CLAIM_TOKEN=dbc_your_connect_code ghcr.io/deltabadger/deltabadger:latest standalone
-```
+1. [Welcome to Deltabadger](manual/01-welcome.md)
+2. [Quick start](manual/02-quick-start.md)
+3. [Docker Compose](manual/03-docker-compose.md)
+4. [Desktop app](manual/04-desktop-app.md)
+5. [Umbrel](manual/05-umbrel.md)
+6. [First run](manual/06-first-run.md)
+7. [Updating](manual/07-updating.md)
 
-Claiming connects subscription market data and exchange proxies, and prefills the editable
-admin name and email on the setup page. You can also paste the code during setup or connect
-later under Settings → Connect. A subscription is optional: without a claim, Deltabadger
-continues through the independent setup path and can use your own CoinGecko key.
+### Bots
 
-### Stocks and ETFs
+#### DCA
 
-Crypto works out of the box. Stock trading needs two things your container cannot invent: the
-list of tradeable symbols, and prices for them. Which broker you can use follows directly from
-who supplies those.
+8. [Creating your first bot](manual/08-creating-your-first-bot.md)
+9. [Amount and interval](manual/09-amount-and-interval.md)
+10. [Order options](manual/10-order-options.md)
+11. [Triggers](manual/11-triggers.md)
+12. [Selling](manual/12-selling.md)
+13. [Managing bots](manual/13-managing-bots.md)
+14. [Charts, statistics and orders](manual/14-charts-statistics-and-orders.md)
 
-**Alpaca — available self-hosted.** An Alpaca API key provides the tradeable symbol list, live
-prices and chart history all at once, so a container can run stocks entirely on its own. An admin
-connects a key once under Settings → Connect (paper or live) to build the catalog. Syncing the
-full US catalog takes a few minutes; after that, stocks appear in the bot wizard. Each user then
-connects their own Alpaca key when creating a bot — the admin key only keeps the catalog fresh,
-and it is never used to place anyone's orders.
+#### Portfolio Rebalancing
 
-**Interactive Brokers — hosted only.** IBKR is a broker, not a market-data provider: it publishes
-no free price feed and no price history, and its market data is a paid, per-exchange subscription
-tied to each account. A self-hosted container therefore has no source for the prices and charts the
-app needs, so the IBKR option stays hidden unless the container is connected to deltabadger.com
-market data. This is a data limitation, not a licensing one. Maybe we'll find a way around.
+15. [Portfolio bot](manual/15-portfolio-bot.md)
+16. [Rebalancing](manual/16-rebalancing.md)
 
+#### Direct Indexing
 
-## Running with Tauri (macOS and Linux)
+17. [Index bot](manual/17-index-bot.md)
+18. [Index changes](manual/18-index-changes.md)
 
-1. Signed desktop releases are not available yet; use the [Docker Quick Start](#quick-start) until they ship.
-2. Run `./setup.sh` first.
-3. Run `./start.sh` to use the app.
+### Rules
 
-On Mac, if you close the app, it continues working in the background. You can find it on the topbar.
+#### Automatic Withdrawals
 
-Scripts should work on Linux as well, but have not been tested.
+19. [Withdrawal rules](manual/19-withdrawal-rules.md)
+20. [Withdrawal keys and addresses](manual/20-withdrawal-keys-and-addresses.md)
 
-For Windows, the best way at the moment is to use Docker.
+### Tracker
+
+#### Portfolio Tracker
+
+21. [Connecting exchanges](manual/21-connecting-exchanges.md)
+22. [Portfolio overview](manual/22-portfolio-overview.md)
+23. [Transactions and positions](manual/23-transactions-and-positions.md)
+24. [Import and export](manual/24-import-and-export.md)
+
+#### Tax Reports
+
+25. [Crypto tax report](manual/25-crypto-tax-report.md)
+26. [Broker tax report](manual/26-broker-tax-report.md)
+
+### Exchanges and brokers
+
+27. [Supported exchanges](manual/27-supported-exchanges.md)
+28. [API keys](manual/28-api-keys.md)
+29. [Stocks and ETFs](manual/29-stocks-and-etfs.md)
+
+### MCP server
+
+30. [Connecting Claude](manual/30-connecting-claude.md)
+31. [Tools and permissions](manual/31-tools-and-permissions.md)
+
+### REST API
+
+32. [REST API](manual/32-rest-api.md)
+
+### Settings
+
+33. [Account settings](manual/33-account-settings.md)
+34. [Two-factor authentication](manual/34-two-factor-authentication.md)
+35. [Market data](manual/35-market-data.md)
+36. [Multiple users](manual/36-multiple-users.md)
+37. [Email notifications](manual/37-email-notifications.md)
+
+### Operations
+
+38. [Configuration](manual/38-configuration.md)
+39. [Data and backups](manual/39-data-and-backups.md)
+40. [Secrets and encryption keys](manual/40-secrets-and-encryption-keys.md)
+41. [Troubleshooting](manual/41-troubleshooting.md)
+42. [Development](manual/42-development.md)
+
+## Community
 
 Are you a developer? Jump on the [Telegram channel](https://t.me/deltabadgerchat) and help build the best DCA bot out there.
-
-## Running with Docker Compose
-
-Alternative to the single command above, using Docker Compose:
-
-1. **Download docker-compose.yml:**
-
-```bash
-curl -O https://raw.githubusercontent.com/deltabadger/deltabadger/main/docker-compose.yml
-```
-
-2. **Start the app:**
-
-```bash
-docker compose up -d
-```
-
-First run downloads the pre-built image. Secrets are auto-generated. Once complete, access the app at `http://localhost:3737`.
-
-3. **Optional: Custom configuration**
-
-Create `.env.docker` to override defaults (copy from `.env.docker.example` for reference):
-
-```bash
-curl -O https://raw.githubusercontent.com/deltabadger/deltabadger/main/.env.docker.example
-cp .env.docker.example .env.docker
-# Edit .env.docker as needed. Leave SECRET_KEY_BASE empty unless you have a
-# reason not to — the container generates and persists a strong one on first run.
-```
-
-### Updating to a New Version
-
-First, stop and remove the old container:
-
-```bash
-docker stop deltabadger && docker rm deltabadger
-```
-
-Then pull the latest image and run:
-
-```bash
-docker pull ghcr.io/deltabadger/deltabadger:latest
-docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage ghcr.io/deltabadger/deltabadger:latest standalone
-```
-
-Docker Compose:
-
-```bash
-docker compose pull
-docker compose up -d
-```
-
-### Docker Commands Reference
-
-| Command | Description |
-|---------|-------------|
-| `docker compose up -d` | Start in background |
-| `docker compose down` | Stop all containers |
-| `docker compose pull` | Pull latest image |
-| `docker compose logs -f` | View logs (Ctrl+C to exit) |
-| `docker compose logs -f web` | View web server logs only |
-
-### Starting Fresh
-
-If something goes wrong and you want to reset everything:
-
-```bash
-docker compose down
-docker volume rm deltabadger_storage deltabadger_logs
-```
-
-> **Note:** This deletes all data. Volume names may vary — run `docker volume ls` to see all volumes.
-
-### Production Notes
-
-Secrets are auto-generated on first run and stored in `/app/storage/.secrets` (inside the volume). These persist across container restarts and upgrades.
-
-For production deployments:
-- Use a reverse proxy (nginx, Traefik) for HTTPS
-- Set `APP_ROOT_URL` and `HOME_PAGE_URL` to your domain in `.env.docker`
-
-### Replacing SECRET_KEY_BASE without losing data
-
-An install that sets `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY` and
-`ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` keeps its stored data encrypted under those,
-not under `SECRET_KEY_BASE`. Replacing `SECRET_KEY_BASE` there ends every session and leaves
-stored data untouched — no credentials to re-enter, no two-factor to re-enrol. Password reset
-and confirmation emails already sent stop working, and your REST API and MCP tokens are
-unaffected, so revoke those separately if the old value was ever exposed.
-
-Installs created from scratch after these keys existed already have them. To check:
-
-```bash
-docker compose run --rm --no-deps deltabadger \
-  rake deltabadger:encryption:derived_keys
-```
-
-If your install does not have them yet, that command prints the two values it currently
-derives. Put both wherever this install's environment comes from, recreate the container with
-`docker compose up -d --force-recreate`, and confirm it starts and your credentials still
-read. `SECRET_KEY_BASE` is free to change from then on.
-
-If your compose file defines more than one service, set them in **every** service block. They
-share one database, and different values leave each unable to read the other's writes.
-
-Only ever set them to the values that command prints. Any others make stored data unreadable.
-
-### Moving to a new SECRET_KEY_BASE
-
-`SECRET_KEY_BASE` is the encryption key for everything encrypted in this instance —
-exchange API keys, your two-factor secret, withdrawal addresses, and market-data
-configuration. You cannot simply change it on a running install: every encrypted field
-is derived from it, so changing the value in place makes all of them unreadable and
-locks you out. The steps below clear the stored credentials under the old key and let
-you re-enter them under the new one.
-
-**Who needs step 4.** Treat your credentials as compromised, and step 4 (revoke) as
-not optional, if either of these is true:
-
-- This install's `SECRET_KEY_BASE` was ever one of the placeholder values shipped in
-  this repository, or any other value that has appeared somewhere public. Anyone
-  holding a copy of your database can already read every credential in it.
-- A person chose the value rather than generating it randomly. A short or
-  human-chosen key is cheap to brute-force offline from a single encrypted database
-  value or one captured session cookie, which yields the same result. A value not
-  being on our placeholder list says nothing about how it was chosen, and neither
-  check below can see how it was chosen either — add `-e PUBLISHED=yes` to the
-  commands in steps 3 and 5 so they say so too.
-- You have already changed `SECRET_KEY_BASE` and can no longer sign in. The stored
-  credentials were written under the *previous* key, and the strong value you are
-  running now tells you nothing about whether that previous one was published.
-
-Only if your secret was randomly generated and has never left the machine is nothing
-here known to be exposed. Then follow the same steps at your convenience and skip
-step 4. If you are unsure, revoke.
-
-The report and the reset make this call where they can, and say which way they went:
-they treat the data as compromised if the secret currently in use is one published in
-this repository, or if anything stored will not decrypt under it — the signature of
-that third case. Neither check can see how a value was chosen, nor a key you have
-already replaced and discarded. Those two are your call to make: add `-e PUBLISHED=yes`
-to the report and reset commands to force the compromised wording.
-
-Follow this order exactly. Back up only after stopping the app — a copy taken while
-it is still writing is not consistent, and it is the only way back. Run the report
-before revoking anything — it is what tells you which credentials exist; revoking
-first means working from memory and missing the fee keys, SMTP password, or
-market-data token. Revoke before the reset, and do not reissue anything until after
-the restart — a replacement has nowhere to be stored until the app is running again,
-and for Interactive Brokers, registering a new key early hands them a public key
-whose private half the reset then deletes.
-
-The commands below use the service name from `docker-compose.yml`. The Umbrel app
-definition calls that service `web` — substitute it if you run from that file.
-
-1. Stop the app.  `docker compose stop`
-2. Back up your data, now that nothing is writing to it. The default deployment uses a
-   named volume, not a host directory:
-   ```bash
-   docker compose cp deltabadger:/app/storage ./storage-backup
-   ```
-   If you changed `docker-compose.yml` to use a bind mount, copy that host directory
-   instead. On a default install this copy includes `/app/storage/.secrets` — the key
-   itself — so the backup decrypts itself. Keep it as carefully as the database, and
-   do not put it anywhere shared. If your key comes from `.env.docker` or a compose
-   file it is *not* in this copy, and step 6 overwrites it — save that value too, or
-   this backup cannot be restored.
-3. List what is stored:
-   ```bash
-   docker compose run --rm --no-deps deltabadger \
-     rake deltabadger:encryption:report
-   ```
-   Copy your withdrawal addresses — they are not recoverable afterwards.
-4. **REVOKE everything it listed, at its source: exchange API keys, fee keys, SMTP
-   password, Alpaca key and secret, CoinGecko key, market-data token.** Revoke only —
-   replacements have nowhere to live until step 7.
-5. Clear what is stored:
-   ```bash
-   docker compose run --rm --no-deps -e CONFIRM=clear-credentials \
-     deltabadger rake deltabadger:encryption:reset
-   ```
-6. Point this install at a new key. Blank the `SECRET_KEY_BASE` line in `.env.docker`,
-   then delete the generated key, which is a separate file inside the volume:
-   ```bash
-   docker compose run --rm --no-deps deltabadger \
-     rm -f /app/storage/.secrets
-   ```
-   On a default install `.env.docker` is already blank and `.secrets` is where your key
-   actually is, so this deletion is what rotates anything at all. A new one is written
-   only when that file is absent; an existing one is never overwritten.
-
-   If your value comes from a compose file instead — the Umbrel app definition sets it
-   from `APP_SEED` — put a freshly generated value in **both service blocks** rather
-   than blanking it:
-   ```bash
-   openssl rand -hex 64
-   ```
-   That file sets `SECRET_KEY_BASE` twice, once under `web` and once under `jobs`, and
-   each container's own environment beats the generated file. Use the same value in
-   both: change one and the two halves of the app run on different keys, and neither
-   can read what the other wrote.
-7. Recreate the container so it picks up the edited value:
-   ```bash
-   docker compose up -d --force-recreate
-   ```
-   Starting the stopped container instead would bring it back with the old value
-   still baked in: Compose reads `env_file` and `environment:` when a container is
-   *created*, not when it starts, so editing the file does not reach a container
-   that already exists. A strong per-install secret is generated for you.
-8. Sign in, issue fresh credentials, add them, re-enable two-factor, re-issue your REST
-   API token, reconnect your MCP clients, and restart your bots and rules — the reset
-   cleared and stopped all of them.
-
-Your REST API token and every connected MCP client are cleared by step 5, not by you in
-step 4, and the reset prints how many it deleted. They are bearer tokens held in this
-database and derived from nothing, so changing `SECRET_KEY_BASE` leaves them working and
-still able to place orders — deleting them is what invalidates them. The OAuth client
-registrations themselves survive, so a client can reconnect under the client ID it
-already has, but it has to be authorized again.
-
-Interactive Brokers is the slow one: its key pair is generated by this app and stored
-here, so it can only be replaced after step 7 — run the connect wizard again, register
-the new key in IBKR's portal, and wait for them to activate it. Registering a fresh
-key any earlier would hand IBKR a public key whose private half step 5 then deletes.
-
-### Building from Source
-
-If you prefer to build the image locally instead of using the pre-built one:
-
-```bash
-docker compose -f docker-compose.build.yml up -d --build
-```
-
----
-
-## Development Setup
-
-### Requirements
-
-- Ruby 3.4.8
-- Node.js 18.19.1
-
-Use [asdf](https://asdf-vm.com) or your preferred version manager.
-
-### 1. Install dependencies
-
-```bash
-bin/setup
-```
-
-### 2. Database
-
-```bash
-bundle exec rails db:prepare
-```
-
-### 3. Start the app
-
-```bash
-bin/dev
-```
-
-This starts the Rails server with Solid Queue (background jobs) running in-process via Puma.
-
-Alternatively, run services separately:
-
-Terminal 1 — Rails (with background jobs):
-
-```bash
-rails s
-```
-
-Terminal 2 — JavaScript bundler (optional, for live reloading):
-
-```bash
-npm run build:watch
-```
-
-### Running tests
-
-```bash
-bin/rails test
-```
-
----
-
-## Troubleshooting
-
-### Docker: Container won't start
-
-Check logs for errors:
-
-```bash
-docker compose logs web
-```
-
-Common fixes:
-- Make sure Docker Desktop is running
-- Try rebuilding: `docker compose build --no-cache`
-- Reset everything (see "Starting Fresh" above)
-
-### Docker: Port already in use
-
-Another app is using port 3737. Either stop that app, or change the port mapping. For example, to use port 4000:
-
-**Single command:** Change `-p 3737:3000` to `-p 4000:3000`
-
-**Docker Compose:** Set in `.env.docker`:
-```bash
-APP_PORT=4000
-```
----
 
 ## License
 

--- a/manual/01-welcome.md
+++ b/manual/01-welcome.md
@@ -1,0 +1,36 @@
+# Welcome to Deltabadger
+
+**Deltabadger** is your command center for growing and managing long-term portfolio of stocks and crypto.
+
+It places recurring orders (DCA), rebalance portfolios, execute direct indexing, automatically widthraw crypto from exchanges your wallet, tracks what you hold, generate tax reports, and opens MCP/Rest API gate to the markets for your agents. No matter if you run it on your local computer, Umbrel, or an online server, it can be used by multiple users, and your [API keys stay there private and encrypted](40-secrets-and-encryption-keys.md).
+
+## Invest. Track. Connect.
+
+**Bots** can both build your portfolio by dollar-cost averaging, and manage it long-term with rebalancing. When you [creating your bot](08-creating-your-first-bot.md), you can use multiple smart triggers: price suddenly dropped, RSI below 30, price below moving average, and more. You can switch between DCA and portfolio rebalancing or do both, according to your current needs.
+
+**Rebalanced DCA** is a unique Deltabadger way to DCA into multiple assets where rebalancing is with buying orders only which doesn't create tax events.
+
+You can pick a single asset, a custom basket, or [follow one of popular indexes](17-index-bot.md).
+
+[Withdrawal rules](19-withdrawal-rules.md) helps to limit your risk by regularly moving your assets from an exchange to an address in that exchange's address book once the balance passes a threshold, checked every 4 hours. See .
+
+**Tracker** shows holdings, value and profit across the exchanges you connect with read-only keys, keeps the transaction ledger, and generates [tax reports](25-crypto-tax-report.md). See [Connecting exchanges](21-connecting-exchanges.md) and .
+
+An **MCP server** and a **REST API** give Claude and your own scripts the same data. See [Connecting Claude](30-connecting-claude.md) and [REST API](32-rest-api.md).
+
+Crypto trades on the exchanges under [Supported exchanges](27-supported-exchanges.md). Stocks and ETFs trade through Alpaca, and through Interactive Brokers with a Deltabadger.com connection. See [Stocks and ETFs](29-stocks-and-etfs.md).
+
+## Market data
+
+Trading and withdrawing need only your exchange API keys; prices, candles and everything the triggers use come from the exchange itself. A market data provider is needed on top for index bots, for tax reports, which price every transaction on its day, and for keeping the list of exchanges and assets up to date. Without one you have the list that shipped with the app.
+
+A free CoinGecko API key, pasted under **Settings → Connect → Market Data**, covers all three. A Deltabadger.com connection adds market data with full price history, exchange proxies (your API traffic leaves from fixed IP addresses, so you can lock your keys to them on the exchange), the stock catalog without an Alpaca key, and Interactive Brokers. See [Market data](35-market-data.md).
+
+## Ways to run it
+
+| Method | Page |
+|---|---|
+| Docker, one command | [Quick start](02-quick-start.md) |
+| Docker Compose, with an `.env.docker` file | [Docker Compose](03-docker-compose.md) |
+| Desktop app on macOS or Linux, built from source | [Desktop app](04-desktop-app.md) |
+| Umbrel app | [Umbrel](05-umbrel.md) |

--- a/manual/02-quick-start.md
+++ b/manual/02-quick-start.md
@@ -1,0 +1,19 @@
+# Quick start
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for your operating system, and make sure it's running, then run Deltabadger with a single command:
+
+```bash
+docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage ghcr.io/deltabadger/deltabadger:latest standalone
+```
+
+That's it! Access the app at `http://localhost:3737`.
+
+## Self-Hosted plan
+
+If you have a Deltabadger.com Self-Hosted subscription, copy the one-time connect code from your dashboard and pass it when you first start the container:
+
+```bash
+docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage -e CLAIM_TOKEN=dbc_your_connect_code ghcr.io/deltabadger/deltabadger:latest standalone
+```
+
+Claiming connects subscription market data and exchange proxies, and prefills the editable admin name and email on the setup page. You can also paste the code during setup or connect later under Settings → Connect. A subscription is optional: without a claim, Deltabadger continues through the independent setup path and can use your own CoinGecko key.

--- a/manual/03-docker-compose.md
+++ b/manual/03-docker-compose.md
@@ -1,0 +1,65 @@
+# Docker Compose
+
+Alternative to the single command in [Quick start](02-quick-start.md), using Docker Compose:
+
+1. **Download docker-compose.yml:**
+
+```bash
+curl -O https://raw.githubusercontent.com/deltabadger/deltabadger/main/docker-compose.yml
+```
+
+2. **Start the app:**
+
+```bash
+docker compose up -d
+```
+
+First run downloads the pre-built image. Secrets are auto-generated. Once complete, access the app at `http://localhost:3737`.
+
+3. **Optional: Custom configuration**
+
+Create `.env.docker` to override defaults (copy from `.env.docker.example` for reference):
+
+```bash
+curl -O https://raw.githubusercontent.com/deltabadger/deltabadger/main/.env.docker.example
+cp .env.docker.example .env.docker
+# Edit .env.docker as needed. Leave SECRET_KEY_BASE empty unless you have a
+# reason not to — the container generates and persists a strong one on first run.
+```
+
+## Docker commands reference
+
+| Command | Description |
+|---------|-------------|
+| `docker compose up -d` | Start in background |
+| `docker compose down` | Stop all containers |
+| `docker compose pull` | Pull latest image |
+| `docker compose logs -f` | View logs (Ctrl+C to exit) |
+| `docker compose logs -f web` | View web server logs only |
+
+## Starting fresh
+
+If something goes wrong and you want to reset everything:
+
+```bash
+docker compose down
+docker volume rm deltabadger_storage deltabadger_logs
+```
+
+> **Note:** This deletes all data. Volume names may vary — run `docker volume ls` to see all volumes.
+
+## Production notes
+
+Secrets are auto-generated on first run and stored in `/app/storage/.secrets` (inside the volume). These persist across container restarts and upgrades.
+
+For production deployments:
+- Use a reverse proxy (nginx, Traefik) for HTTPS
+- Set `APP_ROOT_URL` and `HOME_PAGE_URL` to your domain in `.env.docker`
+
+## Building from source
+
+If you prefer to build the image locally instead of using the pre-built one:
+
+```bash
+docker compose -f docker-compose.build.yml up -d --build
+```

--- a/manual/04-desktop-app.md
+++ b/manual/04-desktop-app.md
@@ -1,0 +1,13 @@
+# Desktop app
+
+## Running with Tauri (macOS and Linux)
+
+1. Signed desktop releases are not available yet; use the [Docker quick start](02-quick-start.md) until they ship.
+2. Run `./setup.sh` first.
+3. Run `./start.sh` to use the app.
+
+On Mac, if you close the app, it continues working in the background. You can find it on the topbar.
+
+Scripts should work on Linux as well, but have not been tested.
+
+For Windows, the best way at the moment is to use Docker.

--- a/manual/05-umbrel.md
+++ b/manual/05-umbrel.md
@@ -1,0 +1,43 @@
+# Umbrel
+
+Deltabadger ships as an Umbrel app, so it runs on an Umbrel home server with no Docker commands to type.
+
+## Installing
+
+Open the Umbrel App Store, find **Deltabadger** in the Finance category and press **Install**. If it is not listed in your store, add this repository as a community app store: `https://github.com/deltabadger/deltabadger`.
+
+The app listens on port `3737`, so it opens at your Umbrel's address on port `3737`, for example `http://umbrel.local:3737`. Umbrel does not put its own login in front of it: Deltabadger has its own accounts, and the first visit shows the setup page. Continue with [First run](06-first-run.md).
+
+## Where data lives
+
+Everything is kept in the app's data directory on your Umbrel, under `data/`:
+
+| Folder | Contents |
+|---|---|
+| `data/storage` | The databases and `.secrets`, the file with this install's encryption keys |
+| `data/logs` | Application logs |
+
+The session secret is not in that folder. Umbrel derives it from the app's seed and passes it to both services as `SECRET_KEY_BASE`. A copy of `data/storage`, taken while the app is stopped, is a complete backup of a fresh install. If your install predates the `.secrets` file, its encryption keys are still derived from the Umbrel seed; run `rake deltabadger:encryption:derived_keys` first so they are stored in `.secrets` (see [Secrets and encryption keys](40-secrets-and-encryption-keys.md)). See also [Data and backups](39-data-and-backups.md).
+
+## Two services
+
+The Umbrel app runs the same image as two containers that share one database:
+
+| Service | Container | Runs |
+|---|---|---|
+| `web` | `deltabadger_web_1` | The interface; runs database migrations on start |
+| `jobs` | `deltabadger_jobs_1` | Bots, rules, exchange syncs, emails |
+
+Bots run in `jobs`. If that container is stopped, nothing trades, even though the interface still opens. The container names follow Umbrel's `<app>_<service>_1` pattern; `docker ps` lists them. Read their logs with `docker logs deltabadger_web_1` and `docker logs deltabadger_jobs_1`.
+
+The rest of this manual writes maintenance commands for the Docker Compose service, `docker compose run --rm --no-deps deltabadger …`. On Umbrel run them inside the running web container instead:
+
+```bash
+docker exec -it deltabadger_web_1 docker-entrypoint.sh rake deltabadger:encryption:report
+```
+
+Anything you set in the environment, such as your own encryption keys, has to be the same in both service blocks, or neither service can read what the other wrote.
+
+## Updating
+
+Update Deltabadger from the Umbrel App Store like any other app. Both services pull the `latest` image, and `web` migrates the database on start. The Docker steps on [Updating](07-updating.md) do not apply here.

--- a/manual/06-first-run.md
+++ b/manual/06-first-run.md
@@ -1,0 +1,33 @@
+# First run
+
+The setup page creates the admin account and, if you have one, connects a Deltabadger.com subscription. The first time you open Deltabadger it shows this page, titled **Welcome to Deltabadger**, and every other page redirects there until the admin account exists.
+
+## Admin Account
+
+Pick the interface language from the dropdown at the top; it is saved with the account and can be changed later under [Account settings](33-account-settings.md).
+
+Fill in **Name**, **Email** and **Password**. The password needs at least 8 characters, an uppercase and a lowercase letter, a digit and a symbol; the checklist under the field turns green as you type. Press **Continue**.
+
+This account is the admin: confirmed immediately, no email sent, and the only account that can set up market data, email notifications, the stock catalog and sign-up for other people (see [Multiple users](36-multiple-users.md)). After **Continue** you are signed in and land on the **Bots** page with the new-bot wizard already open. Close it if you want to look around first; **New bot** brings it back.
+
+## Have a Deltabadger.com subscription?
+
+Below the form, **Have a Deltabadger.com subscription?** unfolds a single field. Paste the **Connect code** from Deltabadger.com and press **Connect**. On success the field is replaced by **Connected ✓ — market data and exchange proxies active** (or **Connected ✓ — market data active; exchange proxies unavailable**) and **Name** and **Email** are prefilled from your subscription; both stay editable. An invalid or expired code shows an alert.
+
+If you started the container with `CLAIM_TOKEN` (see [Quick start](02-quick-start.md)), the code is redeemed on its own when the page opens and you see the connected message straight away.
+
+This step is optional. Without a subscription, create the account and use a free CoinGecko key later, or paste a connect code later, under **Settings → Connect → Market Data** (see [Market data](35-market-data.md)).
+
+## Syncing assets
+
+Once a market data provider is connected, by connect code now or under Settings later, a **Syncing assets…** banner appears at the top of every page once you are signed in, while Deltabadger loads the list of exchanges and assets and syncs each exchange's markets. With Deltabadger.com this takes a few minutes. With CoinGecko it pauses about a minute between exchanges to stay within the free plan's rate limit, so expect around a quarter of an hour. The banner disappears on its own.
+
+You can use the app in the meantime: the bot wizard works from the asset list that shipped with the app, and anything listed since appears once the sync is done. If you never connect a provider, the banner never shows and the shipped list is what you have.
+
+## What next
+
+- Create a bot: [Creating your first bot](08-creating-your-first-bot.md).
+- Connect the Tracker with read-only keys: [Connecting exchanges](21-connecting-exchanges.md).
+- Set up market data if you skipped it: [Market data](35-market-data.md).
+- Set up email so bots can alert you: [Email notifications](37-email-notifications.md).
+- Protect the account: [Two-factor authentication](34-two-factor-authentication.md).

--- a/manual/07-updating.md
+++ b/manual/07-updating.md
@@ -1,0 +1,23 @@
+# Updating
+
+## Docker
+
+First, stop and remove the old container:
+
+```bash
+docker stop deltabadger && docker rm deltabadger
+```
+
+Then pull the latest image and run:
+
+```bash
+docker pull ghcr.io/deltabadger/deltabadger:latest
+docker run -d --name deltabadger -p 3737:3000 -v deltabadger_data:/app/storage ghcr.io/deltabadger/deltabadger:latest standalone
+```
+
+## Docker Compose
+
+```bash
+docker compose pull
+docker compose up -d
+```

--- a/manual/08-creating-your-first-bot.md
+++ b/manual/08-creating-your-first-bot.md
@@ -1,0 +1,33 @@
+# Creating your first bot
+
+A DCA bot buys a fixed amount of one asset at a fixed interval on an exchange account you connect with an API key. The wizard only asks for the exchange, the key, the asset and the currency; the amount, interval and options are set on the bot's page afterwards.
+
+## New bot
+
+On the **Bots** page press **New bot** and pick the **DCA / Rebalance** card. The other card, **Index**, is covered in [Index bot](17-index-bot.md).
+
+## Pick exchange
+
+The wizard opens on **Pick exchange**: a grid of supported exchanges. Click one.
+
+The sentence above the list reads "You can also start with assets". Click **assets** to pick the asset first and see only exchanges that trade it. Either way the sentence fills in as you go — "Buy BTC on Kraken spending USD" — and clicking a filled part takes you back to that step.
+
+## Connect exchange
+
+Enter the key and secret of an API key created on the exchange (some exchanges also ask for a passphrase). The numbered guide beside the form shows where to create the key and which permissions it needs; where the exchange supports IP whitelisting it also says which IP to enter (the machine running Deltabadger, or the exchange proxy when one is configured, see [Configuration](38-configuration.md)). Press **Connect**; the key is validated before the wizard moves on. If a valid key for this exchange already exists, this step is skipped. See [API keys](28-api-keys.md).
+
+## Pick asset
+
+Search and click the asset to buy. One asset makes a DCA bot. You can keep adding assets, up to 20 — two or more turn the bot into a portfolio bot, see [Portfolio bot](15-portfolio-bot.md). Click the chosen assets in the sentence to open the basket and remove one with **×**. If no supported exchange lists every chosen asset, the wizard says so.
+
+Stocks and ETFs appear in the search when a stock catalog is active; picking one sends you to a broker instead of a crypto exchange; when more than one broker lists it, the **Pick exchange** step shows the brokers to choose from. See [Stocks and ETFs](29-stocks-and-etfs.md).
+
+## Currency
+
+Pick the currency to spend. Only currencies the exchange pairs with your asset are listed. This is the last step: the bot is created and its page opens.
+
+## Start
+
+The new bot is not running yet. Its page shows the default schedule, **Invest 100 USD / Week into BTC**, with the [amount and interval](09-amount-and-interval.md), [order options](10-order-options.md) and [triggers](11-triggers.md) below it.
+
+Press **Start**. The first order is placed right away and the next ones follow the interval, unless a starting time or a trigger holds them back. **Start** stays disabled while the API key is not valid, the exchange no longer lists the pair (a hint "Not all the assets are listed on …" appears beside it), or a setting is invalid — for example a starting date that has already passed. Stopping, restarting and renaming are described in [Managing bots](13-managing-bots.md).

--- a/manual/09-amount-and-interval.md
+++ b/manual/09-amount-and-interval.md
@@ -1,0 +1,35 @@
+# Amount and interval
+
+The amount and the interval decide how much the bot spends and how often. Together they are the sentence at the top of a bot's page — **Invest 100 USD / Week into BTC** — and everything below it is optional.
+
+## The sentence
+
+The amount is a number field in the currency you picked when creating the bot. Type a new value and it saves on its own. Any amount above zero is accepted; the exchange minimum is handled separately, see below.
+
+The interval is a dropdown: **Hour**, **Day**, **Week** or **Month**. A monthly bot orders on the same day of each month.
+
+Both fields are locked while the bot runs. Press **Stop**, change them, then **Start** again; a bot that has run before then asks how to handle the missed part of the schedule, see [Managing bots](13-managing-bots.md).
+
+The asset and the currency cannot be changed once the bot exists. To trade another pair, create another bot.
+
+## How the schedule runs
+
+When you press **Start**, the first order is placed right away and the interval counts from that moment. To delay the first order, set a starting time in [Order options](10-order-options.md).
+
+An order that could not be placed is not lost. The bot keeps track of how much it should have invested since it started, and adds the shortfall to its next order.
+
+## Exchange minimum order size
+
+Every exchange sets a minimum order size for each pair, in the asset, in the currency, or both. When the amount is below it, the bot does not send the order. The orders table shows it as skipped, with the explanation "This order has been skipped because the amount was below the … minimum order size. The amount has been buffered and added to the next order." The buffered amount is added to the next scheduled order, so orders combine until they clear the minimum.
+
+When this happens on the very first order, a modal titled **Congratulations! Your bot is running.** explains it and quotes the exchange minimum for your pair, in both the asset and the currency. Press **Got it!**; nothing needs to change unless you would rather raise the amount.
+
+Splitting the amount with **Smart Intervals** makes each order smaller, so check the unit against the minimum too.
+
+## Market orders
+
+By default the bot buys at market price: the order fills immediately at the exchange's current ask and pays the taker fee. To place limit orders instead, switch on **FeeCutter** in [Order options](10-order-options.md).
+
+## Running out of funds
+
+When the balance in the spend currency falls below about three days of contributions, the bot emails you, see [Email notifications](37-email-notifications.md).

--- a/manual/10-order-options.md
+++ b/manual/10-order-options.md
@@ -1,0 +1,37 @@
+# Order options
+
+Three toggles sit under the main sentence of every DCA bot: **Smart Intervals**, **FeeCutter** and a starting time. Each is off by default. Switch one on, set its value, and it saves on its own. All three are locked while the bot runs; press **Stop** to change them.
+
+## Smart Intervals
+
+The toggle reads **Smart Intervals** Split the amount into 10 USD units. It splits each contribution into smaller, equal orders spread evenly across the interval, so you buy more often at more prices. The line under it spells out the result: "Splitting your 100 USD / Week into units of 10 USD will result in one investment every about 17 hours."
+
+The one parameter is the unit size, in the spend currency; it is prefilled with a tenth of the amount, or more when a tenth would sit under the floor described next. The field has a floor: a unit cannot be so small that orders would come more often than every five minutes, or finer than the currency's precision on the exchange.
+
+Check the unit against the exchange minimum order size. A unit below it is skipped and buffered into the next one, so orders arrive less often than the line says, see [Amount and interval](09-amount-and-interval.md).
+
+On a bot that sells a fixed amount of the asset the split is in the asset; a bot that sells for a fixed currency amount does not offer Smart Intervals, see [Selling](12-selling.md).
+
+## FeeCutter
+
+The toggle reads **FeeCutter** Cut fees using limit orders 0.1% below the price. It replaces market orders with limit orders placed at the last traded price minus the percentage you set (a selling bot places them above the price). An order that waits in the order book pays the exchange's maker fee instead of the taker fee.
+
+The one parameter is the distance below the price, in percent; the default is 0.1. The line under the toggle names the exchange's maker fee: set the distance to it to cut the fee to zero, lower for faster execution, higher for a potentially better price.
+
+A limit order fills only if the price reaches it. Until then it stays open on the exchange; the bot checks open orders at each run and counts them as invested, so it does not buy again in their place. Open orders are listed in the orders table, where you can cancel them, see [Charts, statistics and orders](14-charts-statistics-and-orders.md).
+
+On Hyperliquid the toggle is locked on: Hyperliquid does not support market orders on spot.
+
+## Starting time
+
+The third toggle reads **Start on Monday** or **Start at**, depending on its mode. It delays the first order to a moment you choose; after it, the interval counts from that moment.
+
+| Mode | Sentence | Meaning |
+|---|---|---|
+| **Monday** … **Sunday** | **Start on Monday** 09:30 | The next such weekday at that time |
+| **date** | **Start at** a date and time | That exact moment; it must be in the future when you press **Start** |
+| **hour** | **Start at** 00:00 | The next time the clock shows that hour, today or tomorrow |
+
+Times are in your time zone, set under [Account settings](33-account-settings.md); the zone's abbreviation is shown after the field. The default is the next Monday at 09:30 New York time converted to your zone — the NYSE opening bell, which suits stock bots.
+
+The setting applies to the first order only. Once that order runs, the toggle switches itself off and the bot continues at its interval. Switch it on again with a new value to plan another delayed start.

--- a/manual/11-triggers.md
+++ b/manual/11-triggers.md
@@ -1,0 +1,37 @@
+# Triggers
+
+Triggers are the rules listed under the main sentence of a single-asset bot. The bot keeps its schedule from [Amount and interval](09-amount-and-interval.md), but a trigger decides whether an order is actually placed: only while the market meets a condition, only after it has met it once, or by switching the bot into selling when it does.
+
+Triggers belong to single-asset bots. A [Portfolio bot](15-portfolio-bot.md) or an [Index bot](17-index-bot.md) has Smart Intervals, FeeCutter, Starting time and Rebalance, nothing else. Like every other setting, a trigger is locked while the bot runs: press **Stop**, change it, press **Start**.
+
+## The mode
+
+Each trigger sentence starts with a dropdown that sets what the trigger does:
+
+| Mode | What happens |
+|---|---|
+| **Buy only** | Orders are placed only while the condition holds. When it stops holding, the status bar reads **Waiting for all conditions to be met** and the bot checks again, every minute for the price triggers and at each candle close for the moving average and RSI triggers. |
+| **Start buying** | The bot waits for the condition once. After it has been met, orders follow the schedule and the condition is not checked again. |
+| **Start selling** | The bot keeps buying and watches. The moment the condition is met it reverses into selling, see [Selling](12-selling.md). |
+
+The price-drop trigger offers **Start buying** and **Start selling** only.
+
+## Price
+
+**Buy only when price is above / below / between …** with the price in the quote currency. **between** takes two prices and is available in **Buy only** mode. The line under the sentence shows the current price so you can see how far the market is from the condition.
+
+## Price drop
+
+**Start buying when price drops X% from its all-time high** or **24h high**. The default is 20% from the all-time high. The line under the sentence shows the current reference high.
+
+## Moving average
+
+**Buy only when the price is above / below the SMA 9 on daily candles.** Pick **SMA** or **EMA**, the period, and the candle timeframe: **hourly**, **4-hour**, **daily**, **3-day**, **weekly** or **monthly**. The line under the sentence shows the moving average on the last candle close.
+
+## RSI
+
+**Buy only when the RSI on daily candles is above / below 30.** The RSI uses a 14-candle period; the candle timeframes are the same as for the moving average. RSI is the only indicator offered.
+
+## Don't spend more than
+
+The last rule caps the total: **Don't spend more than 1000 USD**. It counts what the bot has bought since the rule was switched on, open orders included, and shows what is left, for example **(400 USD left)**. When the cap is reached the bot stops itself, the status bar reads **Paused** and the rule's line reads **The whole amount has been invested**; when [Email notifications](37-email-notifications.md) are set up, it also sends the "invested full amount" email. A bot whose cap is already reached cannot be started. Switch the rule off to reset the target.

--- a/manual/12-selling.md
+++ b/manual/12-selling.md
@@ -1,0 +1,33 @@
+# Selling
+
+A single-asset bot can sell on a schedule as well as buy: to take profit in steps, to exit a position without timing the market, or to alternate between buying and selling on a [trigger](11-triggers.md). Portfolio and index bots do not sell this way; for them see [Index changes](18-index-changes.md).
+
+## The ⇄ control
+
+The ⇄ icon at the end of the main sentence rotates the bot through three states:
+
+| State | Sentence | What a tick does |
+|---|---|---|
+| Buying | **Invest 100 USD / Week into BTC** | Buys BTC for 100 USD |
+| Selling an amount | **Sell 0.01 BTC / Week to USD** | Sells 0.01 BTC |
+| Selling for an amount | **Sell BTC for 100 USD / Week** | Sells as much BTC as is worth 100 USD at the order price |
+
+A fourth press returns to buying. The control works only while the bot is stopped. If the bot has open orders you are asked to confirm, because reversing cancels them: **Reversing will cancel any open orders on this bot. Continue?**
+
+The sell sentence starts with an empty amount. Fill it in; until you do the bot runs but sells nothing. The selling interval is separate from the buying one and starts out equal to it.
+
+> **Note:** The bot sells from your exchange balance of the asset, not only from what it bought. Each tick sells the configured amount, capped by the free balance on the exchange.
+
+## Options while selling
+
+**Smart Intervals** splits the amount to sell into smaller units; it is not offered while selling for a quote amount. **FeeCutter** places limit orders the chosen percentage *above* the price instead of below. **Starting time** works as when buying. See [Order options](10-order-options.md).
+
+## Triggers while selling
+
+Every trigger keeps a separate setting for each direction, so switching the bot to selling does not carry the buy-side conditions over. The mode reads **Sell only**, **Start selling** or, as the flip, **Start buying**. The price-drop trigger mirrors: **Start selling when price rises X% from its 24h low / 7d low**. The RSI trigger defaults to above 70, the moving average to price above the SMA 9 on daily candles.
+
+A buy-side trigger set to **Start selling** and a sell-side trigger set to **Start buying** turn the bot into a simple trading bot that alternates. A trigger flip keeps the selling state you chose with ⇄ (an amount or a quote amount).
+
+## Don't sell more than
+
+While selling, the spend cap becomes **Don't sell more than 0.5 BTC**. It counts what has been sold since the rule was switched on, open sell orders included. When the cap is reached the bot stops itself; the status bar reads **Paused** and the rule's line reads **The whole amount has been sold**. When [Email notifications](37-email-notifications.md) are set up it also sends the "sold full amount" email. Switch the rule off to reset the target.

--- a/manual/13-managing-bots.md
+++ b/manual/13-managing-bots.md
@@ -1,0 +1,39 @@
+# Managing bots
+
+Bots live on the **Bots** page and each bot has its own page. This is where you start, stop, rename, archive, delete and move bots between exchanges.
+
+## The Bots page
+
+Every bot is a tile with its asset or index, the exchange logo, its P/L, its name, the status bar and the **Start** / **Stop** button. Drag tiles to reorder them. Above the tiles sits the P/L of the whole account; click it to switch between percent and amount. A filter with **All**, **Active**, **Inactive** and **Archived** appears once you have bots in different states or an archived one. **New bot** opens the wizard, see [Creating your first bot](08-creating-your-first-bot.md).
+
+With exactly one bot there is no list: the menu entry reads **Bot** and opens that bot directly.
+
+## Start and Stop
+
+**Start** is greyed out when the bot cannot run: the API key is not valid, an asset is not listed on the exchange (**Not all the assets are listed on …**), or a portfolio's allocations do not add up to 100%. While the bot runs its settings are locked. **Stop** cancels the schedule and the status reads **Paused**.
+
+Starting a bot that has run before opens a choice. Inside the interval: **Continue original schedule** or **Skip it**, which orders immediately. Past it: **Do you want to invest … missed while the bot was paused …** with **Yes, buy and continue** or **Skip the missed part**.
+
+## Statuses
+
+| Status bar | Meaning |
+|---|---|
+| Countdown with a progress bar | Time to the next order |
+| **Paused** / **Paused: …** | Stopped, with the reason when the bot stopped itself |
+| **Setting orders…** | An order is being placed |
+| **Waiting for all conditions to be met** | A [trigger](11-triggers.md) is not met |
+| **Last order failed: … - Next try in …** | The order failed and will be retried |
+| **The market is closed now.** with a countdown | A stock bot waiting for the market to open |
+| **Archived** | See below |
+
+## The ⋯ menu
+
+**Change name** replaces the default name, which is the asset, basket or index the bot buys. **Archive** asks **Do you want to archive this bot?**; an archived bot leaves the list, trades nothing and keeps its history. Find it under the **Archived** filter, where **Reactivate** takes the place of **Start** and returns it to the stopped state. **Delete** asks **Do you want to delete this bot?** and removes the bot from Deltabadger for good; there is no undo. Archive instead if you may want the numbers later.
+
+## Exchange and keys
+
+The exchange chip at the top left of the bot page opens a menu. **Add new keys** replaces the current key, see [API keys](28-api-keys.md); when the key is not valid a **Connect** button sits next to the chip. Below the divider are the other exchanges that list the bot's assets, those with saved keys highlighted; picking one moves the bot there. The menu says when it cannot: **Stop the bot to move it to another exchange.**, **No other supported exchange lists …**, or **This exchange no longer operates — switch the bot to another one.**
+
+## Switching bots
+
+The bot name at the top of the page is a dropdown with **New bot +** and every other bot.

--- a/manual/14-charts-statistics-and-orders.md
+++ b/manual/14-charts-statistics-and-orders.md
@@ -1,0 +1,36 @@
+# Charts, statistics and orders
+
+The bot page shows what the bot has done: a chart of the position over time, a statistics panel with the holdings, and a log of orders and events. The chart appears after the bot's first order attempt.
+
+## Chart
+
+The chart draws the portfolio value against the total invested, marked at the market price. The headline shows the date, the P/L and the percentage; move along the curve to read any point.
+
+A switch above the plot toggles between **Value** and **P/L**. **Value** plots both curves; it always climbs for a DCA bot because the money going in climbs. **P/L** makes the invested line the zero line and plots the distance from it, so the shape is performance alone.
+
+Point at a row of the holdings table to draw that asset alone; click the row to pin it so you can read along its curve, click again to let go. With **Hide balances** on (see [Account settings](33-account-settings.md)) the chart shows percentages only.
+
+## Statistics
+
+**Total Invested** (**Total invested** on portfolio and index bots) and **Portfolio Value** are shown in the bot's quote currency. Portfolio and index bots add **Realised P/L** once something has been sold from the basket: it comes from selling assets removed from the portfolio, and rebalancing is not counted, see [Index changes](18-index-changes.md).
+
+The holdings table lists each asset with **Amount**, **Avg. Price**, **Value** and **P/L**. If the exchange cannot be reached the panel says so: **The exchange API does not respond at the moment. Calculations are based on the last data available.**
+
+## Orders
+
+The log combines orders and bot events. Tabs appear once there is more than one kind of row:
+
+| Tab | Rows |
+|---|---|
+| **All** | Everything as sentences: **Bought 0.001 BTC for 100 USD**, **Bot started**, **Paused: price limit not met**, **Rebalancing — selling the overweight asset** … |
+| **Transactions** | Filled orders with **Date**, **Amount**, **Value** and **Price** |
+| **Scheduled** | Open orders, that is limit orders not yet filled |
+| **Other** | Cancelled, skipped and failed orders |
+
+An open order has a **Cancel** button that cancels it on the exchange. A row marked **Skipped (below minimum)** was under the exchange minimum; the amount is carried into the next order, see [Amount and interval](09-amount-and-interval.md). Older rows load on their own below the newest ones.
+
+## Export and Import
+
+**Export** refreshes the open orders and downloads `orders.csv` with every filled order: `Timestamp`, `Order ID`, `Type`, `Side`, `Amount`, `Value`, `Price`, `Base Asset`, `Quote Asset`, `Status`.
+
+**Import** takes a CSV exported from Deltabadger and adds its orders to this bot, for example after recreating a bot. Only rows with the status `Closed` are imported, only those whose currencies match the bot's, and rows already imported into this bot are skipped. The result is reported as **Successfully imported N order(s)**, **No new orders to import …**, **Currency mismatch …** or **Invalid CSV format. Please use a file exported from this application.** Imported orders count in the statistics and cannot be cancelled.

--- a/manual/15-portfolio-bot.md
+++ b/manual/15-portfolio-bot.md
@@ -1,0 +1,35 @@
+# Portfolio bot
+
+A portfolio bot invests one amount across a basket of 2–20 assets at weights you choose. Use it when you want one schedule and one budget for several assets instead of a bot per asset.
+
+## Creating one
+
+Press **New bot** and choose the **DCA / Rebalance** card. On the **Pick asset** step add two or more assets; the basket table under the search removes one with **×**. The rest of the wizard is the same as for one asset — see [Creating your first bot](08-creating-your-first-bot.md). All assets must trade against the same quote currency on one exchange; otherwise the wizard says "This combination of assets doesn't exist on any supported exchange." For stocks see [Stocks and ETFs](29-stocks-and-etfs.md).
+
+The bot starts with equal weights and is named after its basket, for example "BTC, ETH, XRP + 3".
+
+## Allocations
+
+The main rule reads "Invest 100 USD / Week" above one slider per asset. Each slider is that asset's share in percent; the **Total** row shows the sum. The bot cannot start until the total is 100% — "Allocations add up to 95% — they must add up to 100% before the bot can start." Press **Normalize** to scale the sliders proportionally to 100%.
+
+- **+ Add asset** searches for another asset the exchange lists against your quote currency (up to 20). It starts at 0%.
+- **×** next to a slider removes the asset (at least 2 must remain).
+- An asset at 0% stays in the portfolio and receives nothing from contributions; with **Rebalance** on, anything it still holds is sold down over the next checks.
+
+Assets and allocations are locked while the bot is running and while a rebalance is in progress. The quote currency cannot change once the bot has placed orders.
+
+## How a contribution is split
+
+At every interval the bot values its holdings at current prices, adds the contribution, and works out each asset's target value at its weight. The money goes only to assets below target, in proportion to their shortfall. Nothing is sold; an asset far above its weight receives nothing until the others catch up, so contributions alone pull the portfolio toward its weights. An order below the exchange minimum is skipped and buffered into the next contribution — see [Amount and interval](09-amount-and-interval.md).
+
+## Options
+
+A portfolio bot has **Smart Intervals**, **FeeCutter** and **Starting time** — see [Order options](10-order-options.md) — and **Rebalance**, see [Rebalancing](16-rebalancing.md). It has no [triggers](11-triggers.md) or spend cap and cannot switch to [selling](12-selling.md); those exist only on single-asset bots.
+
+## Removed assets
+
+Removing an asset you already hold does not sell it. It moves to the **Removed from portfolio** table, where you can sell it and redeploy the proceeds — see [Index changes](18-index-changes.md).
+
+## Legacy two-asset bots
+
+Older two-asset "Rebalanced DCA" bots keep running and stay editable, but new ones can no longer be created — make a portfolio bot with two assets instead.

--- a/manual/16-rebalancing.md
+++ b/manual/16-rebalancing.md
@@ -1,0 +1,30 @@
+# Rebalancing
+
+The **Rebalance** option keeps a [portfolio bot](15-portfolio-bot.md) or an [index bot](17-index-bot.md) close to its target weights by swapping between the assets it holds. It is separate from the DCA contribution: it runs on its own clock, spends no new money, and keeps working while the schedule is stopped.
+
+## Turning it on
+
+The last toggle in the bot's settings reads "Rebalance when an asset drifts more than **5** % from its target". The number is the drift threshold in percentage points; the default is 5. Drift is the largest gap between any one asset's current share of the portfolio's value and its target — an asset meant to be 40% that is now 47% is 7 points off. It is measured on current value, not cost.
+
+This toggle can be changed while the bot is running. While it is on, the settings show "Keeps running while the DCA schedule is stopped. Always uses market orders." and the live reading "The portfolio is 6.2 % off its target split", green once it exceeds the threshold. If the correcting trade would be below the exchange's minimum order size, it adds "— too small to trade at this exchange's minimum" and nothing happens until the drift grows.
+
+## What a rebalance does
+
+1. Sells the most overweight asset down to its target, at market.
+2. Buys the most underweight asset with the proceeds, at market.
+
+One order per check: the sell at one check, the buy at the next once the sell has filled, so a swap takes up to two checks and the proceeds sit as cash in between (still counted in **Portfolio Value**). With more than two assets each swap fixes one pair and the portfolio converges over several checks. Money the buy does not need goes to the next-most-underweight asset; too little to place is logged as "Too little left over to rebalance — leaving it as cash". The bot never sells more than is actually on the exchange.
+
+Rebalance orders are always market orders, even with FeeCutter on, so expect taker fees on both legs. They are not contributions: they do not count toward **Total invested** or **Realised P/L**. The orders table shows them as "Rebalancing — selling the overweight asset" and "Rebalancing — buying back into the underweight asset". Assets that have left the composition are ignored — see [Index changes](18-index-changes.md).
+
+## When it is checked
+
+Every 4 hours, independently of the bot's interval, and also while the bot is paused. Archived bots are not checked; stocks are only traded while the market is open.
+
+While a rebalance is in progress — sold, buy still owed — a scheduled contribution is skipped ("Contribution skipped — a rebalance is still in progress") and carried into the next one. The exchange cannot be changed until it completes, and on a portfolio bot the assets and allocations are locked too. Turning the toggle off mid-swap still lets the owed buy finish.
+
+## If it halts
+
+When the outcome of a rebalance order cannot be confirmed, the settings show "Rebalancing paused — check your exchange" with a **Resume** link, and the bot places no further orders.
+
+> **Note:** Check the exchange for open rebalancing orders before pressing **Resume** — resuming on top of a live order can sell or buy the same amount twice. If an order is still open, the app refuses: "Order … is still open on your exchange. Wait for it to settle first."

--- a/manual/17-index-bot.md
+++ b/manual/17-index-bot.md
@@ -1,0 +1,36 @@
+# Index bot
+
+An index bot invests on a schedule into a basket picked by market cap — the top coins overall or a category such as Layer 1 — and keeps the basket in step with the market.
+
+## Requirements
+
+Index bots need market data: a Deltabadger.com connection or a CoinGecko key, see [Market data](35-market-data.md). Without one the wizard opens on **Connect CoinGecko**, where an admin pastes a CoinGecko API key; other users are told to ask the admin. A bot without market data will not start: "A market data provider must be configured for Index bots."
+
+## Creating one
+
+Press **New bot** and choose the **Index** card ("Build your personal ETF"). The steps are **Connect CoinGecko** (skipped once market data is configured), **Pick index**, **Exchange**, **Connect exchange**, **Currency**, then a final settings page — see [Creating your first bot](08-creating-your-first-bot.md) for keys and currency. The exchange table's **Coins** column shows which of the index's coins each exchange lists — the first few tickers and a +N for the rest.
+
+## Pick index
+
+A searchable grid of tiles, each with a description and sample tickers:
+
+- **Top Coins** — "Top cryptocurrencies by market cap. The S&P 500 of crypto."
+- Category indices built from CoinGecko's coin categories, for example Layer 1, Layer 2, Meme, DeFi or AI. A category is offered only when at least 3 of its coins trade on a supported exchange; stablecoin categories are left out. The list is refreshed once a day.
+- With a Deltabadger.com connection, indices provided by Deltabadger.com appear first; these can include stock indices — see [Stocks and ETFs](29-stocks-and-etfs.md).
+
+The index cannot be changed once the bot has placed orders.
+
+## Settings
+
+The last step is the bot's settings. The main rule reads "Invest 100 USD / Week into Top 10" with two sliders:
+
+- **Number of coins** — how many of the index's top coins to hold, 2 to 50, limited to what your exchange lists against your currency. New bots start at 10; an index with a fixed member list starts at its full size and you trim it down.
+- **Allocation flattening** — 0% weights the coins purely by market cap, 100% gives every coin an equal share, anything between blends the two.
+
+The **Index Preview** under the sliders shows the resulting composition on your exchange; click it to switch between pie and list. If the exchange lists fewer coins than you asked for, a note says so: "8 of 10 coins in the index are available on Kraken".
+
+Below are **Smart Intervals**, **FeeCutter**, **Starting time** ([Order options](10-order-options.md)) and **Rebalance** ([Rebalancing](16-rebalancing.md)); index bots have no [triggers](11-triggers.md). Press **Start**: the bot is created, starts immediately and opens on its page, named after the index — "Top 10", "Layer 1 · 20".
+
+## How the composition follows the market
+
+Before every contribution and every rebalance check, the bot re-reads the index ranking and rebuilds its composition: the top N coins your exchange lists against your currency, weighted by market cap with your flattening applied. A coin you already hold is not dropped over a momentary price glitch; it leaves only when it falls out of the top N or the exchange stops listing it. A coin that has left stops receiving contributions and moves to the **Left the index** table; it is not sold automatically — see [Index changes](18-index-changes.md). Each contribution is split across the coins below their target weight, as on a [portfolio bot](15-portfolio-bot.md).

--- a/manual/18-index-changes.md
+++ b/manual/18-index-changes.md
@@ -1,0 +1,32 @@
+# Index changes
+
+When a coin drops out of an [index bot](17-index-bot.md)'s composition, or you remove an asset from a [portfolio bot](15-portfolio-bot.md), the bot still holds it. It is listed, you decide when to sell it, and the proceeds can go back into the basket.
+
+## The table
+
+Under the holdings table on the bot page a second table appears, headed **Left the index** (index bot) or **Removed from portfolio** (portfolio bot). Each row shows Amount, Avg. Price, Value and P/L for one asset, with a **Sell** button. Nothing in it is sold automatically: the bot stops buying the asset and [rebalancing](16-rebalancing.md) ignores it. A holding too small to sell at the exchange's minimum order size is not listed. A coin that re-enters the index moves back to the main table.
+
+## Sell
+
+Press **Sell** on a row. The confirmation reads "Sell this position? It is closed at market price." The whole position is sold with a market order, never more than is actually on the exchange, and the orders table records "Selling an asset that left the index". Positions are sold one at a time, because each sale is a separate taxable disposal.
+
+A sale is refused while a rebalance, another sale or a redeploy is still in progress, while the market is closed (stocks), and on an archived bot. If FeeCutter left an open limit buy for that asset, it is skipped — "An asset that left the index could not be sold — left in place" — until that order settles or is cancelled.
+
+## Realised P/L
+
+Once a sale has realised a gain or loss, the statistics panel gains **Realised P/L**: what the sales brought in minus what the sold assets cost. Its tooltip reads "From selling assets removed from the portfolio. Rebalancing is not counted." Selling does not move the bot's total P/L at that moment — the holding's value becomes cash, which **Portfolio Value** still counts.
+
+## Redeploy
+
+The proceeds stay as cash on the exchange. At the bottom of the statistics panel the bot asks "Redeploy 250.00 USD?" with **Yes** and **No**.
+
+- **Yes** buys back into the basket at market, spread across the assets below their target weight, even while the bot is stopped. A share too small for the exchange minimum is added to the most underweight asset instead.
+- **No** takes that amount off the table for good; proceeds of later sales are offered on their own. The cash stays on the exchange, and regular contributions count it before new money.
+
+The prompt is hidden while a sale, rebalance or redeploy is still working, and for amounts below the smallest minimum order size in the basket.
+
+## Unconfirmed orders
+
+If the outcome of a sale or a redeploy order cannot be confirmed, the panel shows "Sale unconfirmed — check your exchange" or "Redeploy unconfirmed — check your exchange" with a **Clear** button, and the bot places no orders until you clear it.
+
+> **Note:** Check the exchange before pressing **Clear**. Clearing while the order is live lets the bot trade on top of it — selling coins twice or spending the same cash twice. If the order is still open, the app refuses: "Order … is still open on your exchange. Wait for it to settle first."

--- a/manual/19-withdrawal-rules.md
+++ b/manual/19-withdrawal-rules.md
@@ -1,0 +1,40 @@
+# Withdrawal rules
+
+A withdrawal rule sends an asset from an exchange to a wallet address registered on that exchange, on its own, once the balance is worth moving. Use it to keep what your bots buy off the exchange without doing it by hand. Rules live under **Rules** in the left menu.
+
+## What a rule says
+
+A rule is one sentence: **Withdraw** N **% of** ASSET **from** EXCHANGE **to** ADDRESS **when** … The percentage defaults to 100. The threshold is one of two:
+
+- **fee is less than** N **%** — waits until the balance is large enough that the withdrawal fee is under N % of the amount sent. Default 0.5 %. Offered only when the exchange reports a fee for the asset; the tile then says at which balance the withdrawal triggers.
+- **the amount crosses** N ASSET — waits until the share you withdraw would be at least N (with 100 % that is a balance of N). The tile shows the fee as a percentage of that amount, in red above 1 %.
+
+**or at least every** N **days** is optional: a withdrawal also goes out once N days have passed since the last successful one, even below the threshold. Leave it empty to turn it off.
+
+Each withdrawal takes N % of the balance not tied up in open orders and sends it minus the fee. If the exchange offers several networks for the asset, the **Settings** step adds **on** NETWORK with the fee per network; pick the one your wallet expects — it cannot be changed after the rule is created.
+
+## Creating a rule
+
+Press **Add** on the Rules page:
+
+1. **Pick asset** — a crypto asset.
+2. **Pick exchange** — only exchanges that support withdrawals are listed: Binance, Binance.US, Kraken, Gemini and MEXC.
+3. **Connect exchange** — a withdrawal key, separate from any trading key. Skipped when you already have one for that exchange.
+4. **Address** — chosen from the exchange's own address book; you cannot type one in.
+5. **Settings** — the sentence above, then **Create Rule**.
+
+Steps 3 and 4 are covered in [Withdrawal keys and addresses](20-withdrawal-keys-and-addresses.md). One rule per asset and exchange. A new rule starts switched off.
+
+## The rule tile
+
+The toggle switches the rule on and off. Switching it on shows "The rule is active." and checks the balance right away. Settings and the address can only be changed while the rule is off. The red X next to the toggle deletes a rule that has been switched on and off again (a rule that has never been on has no X yet), after asking "Do you want to delete this withdrawal rule?". When the rule has a network, a memo or an address label, hovering the address shows the full address with those details.
+
+While the rule is on, a bar under the sentence shows how close the last balance the rule saw is to the trigger amount. It drops to 0 % after a withdrawal.
+
+## When rules are checked
+
+Every active rule is evaluated every 4 hours, and immediately when you switch it on. Each check reads the balance, refreshes the withdrawal fee if it is older than a day, then either withdraws or waits.
+
+## The log
+
+The table under the tiles lists the last 50 entries across your rules: **Date**, **Status**, **Message**. `success` is a withdrawal ("Withdrew 0.01 BTC"), `failed` is an error from the exchange, and `transient` (gray) is a temporary problem the next check retries on its own. Checks that found the balance below the threshold are not listed.

--- a/manual/20-withdrawal-keys-and-addresses.md
+++ b/manual/20-withdrawal-keys-and-addresses.md
@@ -1,0 +1,31 @@
+# Withdrawal keys and addresses
+
+A withdrawal rule needs two things from the exchange: a key that may withdraw but not trade, and an address the exchange already knows. Deltabadger never accepts a typed-in address, so the exchange's own allowlist decides where funds can go.
+
+## Withdrawal keys
+
+A withdrawal key is a separate API key from the one a bot trades with. Create it with these permissions and nothing else — in particular, leave trading off:
+
+| Exchange | Enable |
+|---|---|
+| Binance, Binance.US | Enable Reading, Enable Withdrawals, IP restriction |
+| Kraken | Funds: Query, Withdraw; IP restriction |
+| Gemini | Account Balance, Fund Management; key scope Primary |
+| MEXC | View Order Details, Withdraw; Link IP Address |
+
+The **Connect exchange** step of the rule wizard shows the exact clicks for each exchange under **How to get API keys from …**, including the IP to whitelist (see [API keys](28-api-keys.md)). Paste the key and secret and press **Connect**. Binance and Binance.US reject a key whose permissions differ from the table above — trading still on, IP restriction off, or anything extra. On Kraken and Gemini a missing permission shows up as "Failed to validate API key permissions" rather than a rejection.
+
+Withdrawal keys appear under **Settings → Connect → API keys** in the **Withdrawal keys** list. Click the exchange name to see the required permissions again; the X removes the key. Removing it does not stop the rule — the rule fails at its next check.
+
+## Addresses
+
+Deltabadger reads the destination from the exchange's address book (Binance, Binance.US, MEXC), pre-registered withdrawal addresses (Kraken, verified ones only) or approved addresses (Gemini, active ones only). Add the address on the exchange before creating the rule; where the exchange has a waiting period for new addresses, wait it out. The in-app guide also recommends switching on the exchange's withdrawal whitelist, so a compromised key cannot send funds anywhere else.
+
+The **Address** step picks the first listed address for you. On the **Settings** step, and on the rule tile once the rule has been switched on and off again, the address is a dropdown of everything the exchange lists for that asset. Anything the exchange does not list is refused: the wizard returns you to the Address step, and the tile says "That address is not on the exchange's withdrawal allowlist".
+
+Two things can go wrong on the Address step:
+
+- "There is no defined withdrawal address for BTC. Set it up on Kraken first." — add the address on the exchange, then press **Check again**.
+- "Could not fetch withdrawal addresses from Kraken. Please try again later." — the exchange did not answer, the key cannot read the list, or Deltabadger cannot list addresses for that asset on that exchange (Gemini covers a fixed set of coins). The key form is shown again so you can re-enter it; if the key is fine, wait and retry.
+
+> **Note:** The address list is only as safe as your exchange account. Check that the address you register there is your own wallet on the right network; a withdrawal to a wrong address or network cannot be reversed.

--- a/manual/21-connecting-exchanges.md
+++ b/manual/21-connecting-exchanges.md
@@ -1,0 +1,37 @@
+# Connecting exchanges
+
+The Tracker reads your exchange accounts and turns their history into one portfolio. Everything under **Tracker** — the [overview](22-portfolio-overview.md), the [record](23-transactions-and-positions.md), the [tax reports](25-crypto-tax-report.md) — is built from what it fetches here.
+
+## Adding an exchange
+
+1. Open **Tracker** and press **+**.
+2. Type the exchange name and pick it. The list shows each exchange's maker and taker fee.
+3. Paste an API key with read permission and press **Connect**. The steps for creating one are next to the form; see [API keys](28-api-keys.md) for what each exchange requires.
+
+An exchange already connected for a bot needs no second key: a trading key can read, so the Tracker uses it and skips the form. If that trading key has stopped working, the Tracker asks for a read-only key of its own rather than failing with the bots.
+
+A rejected key shows **Incorrect API key permissions**. **Failed to validate API key permissions** means the exchange could not be reached to check it — try again in a moment. A new key starts fetching your transaction history right away; press **Sync** to load balances (the holdings card says **Click Sync to load your portfolio.** until you do). A reused trading key also needs **Sync**.
+
+## Sync
+
+**Sync** (the arrows button at the right of the bar) fetches your transaction history — trades, deposits, withdrawals, rewards — and your current balances from every connected exchange. Progress shows per exchange as **Importing data from …**; afterwards, withdrawals are matched to the deposits they became (see [Transactions and positions](23-transactions-and-positions.md)) and every figure is recalculated. You rarely need to press it: history and balances are fetched once a day on their own, and a bot placing an order syncs its exchange right away.
+
+**Synced … ago** is the age of the balances. It turns amber when prices are older than the balances: the quantities are current, the money beside them is not.
+
+## Exchange filter
+
+With more than one exchange connected (or one whose key has stopped working), a switch appears above the chart: **All** or one exchange. It scopes the whole page — chart, figures, holdings, positions and transactions. A retired exchange stays in the list for the history it contributed but cannot be reconnected. An exchange whose key was removed or stopped working keeps its place, but its chip opens the key form instead of filtering.
+
+## Sync warnings
+
+A failed sync leaves a banner until the next sync succeeds: **Sync failed for … Transactions from there may be missing — reports generated now can be incomplete.** The message that arrives with the failure says what to do:
+
+| Message | Cause |
+|---|---|
+| … is missing the permission needed to read your transaction history / your balances | The key is valid but lacks a permission. Fix it on the exchange, or create a new key. |
+| … sync failed: … Please update the API key below. | The exchange rejected the key. It is marked invalid; enter a new one. |
+| … is temporarily unavailable. | The exchange did not answer. Sync again in a few minutes. |
+| … sync failed: … Please try again. | Any other error, with the exchange's own message. The key is not marked invalid. |
+| Balances synced, but USD pricing is unavailable right now | Balances are fresh; the chart keeps the last known prices until pricing returns. |
+
+The **Holdings** card names any asset the app could not price: **Pricing unavailable for: …**. Pricing needs market data — see [Market data](35-market-data.md).

--- a/manual/22-portfolio-overview.md
+++ b/manual/22-portfolio-overview.md
@@ -1,0 +1,40 @@
+# Portfolio overview
+
+The top of the **Tracker** page reads your portfolio as one account: a chart, six figures and a card of what you hold. All of it comes from the transactions and balances the Tracker fetched (see [Connecting exchanges](21-connecting-exchanges.md)) and follows the exchange filter above it.
+
+## Chart
+
+The chart draws the portfolio's value day by day against the money put into it. **Value** plots both curves; **P/L** plots the difference. **30D**, **1Y** and **All** narrow the window — a range longer than your history is not offered. Hover a point to read its date, money and percentage in the headline. The history is swept from your first transaction forward when the page first opens, so a new account shows a spinner until it finishes.
+
+## The six figures
+
+| Figure | What it means |
+|---|---|
+| **Total invested** | Money that came in from outside: cash deposits at face value, coins deposited at their value on arrival, minus withdrawals at the cost the coins leave with. Buys, sells and swaps change nothing; a transfer between your own accounts cancels out. Cash spent on a trade that no deposit explains is counted as money in, so a venue that reports trades but not deposits still shows what they cost. |
+| **Portfolio Value** | Every balance the exchanges report, at current prices. |
+| **Fees paid** | Trading fees over the whole history. Already deducted from the two P/L figures. |
+| **Realised P/L** | Gain or loss on everything sold, first-in-first-out. |
+| **Unrealised P/L** | What you still hold, at current prices, minus what it cost. |
+| **Total P/L** | Portfolio Value − Total invested. |
+
+The hint under **Total invested** says how much of it arrived without a purchase behind it — rebates, airdrops, staking rewards, dust credits — counted at its value on arrival.
+
+**Unrealised P/L** leaves out any holding the ledger cannot vouch for — one whose ledger and exchange disagree, or whose opening balance is missing — and shows **—** when no holding can be. The findings panel names the holding and offers to fix it — see [Transactions and positions](23-transactions-and-positions.md).
+
+## Holdings
+
+**Holdings · N** lists every asset the exchanges report, largest first, with a ring of the allocation. The header sums the list by kind — **Crypto 80% · Stock 10% · Stable 10%** — and the centre of the ring is the unrealised return on the positions it can vouch for: the coins held now against what they cost, unlike the chart, which measures the portfolio against every dollar ever put in.
+
+Each row carries the logo, symbol and name, a type pill (**Crypto**, **Stock**, **ETF**, **Fund**, **Cash** or **Stable**), its share, its value and its unrealised percentage. Cash has no cost, so no return; a row without a reliable cost basis shows **—** (hover it for the reason). Rows beyond the sixth fold under **Show more**; slices under 2% fold into **Other** in the ring.
+
+## Display currency
+
+Every money figure on the page is shown in your display currency — USD, EUR, GBP, CHF or PLN — chosen under **Settings → Account** (see [Account settings](33-account-settings.md)).
+
+## Hide balances
+
+The **Hide balances** switch in the **Settings** menu removes every amount from the page: the six figures disappear, the chart becomes proportions with the invested line at 100 and loses its **Value / P/L** and range switches, and every money column drops from the tables — amount, value and fee for transactions; invested, average buy, price and the money beside the P/L for positions. Percentages, shares and holding periods stay.
+
+## Ticker hover card
+
+Wherever an asset appears as a ticker pill — in the holdings and transaction rows, on a bot page, in the bot wizard — hovering it shows a card with its logo, name, symbol and type.

--- a/manual/23-transactions-and-positions.md
+++ b/manual/23-transactions-and-positions.md
@@ -1,0 +1,29 @@
+# Transactions and positions
+
+The record, below the holdings card, lists every transaction the Tracker knows and the positions they add up to. The P/L figures and the tax reports are computed from it, so this is where you correct it.
+
+## Positions and Transactions
+
+The switch at the top of the record chooses the view.
+
+**Positions** shows one row per open position, closed round-trip or cash balance, with its dates, invested amount, average buy price, current or sold price, P/L and holding period. An open row is marked at today's price, a closed one at what it sold for. Status is **Open**, **Win**, **Loss**, **Cash**, or **Closed** — a round-trip whose cost was assumed somewhere along the way, so no win or loss is claimed. A status filter above the table narrows the rows. A coin the exchange has stopped reporting keeps its row; that gap is a finding (below).
+
+**Transactions** is the ledger: **Date**, exchange, **Type**, **Asset**, **Amount**, **Price**, **Value**, **Fee** and **Bot** (a link to the bot that placed the order). Amount, price and fee are the exchange's own figures; **Value** is in your display currency. A type filter and two date pickers narrow the table; the dates also scope the export. The table shows the latest 200 rows; **Export** always contains all of them (see [Import and export](24-import-and-export.md)).
+
+Types: **Buy**, **Sell**, **Swap In**, **Swap Out**, **Deposit**, **Withdrawal**, **Staking**, **Interest**, **Airdrop**, **Mining**, **Fee**, **Income**, **Lost**, **Withholding tax**, **Return of capital**, **Adjustment**, **Other activity**. A withdrawal and deposit linked as a transfer both show **Transfer** instead.
+
+## Transfers
+
+A withdrawal on its own is coins leaving the portfolio: they take their cost with them and reduce **Total invested**. Linked to the deposit they became elsewhere, the pair is a transfer between your own accounts — the coins keep their cost basis and holding period, nothing is realised, and the tax report skips both rows.
+
+Each sync links the obvious cases: same asset, a deposit within 72 hours of the withdrawal, at most 2% smaller. For the rest, hover a **Deposit** or **Withdrawal** row and press **Mark as transfer**; the other leg must be the single match within 14 days, or nothing is linked. **Not a transfer** undoes a link, and later syncs leave the pair alone.
+
+## Value
+
+For a trade, **Value** is what the exchange reported. For a row it did not price — a reward, an airdrop, a deposit — it is the app's own price for that day, shown as a placeholder in a box. Type a figure in your display currency to replace it; clear the box to go back. Hover the box to see whose figure it is.
+
+## Findings and Fix
+
+When the ledger cannot stand behind a holding, a panel above the holdings card says so: **N holdings the ledger cannot vouch for**, one line per case — more left the account than ever arrived, the ledger and the exchange disagree about how much is held, a balance has no history behind it, or part of it arrived without a price. Such a holding shows **—** for its P/L instead of a wrong number.
+
+**Fix** proposes the missing entry. For an opening balance it works out the quantity and date and asks only how the coins arrived: **I earned it** (income at that day's price, which becomes its cost) or **I bought or transferred it** (a cost box, prefilled with that day's market price when one is known — change it, or empty it to leave the cost unknown: the quantity reconciles, the P/L stays blank). For a disposal the exchange no longer reports, it records the coins as having left, realising nothing. **Record this entry** writes it into your transactions as your own entry.

--- a/manual/24-import-and-export.md
+++ b/manual/24-import-and-export.md
@@ -1,0 +1,33 @@
+# Import and export
+
+Exchanges do not always hand over their whole history, and a history is worth keeping outside the app. **Import** fills the gaps from a CSV file; **Export** writes the ledger out as one.
+
+## Import
+
+**Import** on the Tracker bar opens a dialog with a **Format** switch and a drop zone. Drop the file, or click to choose it — the import starts as soon as the file is picked. Duplicates are skipped, so importing the same file twice changes nothing, and a file the reader cannot make sense of is refused rather than half-imported. An import is attached to an exchange account, so connect the exchange first (see [Connecting exchanges](21-connecting-exchanges.md)).
+
+**Deltabadger CSV** is the app's own format, the same file **Export** writes. Every row names its exchange, so one file can carry several accounts; rows for an exchange you have not connected are left out; if nothing else in the file was new, the dialog lists them: **No account connected for: …**.
+
+| Column | Value |
+|---|---|
+| `date` | Time in UTC, e.g. `2024-03-01T14:05:00Z` |
+| `type` | One of `buy`, `sell`, `swap_in`, `swap_out`, `deposit`, `withdrawal`, `staking_reward`, `lending_interest`, `airdrop`, `mining`, `fee`, `other_income`, `lost`, `withholding_tax`, `return_of_capital`, `adjustment`, `unsupported_activity` |
+| `base_currency`, `base_amount` | The asset and quantity that moved |
+| `quote_currency`, `quote_amount` | What was paid or received for it, if any |
+| `fee_currency`, `fee_amount` | The fee, if any |
+| `exchange` | The exchange identifier as it appears in an export, e.g. `binance`, `kraken` |
+| `tx_id` | The exchange's own id, used to recognise the row on re-import; a row without one is matched on exchange, type, asset, amount and time |
+| `group_id` | Ties the two legs of a swap together |
+| `description` | Free text |
+
+A row with an unknown `type` is skipped, and listed when nothing else was imported: **Not imported, unknown operations: …**.
+
+**Binance CSV** reads the transaction history Binance exports from its own site, which reaches further back than the Tracker can fetch through the API. Upload it under the name Binance gave it: the rows carry no time zone, and the file name does — a renamed file is refused. Trades, converts, dust sweeps, deposits, withdrawals, rewards and interest are recognised; moves between your own Binance wallets are ignored on purpose; anything else is listed as unknown. If both Binance and Binance.US are connected, the dialog asks which account the file belongs to.
+
+When rows land, the dialog closes and the page reloads with **Imported N transactions.** If every row was already present it says so instead.
+
+## Export
+
+**Export** downloads `deltabadger-transactions-<date>.csv` with the columns above, oldest row first. It follows the exchange filter and the two date pickers under the record, and it is never limited to the rows shown on the page.
+
+The same export is available from the **Tax Report** button: in the **Generate Report** dialog choose **All**, set **From** and **To**, and press **Download**. Without market data that dialog asks for a CoinGecko API key instead (see [Market data](35-market-data.md)); use **Export** on the bar. The rest of the dialog is described under [Crypto tax report](25-crypto-tax-report.md).

--- a/manual/25-crypto-tax-report.md
+++ b/manual/25-crypto-tax-report.md
@@ -1,0 +1,54 @@
+# Crypto tax report
+
+A CSV of the year's taxable disposals — proceeds, cost basis, gain or loss, holding period — worked out the way the selected country requires. It reads the same transactions the Tracker shows, so put the ledger in order first: link transfers, state missing values, fix the findings (see [Transactions and positions](23-transactions-and-positions.md)). It is a calculation aid, not tax advice.
+
+## What you need
+
+- At least one exchange connected on the Tracker (see [Connecting exchanges](21-connecting-exchanges.md)). The **Tax Report** button appears only then.
+- Historical prices. Tax reports require market data (see [Market data](35-market-data.md)). With none configured, **Tax Report** opens a **CoinGecko API Key** form instead of the report. A free CoinGecko key covers only recent history; older transactions need a paid CoinGecko plan or a Deltabadger.com connection. Only the admin can add the key; other users are told to ask them.
+
+## Generating a report
+
+1. Open the Tracker and press **Tax Report**. The **Generate Report** modal opens.
+2. Choose **Tax Report**. (**All** is the plain transactions export — see [Import and export](24-import-and-export.md).)
+3. Pick **Country** and **Year**. The list offers the current year and the five before it; last year is preselected.
+4. For Austria and Slovakia a checkbox appears: **Treat stablecoins as fiat (ask your accountant)**. In both countries a coin-to-coin swap is not a taxable event; with the box ticked a stablecoin (USDT, USDC, DAI and the like) counts as cash, so selling into one is a disposal.
+5. Press **Generate**.
+
+The report runs in the background. A bar shows **Generating tax report...** with a percentage, and the CSV downloads on its own when done — or the next time you open the Tracker. Each report downloads once; after that you are asked to generate a new one. The file is `deltabadger-tax-report-<country>-<year>.csv`. Your last choices are remembered.
+
+Claude can produce the same report through the Tax & Reporting tools — see [Tools and permissions](31-tools-and-permissions.md).
+
+## What is in the file
+
+One row per disposal in the chosen year; earlier years are read only to establish cost basis. Headers are in the country's language. The base columns are date, acquisition date, asset, amount, proceeds, cost basis, gain/loss, currency, holding days, fee, exchange, transaction ID, and two flags: whether the cost basis was complete and whether any data was missing. France drops acquisition date, cost basis, holding days and the cost-basis flag; Sweden drops acquisition date and holding days; the Netherlands and Switzerland use a different layout (reference date, asset, amount, value, currency). Countries add their own columns (table below). Stocks and ETFs held at a broker are not here — see [Broker tax report](26-broker-tax-report.md).
+
+After the disposals:
+
+- **Income received** — staking rewards, lending interest, airdrops, mining and other income (dividends, interest, rebates), each valued on the day it arrived, with a total per type. Listed separately, not added to the gains.
+- **Warnings** — prices that could not be found; unlinked deposits whose cost basis was assumed at market value on arrival (link each to its withdrawal to use the real basis); and a NOTE listing values you typed by hand in the Tracker.
+
+> **Note:** WARNING rows directly under the header, in the country's language, flag an exchange that was never synced or whose last sync failed, and — when any price is missing — how many values are missing and that the report must not be filed as-is. Fix the data and generate again.
+
+## Countries
+
+| Country | Method | Currency | What the report adds |
+|---|---|---|---|
+| Germany | FIFO | EUR | A tax-exempt column after a holding period over one year |
+| Austria | FIFO | EUR | Coin-to-coin swaps not taxed, basis carries over; an old-stock column for coins bought before 1 March 2021 and held over a year; stablecoin checkbox |
+| France | PVCT | EUR | Total acquisition cost and portfolio value per disposal; coin-to-coin swaps not taxed |
+| Italy | LIFO | EUR | A tax-rate column (26% before 2026, 33% from 2026); an exempt column for years up to 2024 when the year's gains stay under 2,000 |
+| Spain | FIFO | EUR | — |
+| Bulgaria | FIFO | EUR (BGN for 2025) | 10% expense deduction taken off each gain; summary with tax at 10% |
+| Greece | FIFO | EUR | Summary with tax at 15% |
+| Netherlands | Wealth snapshot | EUR | Holdings and their value on 1 January of the year, then total value, allowance, taxable wealth, deemed return and tax — allowance and rates are known for 2025 and 2026; other years use the 2026 figures — no disposal rows |
+| Portugal | FIFO | EUR | A tax-exempt column after one year; a swap restarts the holding period but is not taxed |
+| Switzerland | Wealth snapshot | CHF | Holdings and their value on 31 December, total only; a note that income is not included |
+| Poland | FIFO | PLN | Coin-to-coin swaps not taxed |
+| United Kingdom | Share pooling | GBP | **Matching Rule** per disposal |
+| United States | FIFO | USD | **Term**: Short-term or Long-term |
+| Sweden | Weighted average | SEK | Summary of gains and losses, 70% of losses deductible |
+| Ireland | FIFO with the four-week rule | EUR | **Matching Rule**, **Period**; summary with the 1,270 annual exemption, CGT at 33% and the two payment dates |
+| Denmark | FIFO | DKK | Per-asset summary; a loss is marked denied when the asset was bought again between acquisition and sale |
+| Czech Republic | FIFO | CZK | A tax-exempt column with its reason — time test (held over three years) or value test (total proceeds for the year up to 100,000 — then every disposal is exempt); summary |
+| Slovakia | FIFO | EUR | Term and tax-rate columns (19% short-term, 7% long-term); coin-to-coin swaps not taxed; stablecoin checkbox |

--- a/manual/26-broker-tax-report.md
+++ b/manual/26-broker-tax-report.md
@@ -1,0 +1,35 @@
+# Broker tax report
+
+A calculation basis for the German **Anlage KAP** and **KAP-INV** forms from a connected Alpaca account: which amount belongs on which line, and the worksheets behind each figure. It covers stocks and ETFs; crypto held at Alpaca goes into the [Crypto tax report](25-crypto-tax-report.md). It is a calculation aid, not tax advice — the file says so, and every figure is yours to check.
+
+## What you need
+
+- An Alpaca account connected on the Tracker (see [Stocks and ETFs](29-stocks-and-etfs.md)). The option appears only then.
+- Market data configured, as for the crypto report (see [Market data](35-market-data.md)).
+- Germany only. Supported years: 2023, 2024 and 2025.
+
+## Generating the report
+
+1. Open the Tracker, press **Tax Report** and choose **Broker tax report (Germany — Anlage KAP / KAP-INV)**. The country field disappears and **Year** narrows to the supported years.
+2. Work through **Classify securities**. Every security needs a type: **Share**, **Fund** — with a category: **Equity funds**, **Mixed funds**, **Real estate funds**, **Foreign real estate funds** or **Other funds** — or **Other security**. Stocks are pre-set to Share. ETFs are marked **Default applied** and set to Fund / Other funds (0% Teilfreistellung, because US funds publish no InvStG terms); change that only if you can show the fund's equity quota. **Blocks the report** means the security was not found in market data and must be typed by hand. **Figures withheld** means it stays in the worksheets but is left out of the summaries, with the reason shown. Each change is saved as you make it and remembered for later reports.
+3. Press **Generate**. It stays disabled until every security is classified.
+
+The report runs in the background and downloads on its own when ready, or the next time you open the Tracker. The file is `deltabadger-broker-tax-report-de-<year>.csv`.
+
+## What is in the file
+
+The file is written in German, as the form is.
+
+- **ZUSAMMENFASSUNG — ANLAGE KAP** (summary) — lines 19, 20, 22, 23 and 41, in EUR.
+- **ZUSAMMENFASSUNG — ANLAGE KAP-INV** — per fund category: distributions, Vorabpauschale and result from disposal, each before Teilfreistellung, with the form's line number.
+- **AUFSTELLUNG — VERÄUSSERUNGEN** (disposals) — each sale with units, USD proceeds, ECB rate, EUR proceeds, fees, acquisition cost, Vorabpauschale deducted and gain/loss, then one line per matched lot.
+- **AUFSTELLUNG — ERTRÄGE** (income) — dividends, interest, fund distributions, withholding tax and return of capital exceeding acquisition cost; regulatory fees as a total, for information only.
+- **HINWEISE** (warnings) and **RECHTLICHE HINWEISE** (legal notices).
+
+## How it is computed
+
+Lots are matched first in, first out, and every USD amount is converted at the ECB euro reference rate of its own date, or the previous banking day's when none was published. Dividends are grossed up by the tax withheld; interest is reported net. The full amount withheld goes to line 41. Return of capital reduces the cost basis, and anything beyond it counts as income. Stock splits rescale the lots. For a fund, a Vorabpauschale is worked out for every year-end a lot was held across, from year-end prices, the published Basiszins (known to the app for 2018–2026) and distributions; the previous year's amount is reported in the current year, and what has accrued is deducted from the gain when the lot is sold.
+
+A security whose history cannot be fully substantiated is left out of the summaries rather than guessed at; its worksheet rows stay, marked. Reasons: a disposal that cannot be matched to acquisitions, a transaction type the report does not model (a merger, a spin-off), fund units bought before 2018, a missing year-end price, a missing ECB rate, or a year without a published Basiszins. Withholding tax on such a security is still credited on line 41, with a warning.
+
+> **Note:** If any warning is present, the file's second row — under the title row — is a WARNUNG line saying the report is incomplete and must not be filed as-is.

--- a/manual/27-supported-exchanges.md
+++ b/manual/27-supported-exchanges.md
@@ -1,0 +1,38 @@
+# Supported exchanges
+
+Deltabadger trades crypto on thirteen exchanges and stocks through two brokers. Every venue below works for bots and for the [Tracker](21-connecting-exchanges.md) (Interactive Brokers connects through Settings, not the Tracker's own form); only some can run [withdrawal rules](19-withdrawal-rules.md). How to create the key each one needs is on the [API keys](28-api-keys.md) page.
+
+## Crypto exchanges
+
+| Exchange | Connect with | Withdrawal rules | Notes |
+|---|---|---|---|
+| Binance | API Key, Secret Key | Yes | Whitelist the IP before the trading permission can be enabled. |
+| Binance.US | API Key, Secret Key | Yes | Same key setup as Binance. |
+| Coinbase | API key ID, Secret | No | Needs an **Advanced API** key (Coinbase Developer Platform). |
+| Kraken | API Key, Private Key | Yes | The Tracker needs **Query ledger entries** in addition to the trading permissions. |
+| Bitget | API Key, Secret Key, API Passphrase | No | |
+| KuCoin | API Key, API Secret, API Passphrase | No | |
+| Bybit | API Key, API Secret | No | |
+| MEXC | Access Key, Secret Key | Yes | |
+| Gemini | API Key, API Secret | Yes | Key scope **Primary**. No IP whitelist step. |
+| Bitvavo | API Key, API Secret | No | |
+| Hyperliquid | Wallet Address, Agent Private Key | No | Decentralized; every order is public on-chain. Orders below 10 USDC are rejected. |
+| BingX | API Key, Secret Key | No | |
+| Bitrue | API Key, Secret Key | No | |
+
+BitMart has shut down. It can no longer be picked or keyed; a bot still on it shows *This exchange no longer operates — switch the bot to another one*, and you can move it from the exchange chip (see [Managing bots](13-managing-bots.md)).
+
+In the bot wizard, Binance, Binance.US, Coinbase and Kraken are listed first; the rest follow.
+
+## Stock brokers
+
+| Broker | Connect with | Notes |
+|---|---|---|
+| Alpaca | API Key, API Secret, Mode (**Paper** / **Live**) | Also lists crypto pairs. Stock orders wait for market hours. |
+| Interactive Brokers | OAuth setup under **Settings → Connect → Interactive Brokers (beta)** | Requires a Deltabadger.com connection (see [Market data](35-market-data.md)). Whole shares only. |
+
+Neither broker supports withdrawal rules. What each needs before stocks appear in the wizard is on the [Stocks and ETFs](29-stocks-and-etfs.md) page.
+
+## Exchange proxies
+
+Exchange calls can be routed through a per-exchange HTTP proxy, either set by a Deltabadger.com connect code or by the `PROXY_<EXCHANGE>` variables described in [Configuration](38-configuration.md); without one, Deltabadger calls the exchange directly.

--- a/manual/28-api-keys.md
+++ b/manual/28-api-keys.md
@@ -1,0 +1,62 @@
+# API keys
+
+An API key is how Deltabadger acts on your exchange account. Keys never leave your instance: they are stored encrypted in your own database (see [Secrets and encryption keys](40-secrets-and-encryption-keys.md)).
+
+## Key types
+
+| Type | Used by | Permissions |
+|---|---|---|
+| Trading key | Bots. The Tracker reads balances and history with it too. | Read + trade. No withdrawals. |
+| Read-only key | Tracker only. | Read. A trading key already added for a bot does the same job, so you rarely need one. |
+| Withdrawal key | Withdrawal rules. | Read + withdraw. Trading must be **off**. See [Withdrawal keys and addresses](20-withdrawal-keys-and-addresses.md). |
+
+You can hold one key of each type per exchange. Adding a second one for the same exchange replaces the first.
+
+## Where keys are managed
+
+**Settings → Connect → API keys** lists every stored key under **Trading keys** and **Withdrawal keys** (read-only keys appear with the trading ones). Click the exchange name to reopen its **How to get API keys from …** guide; click the **×** to delete it. Deleting a trading key stops any running bot on that exchange first.
+
+Keys are added where they are needed:
+
+- Bot wizard, **Connect exchange** step (**Add API keys for …**).
+- Tracker, **Connect exchange** (see [Connecting exchanges](21-connecting-exchanges.md)).
+- Withdrawal rule wizard.
+- On a bot's page, the exchange chip: **Connect** when the stored key does not work, or **Add new keys** to replace a working one while the bot is not running.
+
+Each form shows the exchange's own field labels and, beside it, the numbered guide for that key type. Press **Connect**; it reads **Validating…** while the key is checked against the exchange.
+
+## Permissions per exchange
+
+Enable exactly what the guide lists. Binance, Binance.US and Coinbase reject a key that carries extra permissions; on the others, leave withdrawal and futures permissions off.
+
+| Exchange | Trading key |
+|---|---|
+| Binance, Binance.US | **Enable Reading**, **Enable Spot & Margin Trading**. Whitelist the IP first — the trading option is locked until you do. |
+| Coinbase | Portfolio **View** and **Trade** on an **Advanced API** key. |
+| Kraken | Funds: **Query**. Orders & Trades: **Query open orders & trades**, **Query closed orders & trades**, **Create & modify orders**, **Cancel & close orders**. Data: **Query ledger entries** (used by the Tracker). |
+| Bitget | **Read-write**, **Spot - Trade**, plus a **Passphrase**. |
+| KuCoin | **General**, **Spot - Trade**, plus a **Passphrase**. |
+| Bybit | **Read-Only**, **Spot - Trade**. |
+| MEXC | **View Order Details**, **Trade**. |
+| Gemini | Scope **Primary**; **Order Placement**, **Order Status**, **Account Balance**. |
+| Bitvavo | **View**, **Trade**. |
+| Hyperliquid | **Generate API agent** and copy the **Agent Private Key** (shown once). Never enter your main wallet key. |
+| BingX | **Read-write**, **Spot - Trade**. |
+| Bitrue | **Read Info**, **Trade**. |
+| Alpaca | Key and secret from the Alpaca dashboard, and **Mode**: **Paper** (default) or **Live**. |
+| Interactive Brokers | Not a key form — connect under **Settings → Connect → Interactive Brokers (beta)** first; the wizard then skips this step. See [Stocks and ETFs](29-stocks-and-etfs.md). |
+
+For a read-only Tracker key on Binance or Binance.US, leave the default **Enable Reading** and nothing else. Other exchanges use the trading guide for the Tracker as well.
+
+## IP whitelisting
+
+Guides with a whitelist step tell you which address to enter (Gemini and Hyperliquid have none). With exchange proxies configured it is the proxy host; otherwise it is the public IP of the machine running Deltabadger, and the guide links to a page that shows it. On Binance the whitelist must be set before the trading permission can be ticked. A Binance read-only key works without a whitelist.
+
+## Key status
+
+- **Validating…** — the key is being checked.
+- Valid — the wizard moves on; the Tracker starts syncing.
+- **Incorrect API key permissions** — the exchange rejected the key, or its permissions do not match the guide. Create a new key.
+- **Failed to validate API key permissions** — the check itself failed, usually because the exchange could not be reached. Try again.
+
+A key that later stops working shows **Connect** on the bot's exchange chip, and the Tracker's exchange chip opens the re-add form. What a failed Tracker sync means is on [Connecting exchanges](21-connecting-exchanges.md).

--- a/manual/29-stocks-and-etfs.md
+++ b/manual/29-stocks-and-etfs.md
@@ -1,0 +1,11 @@
+# Stocks and ETFs
+
+Crypto works out of the box. Stock trading needs two things your container cannot invent: the list of tradeable symbols, and prices for them. Which broker you can use follows directly from who supplies those.
+
+## Alpaca — available self-hosted
+
+An Alpaca API key provides the tradeable symbol list, live prices and chart history all at once, so a container can run stocks entirely on its own. An admin connects a key once under Settings → Connect (paper or live) to build the catalog. Syncing the full US catalog takes a few minutes; after that, stocks appear in the bot wizard. Each user then connects their own Alpaca key when creating a bot — the admin key only keeps the catalog fresh, and it is never used to place anyone's orders.
+
+## Interactive Brokers — hosted only
+
+IBKR is a broker, not a market-data provider: it publishes no free price feed and no price history, and its market data is a paid, per-exchange subscription tied to each account. A self-hosted container therefore has no source for the prices and charts the app needs, so the IBKR option stays hidden unless the container is connected to deltabadger.com market data. This is a data limitation, not a licensing one. Maybe we'll find a way around.

--- a/manual/30-connecting-claude.md
+++ b/manual/30-connecting-claude.md
@@ -1,0 +1,29 @@
+# Connecting Claude
+
+Deltabadger runs an MCP server, so Claude and other AI clients that speak MCP can read your bots, balances and transactions, and — if you allow it — start bots, place orders and generate tax reports. What a client may do is up to you; see [Tools and permissions](31-tools-and-permissions.md).
+
+## The MCP URL
+
+Open **Settings → Connect**. The **MCP** widget shows your server URL under "Use this URL to connect Claude (and other AI models)". Click it to copy.
+
+The URL is your instance address followed by `/mcp`, built from `APP_ROOT_URL` (see [Configuration](38-configuration.md)). Set that variable to an address the client can reach — `localhost` only works for a client on the same machine.
+
+Add the URL wherever your client accepts a remote MCP server. There is no token to paste: the client registers itself with your instance and opens the authorization page below.
+
+## Authorizing a client
+
+The first time a client connects, your browser opens Deltabadger's **Authorize access** page. Sign in if you are not already. The page shows which client is asking ("*Name* wants to access your Deltabadger server"), warns that the application registered itself and Deltabadger has not verified it — only continue if you started this yourself — and lists what the access covers. Under "Choose what it may use over MCP:" there is a checkbox per group: **Read**, **Control**, **Trade**, **Tax & Reporting**. Only **Read** is ticked to begin with.
+
+Untick what you do not want this client to have, then press **Connect**, or **Cancel** to refuse. The ticked groups become the client's grant, limited to the tools switched on at that moment; tools you switch on later are granted from the **Connected** list.
+
+A client that also asked for REST API access shows a second set of checkboxes; see [REST API](32-rest-api.md).
+
+The client receives a token that lasts an hour and renews it on its own. You do not authorize again unless you revoke the client.
+
+## Connected clients
+
+Below the tool toggles, **Connected** lists every client you have authorized with the date it connected. Each client has a toggle per group: **(some)** means it holds part of a group, **(REST API)** marks groups granted for the REST API. Switch a toggle on to grant the whole group (only tools you currently have on), or off to take it away. A tool switched off in the grid is off for every client at once, but stays in the client's grant until you remove it here.
+
+**Revoke** disconnects a client and stops its tokens immediately. It has to authorize again to connect.
+
+If Claude reports that a tool is disabled or not available to this client, see [Tools and permissions](31-tools-and-permissions.md).

--- a/manual/31-tools-and-permissions.md
+++ b/manual/31-tools-and-permissions.md
@@ -1,0 +1,71 @@
+# Tools and permissions
+
+Every MCP tool has its own switch, so you decide whether a connected AI client can only look at your account or also act on it. Connecting a client is covered in [Connecting Claude](30-connecting-claude.md).
+
+## Two layers of permission
+
+A tool is usable only when both of these are true:
+
+1. It is switched on in **Settings → Connect → MCP**. The grid groups the tools as **Read**, **Control**, **Trade** and **Tax & Reporting**. Click a tool to flip it, or click a group title to flip the whole group. By default **Read** and **Tax & Reporting** are on, **Control** and **Trade** are off. Switching a tool off takes effect immediately for every client, even mid-conversation.
+2. The client was granted it. A client receives its grant when you authorize it, and the grant only contains tools that were switched on at that moment. Tools you enable later have to be granted to each client from the **Connected** list. A client only sees the tools that pass both checks.
+
+These switches are separate from the REST API's; see [REST API](32-rest-api.md).
+
+## Read
+
+| Tool | What it does |
+|---|---|
+| **List bots** | View all DCA bots and their status, type, pair and exchange; filter by status |
+| **Bot details** | View detailed bot info and performance: P/L, average price, invested, current value |
+| **List exchanges** | View connected exchanges and their API key status |
+| **Exchange balances** | Fetch live balances from one exchange |
+| **Portfolio summary** | View global P/L and a per-bot breakdown |
+| **List transactions** | View recent trades, optionally for one bot (up to 100) |
+| **List open orders** | View currently open (unfilled) orders across exchanges; an exchange that cannot be asked is reported, not skipped |
+
+## Control
+
+| Tool | What it does |
+|---|---|
+| **Create bot** | Create and start a DCA bot: exchange, asset, quote currency, amount, interval (hour, day, week or month), optional label and start time |
+| **Start bot** | Start a stopped or newly created bot |
+| **Stop bot** | Stop a running bot |
+| **Update bots** | Change amount or label on a stopped bot |
+| **Start rule** | Start a stopped rule |
+| **Stop rule** | Stop an active rule |
+| **Update rules** | Change settings on a stopped rule: withdrawal percentage, maximum fee percentage, minimum amount, threshold type |
+
+Rules are the [withdrawal rules](19-withdrawal-rules.md) you created in the app; a client can switch them on and off but cannot create one.
+
+## Trade
+
+| Tool | What it does |
+|---|---|
+| **Market buy** | Execute a market buy order on a connected exchange; amount in quote currency by default, or in the asset |
+| **Market sell** | Execute a market sell order; amount in the asset by default, or in quote currency |
+| **Limit buy** | Place a limit buy order at a specific price |
+| **Limit sell** | Place a limit sell order at a specific price |
+| **Cancel order** | Cancel an open order by its ID |
+
+Trade tools work on crypto exchanges and, for stocks, on Alpaca (see [Stocks and ETFs](29-stocks-and-etfs.md)). They act on the exchange account directly and are not tied to a bot.
+
+> **Note:** With **Trade** on and paper trading off, a client places real orders with real money. Keep the group off unless you want that.
+
+## Paper Trading
+
+Under the grid, **Enable paper trading for trade tools** makes the Trade tools simulate orders with real market prices. No real orders are placed, and every result is prefixed with `[DRY RUN]`. Use it to try a client's trading behaviour before letting it spend anything. The setting applies to MCP only; the REST API has no equivalent.
+
+## Tax & Reporting
+
+| Tool | What it does |
+|---|---|
+| **Tax jurisdictions** | View supported countries with their calculation method and currency |
+| **Generate tax report** | Start background tax report generation for a country and year; can treat stablecoins as fiat |
+| **Tax report status** | Check if a tax report is ready |
+| **Download tax report** | Retrieve the generated tax report as CSV |
+| **Export transactions CSV** | Export account transactions as CSV, with optional exchange and date filters |
+| **Account transactions** | View Tracker transactions with exchange, date-range and type filters (up to 200) |
+
+**Generate tax report** produces the [crypto tax report](25-crypto-tax-report.md) only; the [broker tax report](26-broker-tax-report.md) is not available over MCP. For most countries it needs market data (see [Market data](35-market-data.md)) and refuses otherwise. A finished report is also picked up by the Tracker the next time you open it.
+
+The export tools hand a client your complete transaction history; grant **Tax & Reporting** only to clients that need it.

--- a/manual/32-rest-api.md
+++ b/manual/32-rest-api.md
@@ -1,0 +1,66 @@
+# REST API
+
+The REST API lets your own scripts read and control Deltabadger — the same bots, exchanges, orders, transactions and rules as the MCP tools — over plain JSON with a bearer token.
+
+## Token and base URL
+
+Open **Settings → Connect → REST API**. The widget shows the base URL — your instance address followed by `/api/v1`, built from `APP_ROOT_URL` (see [Configuration](38-configuration.md)) — and your personal API token. Both copy on click. The token is created for you and does not expire.
+
+Send it on every request:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:3737/api/v1/bots
+```
+
+Browser sessions are not accepted on `/api/v1`; only the bearer header counts.
+
+**Regenerate** revokes the current token immediately and shows a new one. The confirmation warns that scripts using the old token stop working until you update them. Do this whenever you suspect the token has leaked.
+
+**Download API docs** saves the full reference (`deltabadger-api.md`), including request and response examples and every error code.
+
+## Permissions
+
+Every endpoint is gated by a toggle in the same widget, grouped as **Read**, **Control** and **Trade**. Click a tool to flip it, or a group title to flip the group. All toggles start off, so a fresh token can do nothing until you switch on what your script needs. A call to a switched-off endpoint returns `403` with error code `tool_disabled`.
+
+These toggles are independent of the MCP toggles (see [Tools and permissions](31-tools-and-permissions.md)): switching **List bots** on here does not switch it on for MCP, and the other way round. The REST **Read** group also holds the two transaction export tools that MCP files under Tax & Reporting. There is no tax-report generation and no Paper Trading over REST.
+
+## Endpoints
+
+All paths are under `/api/v1`. The toggle column names the switch that must be on.
+
+| Method | Path | Toggle | Notes |
+|---|---|---|---|
+| GET | `/bots` | List bots | Optional `?status=` |
+| GET | `/bots/:id` | Bot details | Includes metrics when available |
+| POST | `/bots` | Create bot | Required: `exchange_name`, `base_asset`, `quote_asset`, `quote_amount`, `interval`; optional `label`, `start_at` |
+| PATCH | `/bots/:id` | Update bots | `quote_amount`, `label`; bot must be stopped |
+| POST | `/bots/:id/start` | Start bot | `409` if already running |
+| POST | `/bots/:id/stop` | Stop bot | `409` if not running |
+| GET | `/exchanges` | List exchanges | Your connected trading exchanges |
+| GET | `/exchanges/:id/balances` | Exchange balances | Live exchange call; `502` if the exchange fails |
+| GET | `/transactions` | List transactions | Bot trades; optional `?bot_id=`, `?limit=` (max 100) |
+| GET | `/transactions/account` | Account transactions | Tracker transactions; optional `?exchange_id=`, `?from_date=`, `?to_date=`, `?entry_type=`, `?limit=` (max 200) |
+| GET | `/transactions/export` | Export transactions CSV | Returns CSV, not JSON (see below) |
+| GET | `/portfolio` | Portfolio summary | `empty: true` when you have no bots |
+| GET | `/orders` | List open orders | Optional `?exchange_name=`; open orders from the app and live from exchanges |
+| POST | `/orders` | Market buy / Market sell / Limit buy / Limit sell | `type` picks the toggle; needs `Idempotency-Key` (see below) |
+| DELETE | `/orders/:id` | Cancel order | Numeric id = a bot's order (from `GET /orders`); an order placed through this API is cancelled by its exchange order id, with `exchange_name` |
+| POST | `/rules/:id/start` | Start rule | `409` if already active |
+| POST | `/rules/:id/stop` | Stop rule | `409` if not active |
+| PATCH | `/rules/:id` | Update rules | `withdrawal_percentage`, `max_fee_percentage`, `min_amount`, `threshold_type`; rule must be stopped |
+
+## Responses
+
+Every endpoint answers with the same envelope: `{ "data": …, "error": null }` on success, `{ "data": null, "error": { "code": "…", "message": "…" } }` on failure. `code` is stable and meant for scripts; `message` may change.
+
+The one exception is `GET /transactions/export`, which returns `text/csv` as an attachment. It is capped at 5000 rows; the headers `X-Total-Transactions`, `X-Returned-Transactions` and `X-Truncated` tell you whether to narrow the date range. Errors from this endpoint still come as JSON.
+
+## Placing orders
+
+`POST /orders` takes `type` (`market_buy`, `market_sell`, `limit_buy`, `limit_sell`), `exchange_name`, `base_asset`, `quote_asset`, `amount`, optional `amount_type` (`quote` or `base`) and, for limit orders, `price`. A successful placement answers `201`.
+
+The request must carry an `Idempotency-Key` header with a value unique to this attempt (a UUID is fine); without it the call fails with `400 idempotency_key_required`. Repeating the same key with the same body returns the stored response without touching the exchange again, so a retry after a network error cannot place a second order. The same key with a different body is refused with `409 idempotency_key_reused`; a retry while the first attempt is still running gets `409 idempotency_in_progress`. Cancelling does not need a key.
+
+## Other clients
+
+The personal token is for scripts you write yourself. An application someone else wrote connects through the same OAuth flow as an MCP client (see [Connecting Claude](30-connecting-claude.md)) and must ask for the `api` scope when it registers — the default scope only opens the MCP server. On the **Authorize access** page you then choose what it may use over the REST API, group by group; a tool has to be both granted to the client and switched on here. Its tokens last an hour and are refreshed by the client. Your personal token has no per-client grant: your toggles are the whole answer for it.

--- a/manual/33-account-settings.md
+++ b/manual/33-account-settings.md
@@ -1,0 +1,33 @@
+# Account settings
+
+Account settings hold what is yours alone: name, email, password, language, time zone and display currency. Open the **Settings** menu at the bottom of the sidebar and choose **Account**; what you change there applies to your own login only. The number at the top of the page is the Deltabadger version you are running.
+
+## Name, email and password
+
+- **Name** — type a **New name** and press **Update**.
+- **Email** — enter the **New email** and your **Current password**, then **Update**. A confirmation link goes to the new address, and the page shows "Currently, waiting confirmation for: …" until you click it. The old address stays in use until then. This needs a working email provider (see [Email notifications](37-email-notifications.md)).
+- **Password** — enter your **Current password**, the **New password** and **Confirm new password**, then **Update**. The checklist under the fields shows what is required: at least 8 characters, an uppercase and a lowercase letter, a digit and a symbol. You stay signed in.
+
+## Language, Timezone & Currency
+
+Three pickers, each saved as soon as you change it.
+
+- Language — English, Deutsch, Nederlands, Français, Español, Português, Italiano, Polski, Русский, Čeština, Slovenčina, Dansk, Svenska, Ελληνικά, Български. A language picked on the login page before signing in is used for that session; the one saved here is used whenever the URL does not name one.
+- Timezone — used for every time Deltabadger shows you: bot logs and orders, chart labels, the Starting time picker and Tracker transaction dates. The line under the pickers shows the current time in the selected zone so you can check it.
+- Currency — USD, EUR, GBP, CHF or PLN. Profits and portfolio totals are shown in this currency; bots keep trading in their own quote asset. The rate comes from your market data provider (see [Market data](35-market-data.md)); while it cannot be fetched, figures fall back to USD rather than showing the wrong symbol.
+
+## Second Factor Authentication
+
+The **Enable 2FA** / **Disable 2FA** button lives on this page. See [Two-factor authentication](34-two-factor-authentication.md).
+
+## Hide balances
+
+A switch in the **Settings** menu, not on the Account page, that removes money figures from the Bots and Tracker pages. It is per user. What it hides is described on [Portfolio overview](22-portfolio-overview.md).
+
+## Admin widgets
+
+The admin's Account page carries two more widgets: **Multiple Accounts** (see [Multiple users](36-multiple-users.md)) and **Email Notifications** (see [Email notifications](37-email-notifications.md)). Other users do not see them.
+
+## Logout
+
+**Logout** is the last item in the **Settings** menu. It ends the session and invalidates every **Remember me** cookie for your account, so a browser that was remembered elsewhere has to sign in again.

--- a/manual/34-two-factor-authentication.md
+++ b/manual/34-two-factor-authentication.md
@@ -1,0 +1,35 @@
+# Two-factor authentication
+
+Two-factor authentication adds a six-digit code from an authenticator app to your login. It protects the account that holds your exchange keys, so turn it on if anyone else can reach the address your Deltabadger runs on.
+
+## Enabling
+
+1. Open **Settings → Account**. The **Second Factor Authentication** widget shows ON or OFF.
+2. Press **Enable 2FA**. A dialog titled **2FA** opens with a QR code. Scan it with any TOTP authenticator app (Google Authenticator, Aegis, 1Password, …), or copy the code printed under it and add it by hand. The entry appears in the app as Deltabadger.
+3. Type the six digits the app shows into **Enter 2FA code** and press **Enable 2FA**.
+
+A wrong code is refused with "Supplied code is wrong." and nothing changes.
+
+There are no recovery codes. If you lose the authenticator you cannot sign in; keep the app backed up or the secret written down somewhere safe.
+
+## Logging in
+
+After a correct email and password you land on a page asking for the **2FA code**. Enter it and press **Verify**. You have five minutes; after that the pending login is dropped and you are sent back to the login page with "Invalid code. Try again." — sign in once more. **Remember me** ticked on the login page still applies once the code is accepted.
+
+Each code works once. A device whose clock is off by up to about half a minute is still accepted.
+
+## Disabling
+
+Press **Disable 2FA** on the Account page, enter the current code from your app and press **Disable 2FA** in the dialog. The switch turns OFF and the next login needs only the password.
+
+## Password reset
+
+When you reset a forgotten password from the emailed link, the **Change password** form has an extra **2FA code** field. The reset only goes through with a valid code. Without the authenticator, the password cannot be reset this way.
+
+## Lockout
+
+Five wrong codes — at login or on the password-reset form — lock the account for 15 minutes. At login the fifth one sends you back to the login page with "Invalid code. Try again."; only the next sign-in attempt says the account is locked. Wrong passwords count toward the same five. A locked account is not shown the code page at all; wait out the 15 minutes and try again. There is no unlock-by-email.
+
+## Losing the secret
+
+The two-factor secret is encrypted with the instance key. The credential reset described in [Secrets and encryption keys](40-secrets-and-encryption-keys.md) clears it along with everything else, which is the only built-in way to remove two-factor from an account you can no longer verify.

--- a/manual/35-market-data.md
+++ b/manual/35-market-data.md
@@ -1,0 +1,37 @@
+# Market data
+
+A market data provider gives Deltabadger prices and asset details it cannot get from your exchange alone. Open **Settings → Connect → Market Data** to choose one. Only the admin sees this widget.
+
+## What needs it
+
+Deltabadger ships with a bundled list of exchanges, assets and trading pairs, so DCA and portfolio bots, triggers, bot charts and withdrawal rules work with no provider at all — they read prices from the exchange. A provider is needed for:
+
+- Index bots. The wizard refuses to continue: "A market data provider must be configured for Index bots."
+- The Tracker's USD values. Balances still sync, but crypto holdings cannot be priced and the page warns "Balances synced, but USD pricing is unavailable right now". Stocks priced by the broker itself are unaffected.
+- Tax reports, which need historical prices. Without a provider the **Tax Report** button opens a CoinGecko setup form instead.
+- A display currency other than USD (see [Account settings](33-account-settings.md)).
+- Keeping asset names, logos and market caps fresh, and picking up pairs an exchange listed after your install.
+
+## None
+
+Market data is off. The bundled asset list stays as it is.
+
+## CoinGecko
+
+A free CoinGecko account is enough for most uses. The form links to the steps: sign up at CoinGecko, open the API section, press **Get Your API Key Now**, choose **Create Free Account** below the pricing, fill the form, press **Create API key** and copy the key.
+
+Paste it into **CoinGecko API Key** and press **Start**. The key is saved as is; nothing checks it here, so a wrong key only shows up later as failed prices. Press **Synchronize** afterwards to refresh every exchange's pair list — a "Syncing assets…" banner shows while it runs, and it takes a while because the sync pauses between exchanges to stay under CoinGecko's rate limit. (The CoinGecko form that opens from **Tax Report** does check the key and starts the sync itself.)
+
+Once connected the widget reads "Connected to CoinGecko for live market data." and shows **Synchronize**, which refreshes every exchange's pair list (use it if some exchanges or assets are missing), and **Disconnect**, which removes the key and turns market data off.
+
+The free plan covers about two years of price history. For a tax report on older transactions you need a paid CoinGecko plan or a Deltabadger.com connection.
+
+## Deltabadger.com — paste connect code
+
+Select this option, paste the **Connect code** from your Deltabadger.com Self-Hosted subscription and press **Connect**. The code configures market data and, where included, exchange proxies; the widget then reads "Connected to Deltabadger.com for market data and exchange proxies." (or "… Exchange proxies are unavailable."). An invalid or expired code is refused. **Disconnect** removes the connection, proxies included.
+
+The same code can be entered on the setup page (see [First run](06-first-run.md)) or supplied as `CLAIM_TOKEN` (see [Configuration](38-configuration.md)).
+
+## Locked by the environment
+
+When `MARKET_DATA_URL` is set in the environment, the widget shows only that provider — named by `MARKET_DATA_PROVIDER_NAME`, or the URL itself — greyed out, and none of the choices above. Change the environment to change the provider.

--- a/manual/36-multiple-users.md
+++ b/manual/36-multiple-users.md
@@ -1,0 +1,33 @@
+# Multiple users
+
+One Deltabadger can serve several people, each with their own login, exchange keys and bots. The account created on first run is the admin (see [First run](06-first-run.md)); everyone else signs up through a page the admin opens.
+
+## Enable Sign Up
+
+Open **Settings → Account → Multiple Accounts**. The widget shows ON or OFF. Press **Enable Sign Up** to open registration; press **Disable Sign Up** to close it again. Closing it does not remove anyone — existing users keep signing in.
+
+While it is on, the login page shows a **Sign up** link leading to the **New Account** form: **Name**, **Email**, **Password**, then **Sign Up**. The new user lands on a "Thanks!" page asking them to click the confirmation link in their mailbox. The account cannot sign in until that link is clicked. If the address is already registered, the page still says Thanks! and an "Email already taken" notice goes to the existing owner instead.
+
+Confirmation is an email, so sign-up only works with an email provider configured (see [Email notifications](37-email-notifications.md)). A user who did not get the email can ask for it again with **Resend link** on the login page.
+
+## What every user has
+
+Each user works in their own space. Bots, withdrawal rules, the Tracker, API keys, the REST API token, connected MCP clients, two-factor authentication, language, timezone, display currency, **Hide balances** and the Interactive Brokers connection are all per user. One user cannot see another user's keys, bots or transactions.
+
+Stocks follow the same rule: the admin's Alpaca key only builds the shared catalog, and each user trades with their own (see [Stocks and ETFs](29-stocks-and-etfs.md)).
+
+## What stays with the admin
+
+Settings that affect the whole instance are hidden from other users and refused if they try anyway:
+
+| Setting | Where |
+|---|---|
+| Market data provider | **Settings → Connect → Market Data** (see [Market data](35-market-data.md)) |
+| Stocks catalog (Alpaca) | **Settings → Connect → Stocks** |
+| Email notifications (SMTP) | **Settings → Account → Email Notifications** |
+| Multiple Accounts | **Settings → Account** |
+| Deltabadger.com connect code | Market Data widget and the setup page |
+
+A non-admin who reaches a feature that needs one of these sees a message to that effect — for example "The CoinGecko API key is managed by your instance admin. Ask them to add it under Settings → Connect." when opening a tax report, or "Ask your admin to activate stock trading." in the bot wizard.
+
+There is one admin, and the role cannot be handed over from the interface.

--- a/manual/37-email-notifications.md
+++ b/manual/37-email-notifications.md
@@ -1,0 +1,47 @@
+# Email notifications
+
+Deltabadger emails you when a bot needs attention, and uses the same channel for sign-up confirmations and password resets. Nothing is sent until an SMTP server is configured. Open **Settings → Account → Email Notifications** — admin only — to set one up.
+
+## Custom SMTP
+
+The widget shows ON or OFF and two choices, **None** and **Custom SMTP**. Pick **Custom SMTP** and fill in:
+
+| Field | Default |
+|---|---|
+| **SMTP host** | `smtp.gmail.com` |
+| **Port** | `587` |
+| **Username** | — |
+| **Password** | — |
+
+Username and password are required. For Gmail, use an App Password rather than your account password. Press **Set**. The connection uses STARTTLS with plain authentication.
+
+Once saved, the widget reads "Configured with *host*." and offers two buttons:
+
+- **Send Test Email** — sends "Deltabadger Test Email" to your own address and reports "Test email sent to …" or the server's error.
+- **Disconnect** — forgets the host, port, username and password.
+
+Choosing **None** stops sending but keeps the details, so selecting **Custom SMTP** again turns them back on without retyping.
+
+## What is sent
+
+Every email goes to the account's own address. Bot alerts and the test email use the account's language; sign-up, confirmation and password mails use the language of the page that triggered them.
+
+| Subject | When |
+|---|---|
+| Something went wrong with *bot* | An order failed with an error that will not be retried, or the exchange kept rate-limiting the bot until it gave up. Repeated network failures are not emailed; the bot just tries again at the next interval. The mail quotes the exchange's error and points to the bot log. |
+| Your *exchange* account is running out of *QUOTE* | A buying bot's spendable balance dropped below about three days of scheduled buys, or the exchange rejected an order for insufficient funds. The low-balance warning is sent at most once a day per quote asset; a rejected order emails every time it happens. |
+| *bot* invested full amount / *bot* sold full amount | The amount limit was reached and the bot stopped itself (see [Triggers](11-triggers.md)). |
+| Confirm your email | A new user signed up, or you changed your address (see [Multiple users](36-multiple-users.md)). |
+| Reset password instructions | You used **Forgot password?** on the login page. |
+| Email already taken | Someone tried to sign up with your address. |
+| Deltabadger Test Email | You pressed **Send Test Email**. |
+
+There is no per-user opt-out: with SMTP configured, every user gets their own alerts. Email is the only channel — there is no Telegram, push or webhook delivery.
+
+## Sender address
+
+Emails come from `NOTIFICATIONS_SENDER` if that is set in the environment, otherwise from the SMTP username, otherwise from `noreply@localhost` (see [Configuration](38-configuration.md)).
+
+## Locked by the environment
+
+When `SMTP_ADDRESS` is set in the environment, the widget shows that provider — named by `SMTP_PROVIDER_NAME`, or the address itself — greyed out, with only **Send Test Email** available. The `SMTP_*` variables are then the place to change anything.

--- a/manual/38-configuration.md
+++ b/manual/38-configuration.md
@@ -1,0 +1,128 @@
+# Configuration
+
+Deltabadger is configured through environment variables. A local install needs none of them: every value has a working default, and the secrets are generated on first start. Set them when you put the app on a domain, want email, or route exchange traffic through a proxy.
+
+With Docker Compose, put them in `.env.docker` next to `docker-compose.yml` (copy `.env.docker.example`, see [Docker Compose](03-docker-compose.md)). With a single `docker run`, pass them with `-e NAME=value`. Compose reads `.env.docker` when it creates the container, so after editing it run `docker compose up -d --force-recreate`; a plain restart keeps the old values.
+
+Three variables are an exception: Compose resolves `APP_PORT`, `APP_ROOT_URL` and `HOME_PAGE_URL` itself, from your shell or from a `.env` file next to `docker-compose.yml`. Values for those in `.env.docker` do not reach it.
+
+## Ports and URLs
+
+The container always listens on port `3000`; the host port is whatever you map to it.
+
+| Variable | What it does |
+|---|---|
+| `APP_PORT` | Host port Compose maps to the container. Default `3737`. With `docker run`, change `-p 3737:3000` instead. |
+| `APP_ROOT_URL` | The address people open, for example `https://dca.example.com`. Sets the host and protocol of links in emails, the origin allowed for live page updates, and the MCP and REST API URLs shown under **Settings → Connect**. Default `http://localhost:3737` with Compose; `http://localhost:3000` with `docker run`, so pass `-e APP_ROOT_URL=http://localhost:3737` there. |
+| `ALLOWED_HOSTS` | Comma-separated hostnames the app answers to. `localhost` and `127.0.0.1` are always allowed. Unset, any host is accepted. |
+| `FORCE_SSL` | `true` or `false`. Inferred from an `https://` `APP_ROOT_URL`, so set it only to override that: `true` turns on HSTS, secure cookies and `https` links for a non-https root URL; `false` serves an `https://` root URL over plain http. |
+| `BEHIND_PROXY` | `true` or `false`. Whether a reverse proxy sits in front of the container. It decides which address the rate limits on sign-in, password reset and the other authentication pages count: the forwarded address when a proxy is declared, the connecting address otherwise. Inferred from an `https://` `APP_ROOT_URL` or `FORCE_SSL=true`; set `true` yourself for a proxy that talks plain http to the container. Left unset behind a proxy, everyone shares one budget and the sign-in page starts answering "Too many requests from this address. Wait a minute and try again." |
+
+For HTTPS, put nginx, Traefik or similar in front of the container and set `APP_ROOT_URL` to the public address.
+
+## Secrets
+
+Leave these empty on a normal install. See [Secrets and encryption keys](40-secrets-and-encryption-keys.md) before changing any of them.
+
+| Variable | What it does |
+|---|---|
+| `SECRET_KEY_BASE` | Session secret and, on older installs, the root of all stored-data encryption. Generated into `/app/storage/.secrets` on first start when empty. |
+| `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY`, `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` | Keys for stored data (API keys, two-factor secrets, addresses). Generated on a fresh install. Set both or neither; the app refuses to start with one. |
+| `SECRETS_FILE` | Where the generated secrets are kept. Default `/app/storage/.secrets`. |
+
+## Databases
+
+Four SQLite files, all under `/app/storage` by default. See [Data and backups](39-data-and-backups.md).
+
+| Variable | Default |
+|---|---|
+| `DATABASE_PATH` | `/app/storage/production.sqlite3` |
+| `QUEUE_DATABASE_PATH` | `/app/storage/production_queue.sqlite3` |
+| `CACHE_DATABASE_PATH` | `/app/storage/production_cache.sqlite3` |
+| `CABLE_DATABASE_PATH` | `/app/storage/production_cable.sqlite3` |
+
+## Email
+
+Email can also be set up in the app; see [Email notifications](37-email-notifications.md). When `SMTP_ADDRESS` is set in the environment, **Settings → Account → Email Notifications** is locked to that server and shows it under the name from `SMTP_PROVIDER_NAME`. The example file sets `SMTP_ADDRESS=localhost`; blank it to set up email in the app instead.
+
+| Variable | What it does |
+|---|---|
+| `SMTP_ADDRESS` | SMTP server hostname. Setting it turns on the environment SMTP option. |
+| `SMTP_PORT` | SMTP port. |
+| `SMTP_DOMAIN` | HELO domain sent to the server. |
+| `SMTP_USER_NAME`, `SMTP_PASSWORD` | SMTP login. |
+| `NOTIFICATIONS_SENDER` | From address. Falls back to the SMTP username, then `noreply@localhost`. |
+| `SMTP_PROVIDER_NAME` | Label shown in Settings. Falls back to `SMTP_ADDRESS`. |
+
+## Market data
+
+See [Market data](35-market-data.md) for what each provider covers.
+
+| Variable | What it does |
+|---|---|
+| `CLAIM_TOKEN` | A one-time Deltabadger.com connect code (`dbc_…`). Redeemed when the setup page is first opened: connects market data and exchange proxies and prefills the admin name and email. See [First run](06-first-run.md). |
+| `MARKET_DATA_URL`, `MARKET_DATA_TOKEN` | A separately managed market-data service. While `MARKET_DATA_URL` is set, **Settings → Connect → Market Data** is locked to it. |
+| `MARKET_DATA_PROVIDER_NAME` | Label shown in Settings for that service. Falls back to the URL. |
+| `COINGECKO_API_KEY` | CoinGecko key used until one is saved in Settings. A key saved in Settings wins, even when it was cleared. |
+
+## Exchange proxies
+
+`PROXY_<EXCHANGE>` routes one exchange's API traffic through an HTTP proxy, for exchanges that require a fixed IP on the API key. The value is the proxy URL, for example `PROXY_BINANCE=http://proxy.example.com:8100`. Recognised names: `BINANCE`, `BINANCE_US`, `BINGX`, `BITGET`, `BITRUE`, `BITVAVO`, `BYBIT`, `COINBASE`, `GEMINI`, `HYPERLIQUID`, `KRAKEN`, `KUCOIN`, `MEXC`. A proxy supplied by a Deltabadger.com connection overrides the environment value for that exchange.
+
+## Performance
+
+| Variable | What it does |
+|---|---|
+| `WEB_CONCURRENCY` | Web server worker processes. Default `0`, a single process; values above `1` start that many workers. |
+| `RAILS_MAX_THREADS` | Threads per process, and the base of the database connection pool. The image sets `1`; the Umbrel app sets `5`. |
+| `MAX_DB_CONNECTIONS` | Worker pool for live page updates over websockets. Default `4`. |
+
+## Other
+
+| Variable | What it does |
+|---|---|
+| `AUTO_MIGRATE` | In `web` mode, `true` runs database migrations on start. `standalone` always migrates. |
+| `RAILS_LOG_TO_STDOUT` | Set by the image. Logs go to the container output, so `docker compose logs -f` shows them. |
+| `RAILS_SERVE_STATIC_FILES` | Set by the image. The app serves its own assets; keep it unless a web server in front serves `/public`. |
+
+## Command modes
+
+The word after the image name chooses what the container runs.
+
+| Command | Runs |
+|---|---|
+| `standalone` | Web server and job worker in one process. Migrates the database on every start. Used by the quick-start command and `docker-compose.yml`. |
+| `web` | Web server only. Migrates only when `AUTO_MIGRATE=true`. The image default when no command is given. |
+| `jobs` | Job worker only: bots, rules, syncs, emails. Must share the storage volume with a `web` container. |
+
+The Umbrel app runs `web` and `jobs` as two containers; see [Umbrel](05-umbrel.md).
+
+## Maintenance commands
+
+Run these against a stopped app, with the same volume and environment:
+
+```bash
+docker compose stop
+docker compose run --rm --no-deps deltabadger <command>
+```
+
+| Command | Does |
+|---|---|
+| `migrate` | Creates or migrates the databases, and loads the asset list if it is empty. |
+| `setup` | Prepares and seeds the databases. |
+| `console` | Opens an interactive console on the app. |
+| `rake <task>` | Runs a named task, for example `rake deltabadger:encryption:report`. See [Secrets and encryption keys](40-secrets-and-encryption-keys.md). |
+| `shell` | Opens a shell inside the container. |
+
+Anything else is run as given. On Umbrel, run them inside the `web` container instead; the command is on the [Umbrel](05-umbrel.md) page.
+
+## Health endpoints
+
+Both answer without signing in and are safe to poll.
+
+| Endpoint | Response | Used by |
+|---|---|---|
+| `GET /health-check` | `{"health":"check"}`, without touching the database | `docker-compose.yml` |
+| `GET /up` | `200` once the app has booted | The image's own health check, every 30 seconds |
+
+If a container reports unhealthy, read its logs with `docker compose logs -f`. See [Troubleshooting](41-troubleshooting.md).

--- a/manual/39-data-and-backups.md
+++ b/manual/39-data-and-backups.md
@@ -1,0 +1,52 @@
+# Data and backups
+
+Everything Deltabadger stores lives in one directory inside the container, `/app/storage`, on the volume mounted there. A copy of that directory, taken while the app is stopped, is a complete backup.
+
+## What is in the storage directory
+
+| File | Contents |
+|---|---|
+| `production.sqlite3` | Accounts, bots, rules, exchange keys, transactions, settings |
+| `production_queue.sqlite3` | Scheduled work: bot runs, syncs, emails |
+| `production_cache.sqlite3` | Cache: market data, chart series, computed metrics |
+| `production_cable.sqlite3` | Live page updates |
+| `.secrets` | This install's generated keys; see [Secrets and encryption keys](40-secrets-and-encryption-keys.md) |
+
+Each database may have `-wal` and `-shm` companions next to it. Copy the directory whole, never single files. The paths can be changed on [Configuration](38-configuration.md).
+
+Logs are not in the volume. They go to the container output: `docker compose logs -f`, or `docker logs deltabadger` for the quick-start container. On Umbrel, read them with `docker logs deltabadger_web_1` and `docker logs deltabadger_jobs_1`; see [Umbrel](05-umbrel.md).
+
+The quick-start command names the volume `deltabadger_data`; `docker-compose.yml` defines one called `storage`, prefixed with the project directory name. `docker volume ls` shows the real names. Files inside are owned by user id `1000`; the container corrects ownership on every start unless you run it with `user:` set, in which case make the copied files owned by `1000:1000` yourself.
+
+## Backing up
+
+1. Stop the app, so nothing is writing to the databases:
+   ```bash
+   docker compose stop
+   ```
+2. Copy the directory out of the stopped container:
+   ```bash
+   docker compose cp deltabadger:/app/storage ./storage-backup
+   ```
+   For the quick-start container use `docker stop deltabadger` and `docker cp deltabadger:/app/storage ./storage-backup`. If you changed the compose file to use a bind mount, copy that host directory instead.
+3. Start the app again with `docker compose start` (or `docker start deltabadger`).
+
+> **Note:** On a default install the copy contains `.secrets`, the key that decrypts every API key in it, so the backup is as sensitive as your exchange accounts. Keep it as carefully as the database and never put it anywhere shared. If `SECRET_KEY_BASE` or the encryption keys come from `.env.docker`, a compose file or Umbrel instead, they are not in the copy — save those values with it, or the backup cannot be read.
+
+## Restoring
+
+1. Stop the existing container with `docker compose stop`, or create a new one without starting it: `docker compose create` (with plain Docker, `docker create` with the same options as the quick-start command).
+2. Copy the backup in, replacing whatever is there:
+   ```bash
+   docker compose cp ./storage-backup/. deltabadger:/app/storage
+   ```
+   (`docker cp ./storage-backup/. deltabadger:/app/storage` for the quick-start container.)
+3. Start it: `docker compose up -d` or `docker start deltabadger`.
+
+If the keys came from the environment, the restored install has to run with the same values, or nothing stored under them can be read. Restore into the same version of Deltabadger the backup was taken from, or a newer one: `standalone` mode migrates the databases on start.
+
+To wipe an install instead, see [Starting fresh](03-docker-compose.md#starting-fresh).
+
+## Desktop app
+
+The desktop app built with `setup.sh` keeps its databases in the `storage/` folder of the source checkout. Quit the app before copying it.

--- a/manual/40-secrets-and-encryption-keys.md
+++ b/manual/40-secrets-and-encryption-keys.md
@@ -1,0 +1,79 @@
+# Secrets and encryption keys
+
+Secrets are auto-generated on first run and stored in `/app/storage/.secrets` (inside the volume). These persist across container restarts and upgrades.
+
+## Replacing SECRET_KEY_BASE without losing data
+
+An install that sets `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY` and `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` keeps its stored data encrypted under those, not under `SECRET_KEY_BASE`. Replacing `SECRET_KEY_BASE` there ends every session and leaves stored data untouched — no credentials to re-enter, no two-factor to re-enrol. Password reset and confirmation emails already sent stop working, and your REST API and MCP tokens are unaffected, so revoke those separately if the old value was ever exposed.
+
+Installs created from scratch after these keys existed already have them. To check:
+
+```bash
+docker compose run --rm --no-deps deltabadger \
+  rake deltabadger:encryption:derived_keys
+```
+
+If your install does not have them yet, that command prints the two values it currently derives. Put both wherever this install's environment comes from, recreate the container with `docker compose up -d --force-recreate`, and confirm it starts and your credentials still read. `SECRET_KEY_BASE` is free to change from then on.
+
+If your compose file defines more than one service, set them in **every** service block. They share one database, and different values leave each unable to read the other's writes.
+
+Only ever set them to the values that command prints. Any others make stored data unreadable.
+
+## Moving to a new SECRET_KEY_BASE
+
+`SECRET_KEY_BASE` is the encryption key for everything encrypted in this instance — exchange API keys, your two-factor secret, withdrawal addresses, and market-data configuration. You cannot simply change it on a running install: every encrypted field is derived from it, so changing the value in place makes all of them unreadable and locks you out. The steps below clear the stored credentials under the old key and let you re-enter them under the new one.
+
+**Who needs step 4.** Treat your credentials as compromised, and step 4 (revoke) as not optional, if either of these is true:
+
+- This install's `SECRET_KEY_BASE` was ever one of the placeholder values shipped in this repository, or any other value that has appeared somewhere public. Anyone holding a copy of your database can already read every credential in it.
+- A person chose the value rather than generating it randomly. A short or human-chosen key is cheap to brute-force offline from a single encrypted database value or one captured session cookie, which yields the same result. A value not being on our placeholder list says nothing about how it was chosen, and neither check below can see how it was chosen either — add `-e PUBLISHED=yes` to the commands in steps 3 and 5 so they say so too.
+- You have already changed `SECRET_KEY_BASE` and can no longer sign in. The stored credentials were written under the *previous* key, and the strong value you are running now tells you nothing about whether that previous one was published.
+
+Only if your secret was randomly generated and has never left the machine is nothing here known to be exposed. Then follow the same steps at your convenience and skip step 4. If you are unsure, revoke.
+
+The report and the reset make this call where they can, and say which way they went: they treat the data as compromised if the secret currently in use is one published in this repository, or if anything stored will not decrypt under it — the signature of that third case. Neither check can see how a value was chosen, nor a key you have already replaced and discarded. Those two are your call to make: add `-e PUBLISHED=yes` to the report and reset commands to force the compromised wording.
+
+Follow this order exactly. Back up only after stopping the app — a copy taken while it is still writing is not consistent, and it is the only way back. Run the report before revoking anything — it is what tells you which credentials exist; revoking first means working from memory and missing the fee keys, SMTP password, or market-data token. Revoke before the reset, and do not reissue anything until after the restart — a replacement has nowhere to be stored until the app is running again, and for Interactive Brokers, registering a new key early hands them a public key whose private half the reset then deletes.
+
+The commands below use the service name from `docker-compose.yml`. The Umbrel app definition calls that service `web` — substitute it if you run from that file.
+
+1. Stop the app.  `docker compose stop`
+2. Back up your data, now that nothing is writing to it. The default deployment uses a named volume, not a host directory:
+   ```bash
+   docker compose cp deltabadger:/app/storage ./storage-backup
+   ```
+   If you changed `docker-compose.yml` to use a bind mount, copy that host directory instead. On a default install this copy includes `/app/storage/.secrets` — the key itself — so the backup decrypts itself. Keep it as carefully as the database, and do not put it anywhere shared. If your key comes from `.env.docker` or a compose file it is *not* in this copy, and step 6 overwrites it — save that value too, or this backup cannot be restored.
+3. List what is stored:
+   ```bash
+   docker compose run --rm --no-deps deltabadger \
+     rake deltabadger:encryption:report
+   ```
+   Copy your withdrawal addresses — they are not recoverable afterwards.
+4. **REVOKE everything it listed, at its source: exchange API keys, fee keys, SMTP password, Alpaca key and secret, CoinGecko key, market-data token.** Revoke only — replacements have nowhere to live until step 7.
+5. Clear what is stored:
+   ```bash
+   docker compose run --rm --no-deps -e CONFIRM=clear-credentials \
+     deltabadger rake deltabadger:encryption:reset
+   ```
+6. Point this install at a new key. Blank the `SECRET_KEY_BASE` line in `.env.docker`, then delete the generated key, which is a separate file inside the volume:
+   ```bash
+   docker compose run --rm --no-deps deltabadger \
+     rm -f /app/storage/.secrets
+   ```
+   On a default install `.env.docker` is already blank and `.secrets` is where your key actually is, so this deletion is what rotates anything at all. A new one is written only when that file is absent; an existing one is never overwritten.
+
+   If your value comes from a compose file instead — the Umbrel app definition sets it from `APP_SEED` — put a freshly generated value in **both service blocks** rather than blanking it:
+   ```bash
+   openssl rand -hex 64
+   ```
+   That file sets `SECRET_KEY_BASE` twice, once under `web` and once under `jobs`, and each container's own environment beats the generated file. Use the same value in both: change one and the two halves of the app run on different keys, and neither can read what the other wrote.
+7. Recreate the container so it picks up the edited value:
+   ```bash
+   docker compose up -d --force-recreate
+   ```
+   Starting the stopped container instead would bring it back with the old value still baked in: Compose reads `env_file` and `environment:` when a container is *created*, not when it starts, so editing the file does not reach a container that already exists. A strong per-install secret is generated for you.
+8. Sign in, issue fresh credentials, add them, re-enable two-factor, re-issue your REST API token, reconnect your MCP clients, and restart your bots and rules — the reset cleared and stopped all of them.
+
+Your REST API token and every connected MCP client are cleared by step 5, not by you in step 4, and the reset prints how many it deleted. They are bearer tokens held in this database and derived from nothing, so changing `SECRET_KEY_BASE` leaves them working and still able to place orders — deleting them is what invalidates them. The OAuth client registrations themselves survive, so a client can reconnect under the client ID it already has, but it has to be authorized again.
+
+Interactive Brokers is the slow one: its key pair is generated by this app and stored here, so it can only be replaced after step 7 — run the connect wizard again, register the new key in IBKR's portal, and wait for them to activate it. Registering a fresh key any earlier would hand IBKR a public key whose private half step 5 then deletes.

--- a/manual/41-troubleshooting.md
+++ b/manual/41-troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+## Docker: Container won't start
+
+Check logs for errors:
+
+```bash
+docker compose logs web
+```
+
+Common fixes:
+- Make sure Docker Desktop is running
+- Try rebuilding: `docker compose build --no-cache`
+- Reset everything (see [Starting fresh](03-docker-compose.md#starting-fresh))
+
+## Docker: Port already in use
+
+Another app is using port 3737. Either stop that app, or change the port mapping. For example, to use port 4000:
+
+**Single command:** Change `-p 3737:3000` to `-p 4000:3000`
+
+**Docker Compose:** Set in `.env.docker`:
+```bash
+APP_PORT=4000
+```

--- a/manual/42-development.md
+++ b/manual/42-development.md
@@ -1,0 +1,48 @@
+# Development
+
+## Requirements
+
+- Ruby 3.4.8
+- Node.js 18.19.1
+
+Use [asdf](https://asdf-vm.com) or your preferred version manager.
+
+## 1. Install dependencies
+
+```bash
+bin/setup
+```
+
+## 2. Database
+
+```bash
+bundle exec rails db:prepare
+```
+
+## 3. Start the app
+
+```bash
+bin/dev
+```
+
+This starts the Rails server with Solid Queue (background jobs) running in-process via Puma.
+
+Alternatively, run services separately:
+
+Terminal 1 — Rails (with background jobs):
+
+```bash
+rails s
+```
+
+Terminal 2 — JavaScript bundler (optional, for live reloading):
+
+```bash
+npm run build:watch
+```
+
+## Running tests
+
+```bash
+bin/rails test
+```


### PR DESCRIPTION
## Summary

The user manual, written into the repository as `manual/` — forty-two short chapters, one per thing a user does — with the README trimmed to an introduction and a table of contents pointing into them.

Chapters cover installing (Docker Compose, the desktop app, Umbrel), the first run and updating; creating bots, amounts and intervals, order options, triggers, selling and managing bots; charts, statistics and orders; the portfolio bot, rebalancing, the index bot and index changes; withdrawal rules, keys and addresses; connecting exchanges, the portfolio overview, transactions and positions, import and export, the crypto and broker tax reports; supported exchanges, API keys, stocks and ETFs; connecting Claude, tools and permissions, the REST API; account settings, two-factor authentication, market data, multiple users, email notifications; configuration, data and backups, secrets and encryption keys; troubleshooting and development.

Documentation only — no code changes.
