### PR TITLE
Say the unit smaller than the figure

### DIFF
--- a/app/views/bots/orders/_order.html.erb
+++ b/app/views/bots/orders/_order.html.erb
@@ -11,12 +11,12 @@
   <%# How much was traded and what it cost — the two balances in a log row. The unit price below
       survives them: it is a fact about the market, and it is all this row has left to say. %>
   <% unless hide_balances?(order.bot) %>
-    <td><%= amount.nil? ? '-' : decimals[order.base].nil? ? amount : amount.round(decimals[order.base]) %> <%= order.base %></td>
-    <td><%= quote_amount.nil? ? '-' : decimals[order.quote].nil? ? quote_amount : quote_amount.round(decimals[order.quote]) %> <%= order.quote %></td>
+    <td><%= amount.nil? ? '-' : decimals[order.base].nil? ? amount : amount.round(decimals[order.base]) %> <small><%= order.base %></small></td>
+    <td><%= quote_amount.nil? ? '-' : decimals[order.quote].nil? ? quote_amount : quote_amount.round(decimals[order.quote]) %> <small><%= order.quote %></small></td>
   <% end %>
 
   <% unit_price = (amount && quote_amount && !amount.zero?) ? quote_amount / amount : nil %>
-  <td><% if unit_price.nil? %>-<% else %><%= decimals[order.quote].nil? ? unit_price : unit_price.round(decimals[order.quote]) %> <%= order.quote %><% end %></td>
+  <td><% if unit_price.nil? %>-<% else %><%= decimals[order.quote].nil? ? unit_price : unit_price.round(decimals[order.quote]) %> <small><%= order.quote %></small><% end %></td>
 
   <td>
     <% if order.open? %>

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -52,7 +52,7 @@
   </td>
   <% unless hide_money %>
     <td class="tracker-row__value"><%= tracker_amount(value) || '—' %></td>
-    <td class="tracker-row__fee"><%= at.fee_amount.present? ? "#{tracker_amount(at.fee_amount)} #{at.fee_currency}" : '—' %></td>
+    <td class="tracker-row__fee"><% if at.fee_amount.present? %><%= tracker_amount(at.fee_amount) %> <small><%= at.fee_currency %></small><% else %>—<% end %></td>
   <% end %>
   <td>
     <% if at.bot_transaction.present? %>

--- a/test/integration/bots/transaction_unit_price_test.rb
+++ b/test/integration/bots/transaction_unit_price_test.rb
@@ -23,7 +23,7 @@ class Bots::TransactionUnitPriceTest < ActionDispatch::IntegrationTest
     assert_response :ok
     # 27.000331 / 0.00694239 = ~3889.1505... rounded to 4 quote decimals
     expected = (27.000331.to_d / 0.00694239.to_d).round(4)
-    assert_match(/#{expected}\s+#{@bot.quote_asset.symbol}/, response.body)
+    assert_match(%r{#{expected}\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
   end
 
   test 'pending order renders unit price from configured amounts' do
@@ -34,7 +34,7 @@ class Bots::TransactionUnitPriceTest < ActionDispatch::IntegrationTest
     get bot_path(id: @bot.id, format: :turbo_stream), params: { decimals: decimals }
     assert_response :ok
     # 100 / 0.5 = 200.00
-    assert_match(/200\.0+\s+#{@bot.quote_asset.symbol}/, response.body)
+    assert_match(%r{200\.0+\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
   end
 
   test 'unfilled order with nil quote_amount falls back through price * amount' do
@@ -45,7 +45,7 @@ class Bots::TransactionUnitPriceTest < ActionDispatch::IntegrationTest
     get bot_path(id: @bot.id, format: :turbo_stream), params: { decimals: decimals }
     assert_response :ok
     # quote_amount derived as 200 * 0.5 = 100; unit price = 100 / 0.5 = 200
-    assert_match(/200\.0+\s+#{@bot.quote_asset.symbol}/, response.body)
+    assert_match(%r{200\.0+\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
   end
 
   test 'order with zero amount renders bare dash (no quote suffix), no ZeroDivisionError' do
@@ -54,7 +54,7 @@ class Bots::TransactionUnitPriceTest < ActionDispatch::IntegrationTest
     decimals = { @bot.base_asset.symbol => 8, @bot.quote_asset.symbol => 2 }
     get bot_path(id: @bot.id, format: :turbo_stream), params: { decimals: decimals }
     assert_response :ok
-    refute_match(/-\s+#{@bot.quote_asset.symbol}/, response.body,
+    refute_match(%r{-\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body,
                  'dash should not be followed by a quote-asset suffix when unit price is not computable')
   end
 


### PR DESCRIPTION
Currency tickers printed beside a figure in a table now render in `<small>`, so the number carries the cell and the unit sits under it.

Covers the four cells that print a ticker per row:

- bot order log — amount, value, unit price (`bots/orders/_order`)
- tracker transactions — fee (`tracker/_transaction_row`)

This is what the tracker already does in the value column's header and next to the price input; the rows now match.

Sentence-style rows (the timeline and activity summaries) and `Denomination#format` are unchanged — those print prose or a currency symbol (`$`, `€`, `zł`), not the `123.01 USDT` column form.
