### PR TITLE
Recognise a file's row when the venue's copy arrives, keep an old reading of a Convert, and read a window to its last page

### DIFF
--- a/app/models/exchanges/binance.rb
+++ b/app/models/exchanges/binance.rb
@@ -699,8 +699,10 @@ class Exchanges::Binance < Exchange
     @exchange_symbols_map&.dig(symbol, :quote) || tickers.find_by(ticker: symbol)&.quote || symbol
   end
 
+  # The ACCOUNT's pairs, under whichever key was current when they were traded: a venue's history
+  # accumulates across key replacements, and a replaced key's rows are left with no key at all.
   def known_traded_symbols(api_key)
-    AccountTransaction.where(api_key: api_key)
+    AccountTransaction.where(user_id: api_key.user_id, exchange_id: api_key.exchange_id)
                       .where.not(quote_currency: nil)
                       .where(entry_type: %i[buy sell swap_in swap_out])
                       .distinct

--- a/app/models/exchanges/binance.rb
+++ b/app/models/exchanges/binance.rb
@@ -502,10 +502,7 @@ class Exchanges::Binance < Exchange
     # windows from the venue's opening; an incremental one is already floored to `ledger_window`
     # by the caller and reaches the present in one call.
     each_window(start_ms, days: 89, from: TRANSFER_HISTORY_FROM) do |window_start, window_end|
-      result = hm_client.deposit_history(start_time: window_start, end_time: window_end)
-      return result if result.failure?
-
-      Array(result.data).each do |dep|
+      failed = each_transfer(hm_client, :deposit_history, window_start, window_end) do |dep|
         next unless dep['status'] == 1
 
         entries << {
@@ -515,11 +512,9 @@ class Exchanges::Binance < Exchange
           transacted_at: Time.at(dep['insertTime'] / 1000.0).utc, raw_data: dep
         }
       end
+      return failed if failed
 
-      result = hm_client.withdraw_history(start_time: window_start, end_time: window_end)
-      return result if result.failure?
-
-      Array(result.data).each do |wd|
+      failed = each_transfer(hm_client, :withdraw_history, window_start, window_end) do |wd|
         next unless wd['status'] == 6
 
         entries << {
@@ -530,6 +525,7 @@ class Exchanges::Binance < Exchange
           transacted_at: Time.parse(wd['applyTime']).utc, raw_data: wd
         }
       end
+      return failed if failed
     end
 
     # Discover traded symbols and fetch spot trades
@@ -752,6 +748,26 @@ class Exchanges::Binance < Exchange
       chunk_end = [window_start + span, window_end].min
       yield window_start, chunk_end
       window_start = chunk_end
+    end
+  end
+
+  # A window is answered a page at a time, a thousand rows to the page, and a busy account's window
+  # holds more: the next page is read while the last was full. Yields each row; returns the failure
+  # that stopped the read, or nil.
+  TRANSFER_PAGE = 1000
+
+  def each_transfer(hm_client, endpoint, window_start, window_end, &block)
+    offset = 0
+    loop do
+      result = hm_client.public_send(endpoint, start_time: window_start, end_time: window_end,
+                                               offset: offset, limit: TRANSFER_PAGE)
+      return result if result.failure?
+
+      rows = Array(result.data)
+      rows.each(&block)
+      return nil if rows.size < TRANSFER_PAGE
+
+      offset += TRANSFER_PAGE
     end
   end
 

--- a/app/services/account_transaction_sync.rb
+++ b/app/services/account_transaction_sync.rb
@@ -137,10 +137,7 @@ class AccountTransactionSync
       # compared exactly, or bucketed by second, every Convert in the overlap between a file and a
       # sync lands a second time. Less than a full second apart is one event, from either side; a
       # row a full second later stays a row of its own.
-      at = entry[:transacted_at]
-      return scope.where(entry_type: entry[:entry_type], base_currency: entry[:base_currency],
-                         base_amount: entry[:base_amount])
-                  .exists?(['transacted_at > ? AND transacted_at < ?', at - 1.second, at + 1.second])
+      return same_event?(entry, scope) || replaced_trade?(entry)
     end
 
     # Only the STORED side is expanded to merged legs. A standalone leg arriving after its merged
@@ -149,8 +146,45 @@ class AccountTransactionSync
     # one-legged — a wrong share count that looks like data — where importing it merely double-counts
     # visibly and can be corrected.
     return true if stored_merged_activity_ids.include?(tx_id)
+    return true if scope.exists?(tx_id: tx_id)
 
-    scope.exists?(tx_id: tx_id)
+    # The other way round: a file imported BEFORE the first sync stored this row with no id, and
+    # the venue's copy now arrives with one. An id that matches nothing is not yet a new row.
+    same_event?(entry, scope.where(tx_id: nil))
+  end
+
+  # A row with no time is not the same event as anything; it is caught and logged on save.
+  def same_event?(entry, rows)
+    return false if entry[:transacted_at].blank?
+
+    rows.where(entry_type: entry[:entry_type], base_currency: entry[:base_currency], base_amount: entry[:base_amount])
+        .exists?(within_a_second(entry))
+  end
+
+  def within_a_second(entry)
+    at = entry[:transacted_at]
+    ['transacted_at > ? AND transacted_at < ?', at - 1.second, at + 1.second]
+  end
+
+  # A file Convert out of cash used to be read as a purchase, or a sale, and is now the swap pair
+  # the venue books. A file imported under the old reading holds the purchase, and importing it
+  # again must not add the pair on top: a leg of the pair is the trade it replaced when the coin is
+  # that trade's base and the cash is its quote, within a second of it.
+  def replaced_trade?(entry)
+    return false unless entry[:group_id].to_s.start_with?('swapcsv_') && entry[:transacted_at].present?
+
+    legacy = scope.where(tx_id: nil).where(within_a_second(entry))
+    coin, amount = entry.values_at(:base_currency, :base_amount)
+    case entry[:entry_type].to_s
+    when 'swap_in'
+      legacy.exists?(entry_type: :buy, base_currency: coin, base_amount: amount) ||
+        legacy.exists?(entry_type: :sell, quote_currency: coin, quote_amount: amount)
+    when 'swap_out'
+      legacy.exists?(entry_type: :sell, base_currency: coin, base_amount: amount) ||
+        legacy.exists?(entry_type: :buy, quote_currency: coin, quote_amount: amount)
+    else
+      false
+    end
   end
 
   def scope

--- a/app/services/account_transaction_sync.rb
+++ b/app/services/account_transaction_sync.rb
@@ -49,6 +49,8 @@ class AccountTransactionSync
     last_percent = 0
     min_skipped = nil
 
+    @file_pairs = entries.select { |entry| entry[:group_id].to_s.start_with?('swapcsv_') }.group_by { |entry| entry[:group_id] }
+
     entries.each_with_index do |entry, index|
       # A blank id identifies nothing, and several adapters produce one (Bybit's txID is empty for
       # internal transfers; Gemini/Hyperliquid/BingX build the id with .to_s on a field that can be
@@ -168,23 +170,23 @@ class AccountTransactionSync
 
   # A file Convert out of cash used to be read as a purchase, or a sale, and is now the swap pair
   # the venue books. A file imported under the old reading holds the purchase, and importing it
-  # again must not add the pair on top: a leg of the pair is the trade it replaced when the coin is
-  # that trade's base and the cash is its quote, within a second of it.
+  # again must not add the pair on top. The PAIR is matched, as a whole, against one stored trade
+  # within a second of it — the incoming leg as that trade's base and the outgoing leg as its quote
+  # (a purchase), or the other way round (a sale) — so both legs are skipped or neither is; one leg
+  # alone can coincide with an unrelated trade, and skipping it alone would leave a one-legged swap.
   def replaced_trade?(entry)
     return false unless entry[:group_id].to_s.start_with?('swapcsv_') && entry[:transacted_at].present?
 
+    legs = @file_pairs.fetch(entry[:group_id], [])
+    inn = legs.find { |leg| leg[:entry_type].to_s == 'swap_in' }
+    out = legs.find { |leg| leg[:entry_type].to_s == 'swap_out' }
+    return false unless inn && out && legs.size == 2
+
     legacy = scope.where(tx_id: nil).where(within_a_second(entry))
-    coin, amount = entry.values_at(:base_currency, :base_amount)
-    case entry[:entry_type].to_s
-    when 'swap_in'
-      legacy.exists?(entry_type: :buy, base_currency: coin, base_amount: amount) ||
-        legacy.exists?(entry_type: :sell, quote_currency: coin, quote_amount: amount)
-    when 'swap_out'
-      legacy.exists?(entry_type: :sell, base_currency: coin, base_amount: amount) ||
-        legacy.exists?(entry_type: :buy, quote_currency: coin, quote_amount: amount)
-    else
-      false
-    end
+    legacy.exists?(entry_type: :buy, base_currency: inn[:base_currency], base_amount: inn[:base_amount],
+                   quote_currency: out[:base_currency], quote_amount: out[:base_amount]) ||
+      legacy.exists?(entry_type: :sell, base_currency: out[:base_currency], base_amount: out[:base_amount],
+                     quote_currency: inn[:base_currency], quote_amount: inn[:base_amount])
   end
 
   def scope

--- a/test/models/exchanges/binance_get_ledger_test.rb
+++ b/test/models/exchanges/binance_get_ledger_test.rb
@@ -183,6 +183,20 @@ class Exchanges::BinanceGetLedgerTest < ActiveSupport::TestCase
   # every deposit and withdrawal older than three months was never fetched — while Convert, asked in
   # 30-day windows, reached back years. A first sync now walks both in windows from the venue's
   # opening to the present, and a 2021 withdrawal lands.
+  # A venue's history accumulates under whichever key was current, and a replaced key's rows are
+  # left with no key at all. The pairs an incremental sync asks for are the ACCOUNT's, not the
+  # current key's — or a pair traded before the key changed would never be asked for again.
+  test 'an incremental sync asks for the pairs the account traded under any key' do
+    create(:account_transaction, user: @user, exchange: @exchange, api_key: nil, entry_type: :buy,
+                                 base_currency: 'BTC', base_amount: 1, quote_currency: 'USDT', quote_amount: 20_000,
+                                 transacted_at: Time.utc(2026, 3, 1))
+    hm_client = mock('honeymaker_client')
+    stub_common(hm_client)
+    hm_client.expects(:account_trade_list).with(has_entry(symbol: 'BTCUSDT')).returns(Result::Success.new([]))
+
+    @exchange.get_ledger(api_key: @api_key, start_time: Time.utc(2026, 3, 20))
+  end
+
   # A window is answered a page at a time, a thousand rows to the page. A busy account's window
   # holds more than that, and moving on to the next window would leave the rest of this one behind.
   test 'a window with more transfers than one page holds is read page by page' do

--- a/test/models/exchanges/binance_get_ledger_test.rb
+++ b/test/models/exchanges/binance_get_ledger_test.rb
@@ -183,6 +183,27 @@ class Exchanges::BinanceGetLedgerTest < ActiveSupport::TestCase
   # every deposit and withdrawal older than three months was never fetched — while Convert, asked in
   # 30-day windows, reached back years. A first sync now walks both in windows from the venue's
   # opening to the present, and a 2021 withdrawal lands.
+  # A window is answered a page at a time, a thousand rows to the page. A busy account's window
+  # holds more than that, and moving on to the next window would leave the rest of this one behind.
+  test 'a window with more transfers than one page holds is read page by page' do
+    hm_client = mock('honeymaker_client')
+    stub_common(hm_client)
+    at = Time.utc(2021, 9, 20, 10, 10, 52)
+    in_window = ->(args) { args[:start_time] <= at.to_i * 1000 && args[:end_time] > at.to_i * 1000 }
+    row = lambda { |index|
+      { 'coin' => 'LTC', 'amount' => '0.001', 'status' => 6, 'transactionFee' => '0',
+        'applyTime' => '2021-09-20 10:10:52', 'txId' => "tx-#{index}" }
+    }
+    hm_client.stubs(:withdraw_history).with { |args| in_window.call(args) && args[:offset].to_i.zero? }
+             .returns(Result::Success.new(Array.new(1000) { |i| row.call(i) }))
+    hm_client.stubs(:withdraw_history).with { |args| in_window.call(args) && args[:offset] == 1000 }
+             .returns(Result::Success.new([row.call(1000)]))
+
+    result = @exchange.get_ledger(api_key: @api_key)
+
+    assert_equal(1001, result.data.count { |e| e[:entry_type] == :withdrawal })
+  end
+
   test 'a full-history sync walks deposits and withdrawals in windows back to the start' do
     hm_client = mock('honeymaker_client')
     stub_common(hm_client)

--- a/test/services/account_transaction_sync_test.rb
+++ b/test/services/account_transaction_sync_test.rb
@@ -358,6 +358,46 @@ class AccountTransactionSyncTest < ActiveSupport::TestCase
     assert_equal({ imported: 1, duplicates: 0 }, later.slice(:imported, :duplicates), 'a full second on: its own row')
   end
 
+  # The other way round: a file imported BEFORE the first sync stores its rows with no id, and the
+  # API's copies then arrive with one. An id that matches nothing stored is not yet a new row — the
+  # id-less row within a second of it, same type, coin and amount, is the same event.
+  test 'an API row is the id-less file row already stored' do
+    at = Time.utc(2021, 9, 20, 10, 10, 52)
+    file = { entry_type: :withdrawal, base_currency: 'LTC', base_amount: '0.249'.to_d,
+             quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil,
+             tx_id: nil, group_id: nil, description: 'Withdraw', transacted_at: at, raw_data: {} }
+    AccountTransactionSync.new(@api_key).store!([file])
+
+    api = file.merge(tx_id: 'abc123', description: nil, transacted_at: at + 0.4, raw_data: { 'txId' => 'abc123' })
+    counts = AccountTransactionSync.new(@api_key).store!([api, api.merge(tx_id: 'def456', transacted_at: at + 2.seconds)])
+
+    assert_equal({ imported: 1, duplicates: 1 }, counts.slice(:imported, :duplicates))
+  end
+
+  # A Convert out of cash used to be read from the file as a purchase; it is now the swap pair the
+  # API books. A file imported under the old reading holds the purchase, and importing it again must
+  # not add the pair on top: a swap leg is the purchase (or sale) it replaced when the coin leg is
+  # that row's base and the cash leg is its quote.
+  test 'a file Convert stored as a purchase or a sale is not stored again as a swap pair' do
+    at = Time.utc(2021, 9, 20, 6, 22, 54)
+    leg = { quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil, tx_id: nil,
+            description: nil, raw_data: {} }
+    bought = leg.merge(entry_type: :buy, base_currency: 'LTC', base_amount: '0.89568816'.to_d,
+                       quote_currency: 'USDT', quote_amount: 150.to_d, group_id: nil, transacted_at: at)
+    sold = leg.merge(entry_type: :sell, base_currency: 'BNB', base_amount: '0.75'.to_d,
+                     quote_currency: 'USDC', quote_amount: 450.to_d, group_id: nil, transacted_at: at + 1.day)
+    AccountTransactionSync.new(@api_key).store!([bought, sold])
+
+    pair = [leg.merge(entry_type: :swap_out, base_currency: 'USDT', base_amount: 150.to_d, group_id: 'swapcsv_1', transacted_at: at),
+            leg.merge(entry_type: :swap_in, base_currency: 'LTC', base_amount: '0.89568816'.to_d, group_id: 'swapcsv_1', transacted_at: at),
+            leg.merge(entry_type: :swap_out, base_currency: 'BNB', base_amount: '0.75'.to_d, group_id: 'swapcsv_2', transacted_at: at + 1.day),
+            leg.merge(entry_type: :swap_in, base_currency: 'USDC', base_amount: 450.to_d, group_id: 'swapcsv_2', transacted_at: at + 1.day)]
+    counts = AccountTransactionSync.new(@api_key).store!(pair)
+
+    assert_equal({ imported: 0, duplicates: 4 }, counts.slice(:imported, :duplicates))
+    assert_equal 2, AccountTransaction.where(user: @user).count
+  end
+
   # Bybit returns an empty txID for internal transfers, and Gemini/Hyperliquid/BingX build their
   # tx_id with .to_s on a field that can be missing. A blank id identifies nothing, so it must fall
   # through to the nil-tx_id identity rather than collapsing every such row onto one '' key.

--- a/test/services/account_transaction_sync_test.rb
+++ b/test/services/account_transaction_sync_test.rb
@@ -398,6 +398,28 @@ class AccountTransactionSyncTest < ActiveSupport::TestCase
     assert_equal 2, AccountTransaction.where(user: @user).count
   end
 
+  # The pair is matched as a WHOLE against one stored trade — its coin as that trade's base and its
+  # cash as that trade's quote — never one leg at a time: a purchase of 1 LTC for 100 USDT is not
+  # the Convert that received 1 LTC for 200 USDC in the same second, and skipping the LTC leg alone
+  # would leave a one-legged swap in the ledger.
+  test 'a legacy purchase matches a file pair as a whole, never one leg of it' do
+    at = Time.utc(2021, 9, 20, 6, 22, 54)
+    leg = { quote_currency: nil, quote_amount: nil, fee_currency: nil, fee_amount: nil, tx_id: nil,
+            description: nil, raw_data: {}, transacted_at: at }
+    AccountTransactionSync.new(@api_key).store!([leg.merge(entry_type: :buy, base_currency: 'LTC', base_amount: 1.to_d,
+                                                           quote_currency: 'USDT', quote_amount: 100.to_d, group_id: nil)])
+
+    other = [leg.merge(entry_type: :swap_out, base_currency: 'USDC', base_amount: 200.to_d, group_id: 'swapcsv_a'),
+             leg.merge(entry_type: :swap_in, base_currency: 'LTC', base_amount: 1.to_d, group_id: 'swapcsv_a')]
+    same = [leg.merge(entry_type: :swap_out, base_currency: 'USDT', base_amount: 100.to_d, group_id: 'swapcsv_b'),
+            leg.merge(entry_type: :swap_in, base_currency: 'LTC', base_amount: 1.to_d, group_id: 'swapcsv_b')]
+
+    assert_equal({ imported: 2, duplicates: 0 }, AccountTransactionSync.new(@api_key).store!(other).slice(:imported, :duplicates),
+                 'a different Convert, both legs')
+    assert_equal({ imported: 0, duplicates: 2 }, AccountTransactionSync.new(@api_key).store!(same).slice(:imported, :duplicates),
+                 'the purchase, both legs')
+  end
+
   # Bybit returns an empty txID for internal transfers, and Gemini/Hyperliquid/BingX build their
   # tx_id with .to_s on a field that can be missing. A blank id identifies nothing, so it must fall
   # through to the nil-tx_id identity rather than collapsing every such row onto one '' key.


### PR DESCRIPTION
## Summary

Three follow-ups to #258, each closing a way the ledger could still hold a row twice or miss one.

**A file's row is recognised when the venue's copy arrives.** A file imported before the first sync stores its rows with no id; the API's copies then arrive with one. Dedup by id found nothing and stored them again. An identified row is now also matched against the id-less row within a second of it — same type, coin and amount — so the full-history walk from #258 lands cleanly on top of an earlier import, whichever came first.

**An old reading of a Convert is kept.** #258 changed the importer to book a Convert out of cash as the swap pair the API books, where it used to be a purchase. A file imported under the old reading holds the purchase; importing it again must not add the pair on top. The pair is matched as a whole against one stored trade within a second of it — its coin as the trade's base and its cash as its quote (a purchase), or the other way round (a sale) — so both legs are skipped or neither is, and repeated import stays a no-op across the change.

**The pairs an incremental sync asks for are the account's.** `known_traded_symbols` was scoped to the current key; a replaced key's rows are left with no key, so a pair known only through them was never asked for again. It is now scoped to the user and venue.

**A window is read to its last page.** The deposit and withdrawal endpoints answer a thousand rows to the page. A busy account's 89-day window can hold more, and moving to the next window would leave the rest behind. The next page is read while the last was full.

## Tests

- `test/services/account_transaction_sync_test.rb` — an API row is the id-less file row already stored (and one a full two seconds on is not); a file Convert stored as a purchase or a sale is not stored again as a swap pair, and a pair is matched as a whole, never one leg of it.
- `test/models/exchanges/binance_get_ledger_test.rb` — a window with 1,001 withdrawals is read page by page; an incremental sync asks for a pair traded under a replaced key.

Full suite: 4,659 runs, 0 failures. Rubocop clean.
