### PR TITLE
Type an allocation as well as drag it, and say what blocks Start where Start is

### DIFF
--- a/app/assets/stylesheets/new/_dca-multi-asset.sass
+++ b/app/assets/stylesheets/new/_dca-multi-asset.sass
@@ -27,6 +27,31 @@
     .slider__style__track
         display: grid
 
+    // The typed weight sits where the read-only % used to, right-aligned against its own % sign.
+    .allocation
+        display: flex
+        align-items: center
+        justify-content: flex-end
+        gap: 0.25rem
+
+    .allocation__input
+        width: 5rem
+        padding: 0
+        border: none
+        background: none
+        color: inherit
+        font: inherit
+        text-align: right
+        appearance: textfield
+
+        &::-webkit-outer-spin-button,
+        &::-webkit-inner-spin-button
+            appearance: none
+            margin: 0
+
+        &:disabled
+            color: var(--concrete)
+
     &__remove
         flex: 0 0 auto
         color: var(--concrete)

--- a/app/javascript/controllers/bot/allocation_controller.js
+++ b/app/javascript/controllers/bot/allocation_controller.js
@@ -4,29 +4,45 @@ import { Controller } from "@hotwired/stimulus";
 // server-side Normalize action is the deliberate way to squeeze their proportions to 100%.
 // Connects to data-controller="bot--allocation" on the settings form.
 export default class extends Controller {
-  static targets = ["row", "input", "total", "totalRow"];
+  static targets = ["row", "input", "percent", "total", "totalRow"];
 
   connect() {
     this.rowTargets.forEach((row) => this.#paintRow(row));
     this.#paintTotal();
   }
 
+  // Slider dragged: the number field follows it.
   update(event) {
-    const moved = event.target;
-    const value = Math.min(100, Math.max(0, parseFloat(moved.value) || 0));
-    moved.value = value.toFixed(2);
-    this.#paintRow(moved.closest('[data-bot--allocation-target="row"]'));
+    this.#paintRow(this.#rowOf(event.target));
     this.#paintTotal();
+  }
+
+  // Number typed: the slider follows it, and the field's own text is left alone mid-keystroke.
+  type(event) {
+    const row = this.#rowOf(event.target);
+    if (!row) return;
+
+    const range = row.querySelector('input[type="range"]');
+    range.value = Math.min(100, Math.max(0, parseFloat(event.target.value) || 0));
+    this.#paintTrack(row, parseFloat(range.value) || 0);
+    this.#paintTotal();
+  }
+
+  #rowOf(element) {
+    return element.closest('[data-bot--allocation-target="row"]');
   }
 
   #paintRow(row) {
     if (!row) return;
 
     const pct = parseFloat(row.querySelector('input[type="range"]')?.value) || 0;
-    row.querySelector(
-      ".slider__style__track",
-    ).style.gridTemplateColumns = `${pct}% auto`;
-    row.querySelector(".allocation").textContent = `${pct.toFixed(2)}%`;
+    this.#paintTrack(row, pct);
+    row.querySelector(".allocation__input").value = pct.toFixed(1);
+  }
+
+  #paintTrack(row, pct) {
+    row.querySelector(".slider__style__track").style.gridTemplateColumns =
+      `${pct}% auto`;
   }
 
   #paintTotal() {
@@ -35,7 +51,7 @@ export default class extends Controller {
       (total, input) => total + (parseFloat(input.value) || 0),
       0,
     );
-    this.totalTarget.textContent = `${sum.toFixed(2)}%`;
+    this.totalTarget.textContent = `${sum.toFixed(1)}%`;
     const unbalanced = Math.abs(sum - 100) > 0.1;
     this.totalRowTarget.classList.toggle(
       "asset-allocations__total--off",

--- a/app/models/bots/dca_multi_asset/allocatable.rb
+++ b/app/models/bots/dca_multi_asset/allocatable.rb
@@ -40,9 +40,10 @@ module Bots::DcaMultiAsset::Allocatable
 
   def composition_locked? = working? || rebalance_pending?
 
-  # String keys (JSON), floats, 4 dp, sum exactly 1. Negative inputs clamp to 0. The residual goes
-  # to the largest weight: on the last key it could make a tiny allocation negative. Zero is a
-  # legal weight — a parked asset stays a member.
+  # String keys (JSON), floats, 3 dp, sum exactly 1. Three decimals is the slider's 0.1% step: a
+  # finer weight would be snapped by the range input on the next render and stop adding up to 100%.
+  # Negative inputs clamp to 0. The residual goes to the largest weight: on the last key it could
+  # make a tiny allocation negative. Zero is a legal weight — a parked asset stays a member.
   def normalize_allocations(hash)
     entries = hash.to_h { |key, value| [key.to_s, [value.to_f, 0].max] }
     total = entries.values.sum
@@ -51,9 +52,9 @@ module Bots::DcaMultiAsset::Allocatable
     entries.transform_values! { 1.0 } unless total.positive?
     total = entries.values.sum
 
-    rounded = entries.transform_values { |value| (value / total).round(4) }
+    rounded = entries.transform_values { |value| (value / total).round(3) }
     largest = rounded.max_by { |_, value| value }.first
-    rounded[largest] = (rounded[largest] + (1 - rounded.values.sum)).round(4)
+    rounded[largest] = (rounded[largest] + (1 - rounded.values.sum)).round(3)
     rounded
   end
 

--- a/app/views/bots/dca_multi_assets/settings/_main.html.erb
+++ b/app/views/bots/dca_multi_assets/settings/_main.html.erb
@@ -2,7 +2,7 @@
 <% base_assets = bot.base_assets %>
 <% composition_locked = bot.composition_locked? %>
 <% allocations_balanced = bot.allocations_balanced? %>
-<% allocation_sum = number_with_precision(bot.allocations_total * 100, precision: 2) %>
+<% allocation_sum = number_with_precision(bot.allocations_total * 100, precision: 1) %>
 
 <%= form_with model: bot,
               url: path,
@@ -29,7 +29,7 @@
   <div class="asset-allocations">
     <% base_assets.each do |asset| %>
       <% color = ensure_contrast(asset.color || '#8A9BA8') %>
-      <% pct = (bot.allocation_for(asset.id) * 100).round(2) %>
+      <% pct = (bot.allocation_for(asset.id) * 100).round(1) %>
       <div class="index-asset asset-allocation"
            data-bot--allocation-target="row"
            style="--slider-progress: <%= color %>">
@@ -40,7 +40,7 @@
                    name="bots_dca_multi_asset[allocations][<%= asset.id %>]"
                    min="0"
                    max="100"
-                   step="0.01"
+                   step="0.1"
                    value="<%= pct %>"
                    class="slider__input"
                    data-bot--allocation-target="input"
@@ -56,7 +56,16 @@
               </div>
             </div>
           </div>
-          <div class="allocation" data-bot--allocation-target="percent"><%= number_with_precision(pct, precision: 2) %>%</div>
+          <div class="allocation">
+            <%# The same weight, typed: the slider follows this field and this field follows the slider. %>
+            <input type="number" min="0" max="100" step="0.1" inputmode="decimal"
+                   value="<%= pct %>"
+                   class="allocation__input"
+                   data-bot--allocation-target="percent"
+                   data-action="input->bot--allocation#type change->form--submit#submit"
+                   aria-label="<%= asset.symbol %>"
+                   <%= 'disabled' if composition_locked %>>%
+          </div>
           <% if !composition_locked && base_assets.size > Bots::DcaMultiAsset::MIN_ASSETS %>
             <%# This stays inside the PATCH form so a removal preserves every slider value posted
                 with the click; a second form here would be invalid HTML and lose those edits. %>

--- a/app/views/bots/status/_status_bar.html.erb
+++ b/app/views/bots/status/_status_bar.html.erb
@@ -7,6 +7,11 @@
     <div class="bot-control__status__text" data-marquee-target="text">
       <%= t('bot.status.setting_orders') %>
     </div>
+  <% elsif bot.respond_to?(:allocations_balanced?) && !bot.allocations_balanced? %>
+    <%# The Start button next to this is disabled while the weights do not add up: say what unblocks it. %>
+    <div class="bot-control__status__text" data-marquee-target="text">
+      <%= t('bot.dca_multi_asset.normalize_first') %>
+    </div>
   <% elsif bot.stopped? %>
     <div class="bot-control__status__text" data-marquee-target="text">
       <% if bot.stop_message_key.present? %>

--- a/app/views/bots/status/_status_button.html.erb
+++ b/app/views/bots/status/_status_button.html.erb
@@ -12,11 +12,6 @@
         <%= t('errors.bots.exchange_asset_mismatch', exchange_name: bot.exchange&.name) %>
       </p>
     <% end %>
-    <% if (bot.stopped? || bot.created? || bot.restarting?) && bot.respond_to?(:allocations_balanced?) && !bot.allocations_balanced? %>
-      <p class="status-button__hint" role="status">
-        <%= t('bot.dca_multi_asset.unbalanced_hint', sum: number_with_precision(bot.allocations_total * 100, precision: 2)) %>
-      </p>
-    <% end %>
     <% if !bot.stopped? && !bot.created? %>
       <%= button_to bot_stop_path(bot), method: :patch, class: "sbutton sbutton--sky sbutton--outline", data: { hw_animate_out: "animate-button-to-start-shape", turbo_frame: "_top" }, aria: { label: t('button.stop') } do %>
         <div class="animicon animicon--stop">

--- a/app/views/bots/update.turbo_stream.erb
+++ b/app/views/bots/update.turbo_stream.erb
@@ -11,6 +11,7 @@
   <%= turbo_stream.replace 'settings', partial: 'bots/signals/settings', locals: { bot: @bot } %>
 <% end %>
 <%= turbo_stream.replace 'exchange_select', partial: 'bots/exchange_select', locals: { bot: @bot } %>
+<%= turbo_stream.replace dom_id(@bot, :status_bar), partial: 'bots/status/status_bar', locals: { bot: @bot } %>
 <%= turbo_stream.replace dom_id(@bot, :status_button), partial: 'bots/status/status_button', locals: { bot: @bot } %>
 
 <%= turbo_stream_prepend_flash %>

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -16,6 +16,7 @@ bg:
             removed_from_portfolio: "Премахнати от портфейла"
             allocation_sum: "Общо"
             normalize: "Нормализиране"
+            normalize_first: "Първо нормализирайте разпределението."
             unbalanced_hint: "Разпределенията са общо %{sum}% — трябва да бъдат 100%, преди ботът да може да стартира."
         dca_index:
             setup:

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -16,6 +16,7 @@ cs:
             removed_from_portfolio: "Odebráno z portfolia"
             allocation_sum: "Celkem"
             normalize: "Normalizovat"
+            normalize_first: "Nejprve normalizujte alokace."
             unbalanced_hint: "Součet alokací je %{sum}% — před spuštěním bota musí být 100%."
         dca_index:
             setup:

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -16,6 +16,7 @@ da:
             removed_from_portfolio: "Fjernet fra porteføljen"
             allocation_sum: "I alt"
             normalize: "Normaliser"
+            normalize_first: "Normaliser fordelingen først."
             unbalanced_hint: "Fordelingerne giver i alt %{sum}% — de skal give 100%, før botten kan startes."
         dca_index:
             setup:

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -16,6 +16,7 @@ de:
             removed_from_portfolio: "Aus dem Portfolio entfernt"
             allocation_sum: "Gesamt"
             normalize: "Normalisieren"
+            normalize_first: "Zuerst die Allokation normalisieren."
             unbalanced_hint: "Die Allokationen ergeben %{sum} % — vor dem Start des Bots müssen sie zusammen 100 % ergeben."
         dca_index:
             setup:

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -16,6 +16,7 @@ el:
             removed_from_portfolio: "Αφαιρέθηκαν από το χαρτοφυλάκιο"
             allocation_sum: "Σύνολο"
             normalize: "Κανονικοποίηση"
+            normalize_first: "Πρώτα κανονικοποιήστε την κατανομή."
             unbalanced_hint: "Οι κατανομές αθροίζονται σε %{sum}% — πρέπει να φτάνουν το 100% πριν ξεκινήσει το bot."
         dca_index:
             setup:

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -16,6 +16,7 @@ en:
             removed_from_portfolio: "Removed from portfolio"
             allocation_sum: "Total"
             normalize: "Normalize"
+            normalize_first: "Normalize allocation first."
             unbalanced_hint: "Allocations add up to %{sum}% — they must add up to 100% before the bot can start."
         dca_index:
             setup:

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -19,6 +19,7 @@ es:
             removed_from_portfolio: "Eliminados de la cartera"
             allocation_sum: "Suma total"
             normalize: "Normalizar"
+            normalize_first: "Normaliza primero las asignaciones."
             unbalanced_hint: "Las asignaciones suman un %{sum}% — deben sumar un 100% antes de iniciar el bot."
         dca_index:
             setup:

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -19,6 +19,7 @@ fr:
             removed_from_portfolio: "Retirés du portefeuille"
             allocation_sum: "Total des allocations"
             normalize: "Normaliser"
+            normalize_first: "Normalisez d'abord les allocations."
             unbalanced_hint: "La somme des allocations est de %{sum} % — elle doit atteindre 100 % avant de pouvoir démarrer le bot."
         dca_index:
             setup:

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -16,6 +16,7 @@ it:
             removed_from_portfolio: "Rimossi dal portafoglio"
             allocation_sum: "Totale"
             normalize: "Normalizza"
+            normalize_first: "Normalizza prima le allocazioni."
             unbalanced_hint: "La somma delle allocazioni è %{sum}% — deve essere 100% prima di poter avviare il bot."
         dca_index:
             setup:

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -19,6 +19,7 @@ nl:
             removed_from_portfolio: "Verwijderd uit de portefeuille"
             allocation_sum: "Totaal"
             normalize: "Normaliseren"
+            normalize_first: "Normaliseer eerst de allocatie."
             unbalanced_hint: "De allocaties komen uit op %{sum}% — ze moeten samen 100% zijn voordat de bot kan starten."
         dca_index:
             setup:

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -19,6 +19,7 @@ pl:
             removed_from_portfolio: "Usunięte z portfela"
             allocation_sum: "Łącznie"
             normalize: "Normalizuj"
+            normalize_first: "Najpierw znormalizuj alokację."
             unbalanced_hint: "Suma alokacji wynosi %{sum}% — przed uruchomieniem bota musi wynosić 100%."
         dca_index:
             setup:

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -19,6 +19,7 @@ pt:
             removed_from_portfolio: "Removidos do portefólio"
             allocation_sum: "Total das alocações"
             normalize: "Normalizar"
+            normalize_first: "Normalize primeiro as alocações."
             unbalanced_hint: "As alocações somam %{sum}% — têm de somar 100% antes de o bot poder iniciar."
         dca_index:
             setup:

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -19,6 +19,7 @@ ru:
             removed_from_portfolio: "Удалены из портфеля"
             allocation_sum: "Итого"
             normalize: "Нормализовать"
+            normalize_first: "Сначала нормализуйте доли."
             unbalanced_hint: "Сумма долей составляет %{sum}% — перед запуском бота она должна составлять 100%."
         dca_index:
             setup:

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -16,6 +16,7 @@ sk:
             removed_from_portfolio: "Odstránené z portfólia"
             allocation_sum: "Celkom"
             normalize: "Normalizovať"
+            normalize_first: "Najprv normalizujte alokácie."
             unbalanced_hint: "Súčet alokácií je %{sum}% — pred spustením bota musí byť 100%."
         dca_index:
             setup:

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -16,6 +16,7 @@ sv:
             removed_from_portfolio: "Borttagna från portföljen"
             allocation_sum: "Totalt"
             normalize: "Normalisera"
+            normalize_first: "Normalisera fördelningen först."
             unbalanced_hint: "Allokeringarna blir totalt %{sum}% — de måste bli 100% innan boten kan starta."
         dca_index:
             setup:

--- a/test/controllers/bots/dca_multi_assets/settings_update_test.rb
+++ b/test/controllers/bots/dca_multi_assets/settings_update_test.rb
@@ -17,7 +17,8 @@ class Bots::DcaMultiAssetsSettingsUpdateTest < ActionDispatch::IntegrationTest
     assert_equal({ @first.id.to_s => 0.7, @second.id.to_s => 0.7 }, @bot.reload.allocations)
     assert_equal({ @first.id => 0.5, @second.id => 0.5 }, composition_weights)
     assert_not @bot.valid?(:start)
-    assert_match I18n.t('bot.dca_multi_asset.unbalanced_hint', sum: '140.00'), response.body
+    assert_match I18n.t('bot.dca_multi_asset.unbalanced_hint', sum: '140.0'), response.body
+    assert_match I18n.t('bot.dca_multi_asset.normalize_first'), response.body
     assert_match(/disabled="disabled"/, response.body)
   end
 

--- a/test/controllers/bots/dca_multi_assets/show_settings_test.rb
+++ b/test/controllers/bots/dca_multi_assets/show_settings_test.rb
@@ -18,9 +18,10 @@ class Bots::DcaMultiAssetsShowSettingsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     @assets.each do |asset|
-      assert_select 'input[type="range"][name=?][min="0"][max="100"][step="0.01"]',
+      assert_select 'input[type="range"][name=?][min="0"][max="100"][step="0.1"]',
                     "bots_dca_multi_asset[allocations][#{asset.id}]", count: 1
     end
+    assert_select 'input.allocation__input[type="number"][step="0.1"]', count: @assets.size
     assert_select '.slider__style__thumb', count: @assets.size
     names = css_select('[data-bot--allocation-target="row"] input[type="range"]').map { |input| input['name'] }
     assert_equal @assets.map { |asset| "bots_dca_multi_asset[allocations][#{asset.id}]" }, names
@@ -29,7 +30,7 @@ class Bots::DcaMultiAssetsShowSettingsTest < ActionDispatch::IntegrationTest
   test 'renders the total, and reveals Normalize with a hint only when unbalanced' do
     get bot_path(id: @bot.id)
 
-    assert_select '[data-bot--allocation-target="total"]', text: '100.00%'
+    assert_select '[data-bot--allocation-target="total"]', text: '100.0%'
     assert_select 'button.asset-allocations__normalize[hidden]', count: 1
     assert_select 'small.asset-allocations__hint[hidden]', count: 1
 
@@ -43,10 +44,12 @@ class Bots::DcaMultiAssetsShowSettingsTest < ActionDispatch::IntegrationTest
     @bot.update_columns(settings:)
     get bot_path(id: @bot.id)
 
-    assert_select '[data-bot--allocation-target="total"]', text: '85.00%'
+    assert_select '[data-bot--allocation-target="total"]', text: '85.0%'
     assert_select 'button.asset-allocations__normalize:not([hidden])', count: 1
     assert_select 'small.asset-allocations__hint:not([hidden])', count: 1
-    assert_select "##{dom_id(@bot, :status_button)} .status-button__hint", text: /85\.00%/
+    # The blocker reads once, next to the Start button it disables — the status bar, not the button.
+    assert_select "##{dom_id(@bot, :status_bar)}", text: /#{I18n.t('bot.dca_multi_asset.normalize_first')}/
+    assert_select "##{dom_id(@bot, :status_button)} .status-button__hint", count: 0
     assert_select "##{dom_id(@bot, :status_button)} button[disabled]", count: 1
   end
 

--- a/test/integration/bots/dca_multi_assets_creation_test.rb
+++ b/test/integration/bots/dca_multi_assets_creation_test.rb
@@ -44,7 +44,7 @@ class Bots::DcaMultiAssetsCreationTest < ActionDispatch::IntegrationTest
     assert_equal 'BTC, ETH, SOL', bot.label
     assert_equal [@bitcoin.id, @ethereum.id, @solana.id], bot.base_asset_ids
     assert_in_delta 1, bot.allocations.values.sum, 0.0001
-    assert_equal [0.3334, 0.3333, 0.3333], bot.allocations.values
+    assert_equal [0.334, 0.333, 0.333], bot.allocations.values
     assert_equal 3, bot.bot_index_assets.in_index.count
     assert_match %(action="redirect" target="#{bot_path(bot)}"), response.body
   end

--- a/test/models/bots/dca_multi_asset_test.rb
+++ b/test/models/bots/dca_multi_asset_test.rb
@@ -29,7 +29,7 @@ class Bots::DcaMultiAssetTest < ActiveSupport::TestCase
     bot.save!
 
     ids = @assets.values.map { it[:asset].id.to_s }
-    assert_equal({ ids[0] => 0.3334, ids[1] => 0.3333, ids[2] => 0.3333 }, bot.allocations)
+    assert_equal({ ids[0] => 0.334, ids[1] => 0.333, ids[2] => 0.333 }, bot.allocations)
     assert_equal 1.0, bot.allocations.values.sum
     assert_not bot.settings.key?('base_asset_ids')
   end
@@ -203,7 +203,7 @@ class Bots::DcaMultiAssetTest < ActiveSupport::TestCase
 
     result = bot.parse_params(normalize_allocations: '1')[:allocations]
 
-    assert_equal({ a => 0.6667, b => 0.3333 }, result)
+    assert_equal({ a => 0.667, b => 0.333 }, result)
   end
 
   test 'add and remove in one request compose' do


### PR DESCRIPTION
## Summary

Two refinements to the multi-asset bot's allocation settings.

**Type an allocation as well as drag it.** Each slider gets a number field beside it. Dragging the slider moves the field; typing in the field moves the slider and leaves the field's own text alone mid-keystroke. Both step by 0.1%, and `normalize_allocations` keeps weights to three decimals to match — a finer stored weight would be snapped by the range input on the next render and the row would stop adding up to 100%.

**Say what blocks Start where Start is.** While the weights do not add up, the Start button is disabled. The hint explaining why used to sit under the button; it now reads in the status bar beside it ("Normalize allocation first."), and the settings update refreshes that bar together with the button. Translated in every locale.

## Tests

- `show_settings_test.rb` — sliders and number fields at a 0.1 step, totals at one decimal, the blocker in the status bar and no longer under the button.
- `settings_update_test.rb`, `dca_multi_assets_creation_test.rb`, `dca_multi_asset_test.rb` — updated to three-decimal weights.

Full suite: 4,654 runs, 0 failures. Rubocop clean.
