### PR TITLE
Say the unit smaller than the figure everywhere it appears

### DIFF
--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -144,7 +144,7 @@ module TrackerHelper
     quantity = ->(units) { hidden && money?(note.symbol) ? '•••' : tracker_amount(units) }
     t("tracker.notes.#{note.kind}", symbol: note.symbol, exchange: note.exchange || t('tracker.notes.your_exchanges'),
                                     history: quantity.call(note.history), held: quantity.call(note.held),
-                                    amount: hidden ? '•••' : @denomination.format(note.amount_usd))
+                                    amount: hidden ? '•••' : @denomination.format_plain(note.amount_usd))
   end
 
   # Whose price a row carries, and what it is — [price, source]:
@@ -172,9 +172,9 @@ module TrackerHelper
     return [nil, nil] if amount.zero?
 
     if record.quoted?
-      ["#{tracker_amount(record.quote_amount.to_d / amount)} #{record.quote_currency}", :exchange]
+      [tracker_figure(record.quote_amount.to_d / amount, record.quote_currency), :exchange]
     elsif (cash = with_group(record).cash_counterpart)
-      ["#{tracker_amount(cash.base_amount.to_d / amount)} #{cash.base_currency}", :exchange]
+      [tracker_figure(cash.base_amount.to_d / amount, cash.base_currency), :exchange]
     elsif (stated = record.manual_value(:price))
       [denomination.convert(stated), :stated]
     else
@@ -227,6 +227,11 @@ module TrackerHelper
   # A signed percentage, one decimal — the reading on every P/L cell on the page.
   def tracker_percent(percent)
     "#{'+' if percent >= 0}#{number_with_precision(percent, precision: 1)}%"
+  end
+
+  # A figure and the unit it is in, the unit in <small>: the number is what the column is read for.
+  def tracker_figure(value, unit)
+    safe_join([tracker_amount(value), ' ', tag.small(unit)])
   end
 
   # A quantity or a price. Two decimals once it is worth more than a unit, eight below that, where

--- a/app/models/denomination.rb
+++ b/app/models/denomination.rb
@@ -65,14 +65,28 @@ class Denomination
 
   # nil in, nil out: callers hand this whatever they have, including the "rate not cached
   # yet" nil that renders as no amount at all.
+  #
+  # The unit rides in <small>, as it does beside a ticker in the tables: the figure is what the
+  # column is read for, the symbol only says which unit it is in.
   def format(usd_amount, precision: 2)
+    formatted(usd_amount, ActionController::Base.helpers.tag.small(unit), precision)&.html_safe
+  end
+
+  # The same figure with no markup, for somewhere it is not drawn — an aria-label, a sentence —
+  # where a tag is spelled out instead of rendered.
+  def format_plain(usd_amount, precision: 2)
+    formatted(usd_amount, unit, precision)
+  end
+
+  private
+
+  def formatted(usd_amount, unit, precision)
     return if usd_amount.nil?
 
     layout = SUFFIXED.include?(currency) ? '%n %u' : '%u%n'
     ActiveSupport::NumberHelper.number_to_currency(
-      convert(usd_amount),
-      unit: UNITS.fetch(currency, currency), format: layout,
-      negative_format: "-#{layout}", precision: precision
+      convert(usd_amount), unit: unit, format: layout,
+                           negative_format: "-#{layout}", precision: precision
     )
   end
 end

--- a/app/views/tracker/_tiles.html.erb
+++ b/app/views/tracker/_tiles.html.erb
@@ -11,7 +11,7 @@
   <% figures = @figures %>
   <%# The value is known from the balances alone; everything the history decides waits for it. %>
   <% warming = figures&.ledger.nil? %>
-  <% signed = ->(amount) { "#{'+' unless amount.negative?}#{@denomination.format(amount)}" } %>
+  <% signed = ->(amount) { safe_join([('+' unless amount.negative?), @denomination.format(amount)]) } %>
   <% tone = ->(amount) { amount.negative? ? 'text-danger' : 'text-success' } %>
   <% money = ->(amount) { amount ? signed.call(amount) : '—' } %>
   <%# `--six` keeps the widest step at three columns below the point where all six fit on one row. %>
@@ -23,7 +23,7 @@
     <%= render partial: 'bots/metrics_item', locals: {
       label: t('bot.details.stats.total_invested'),
       value: figures&.invested && @denomination.format(figures.invested),
-      hint: (t('tracker.tiles.received_hint', received: @denomination.format(received)) if received&.positive?),
+      hint: (t('tracker.tiles.received_hint', received: @denomination.format_plain(received)) if received&.positive?),
       loading: warming
     } %>
     <%= render partial: 'bots/metrics_item', locals: {

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -37,7 +37,7 @@
     <% if source == :exchange %>
       <%= price %>
     <% elsif source == :cash %>
-      <%= price ? "#{tracker_amount(price)} #{denomination.currency}" : '—' %>
+      <%= price ? tracker_figure(price, denomination.currency) : '—' %>
     <% else %>
       <%= form_with url: price_tracker_transaction_path(at), method: :patch,
                     data: { controller: 'form--submit' } do %>
@@ -62,7 +62,7 @@
   </td>
   <% unless hide_money %>
     <td class="tracker-row__value"><%= tracker_amount(value) || '—' %></td>
-    <td class="tracker-row__fee"><% if at.fee_amount.present? %><%= tracker_amount(at.fee_amount) %> <small><%= at.fee_currency %></small><% else %>—<% end %></td>
+    <td class="tracker-row__fee"><%= at.fee_amount.present? ? tracker_figure(at.fee_amount, at.fee_currency) : '—' %></td>
   <% end %>
   <td>
     <% if at.bot_transaction.present? %>

--- a/test/integration/tracker_manual_value_test.rb
+++ b/test/integration/tracker_manual_value_test.rb
@@ -50,6 +50,7 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     assert_includes cell['class'], 'tracker-row__price--exchange'
     assert_empty cell.css('input'), 'nothing here for a user to state'
     assert_equal '20,000.00 USD', cell.text.strip
+    assert_equal 'USD', cell.css('small').text, 'the unit is the small half of the figure'
     assert_equal '20,000.00', value_cell(bought).text.strip
   end
 

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -381,5 +381,9 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
 
     assert_select '.data-grid__item__value', text: /320,000\.00 zł/
     assert_select '.tracker-holdings__value', text: /240,000\.00 zł/
+    # The unit is the small half of the figure, and it has to reach the page as a tag rather than
+    # as the four characters "<small>".
+    assert_select '.tracker-holdings__value small', text: 'zł'
+    assert_no_match(/&lt;small&gt;/, response.body)
   end
 end

--- a/test/models/bot/broadcast_pnl_format_test.rb
+++ b/test/models/bot/broadcast_pnl_format_test.rb
@@ -31,7 +31,7 @@ class Bot::BroadcastPnlFormatTest < ActiveSupport::TestCase
     assert_includes html, 'pnl-percent'
     assert_includes html, 'pnl-amount'
     assert_includes html, '25.00%'
-    assert_includes html, '+$25.00'
+    assert_includes html, '+<small>$</small>25.00'
   end
 
   # Unlike the index, this runs in a background job — it may fetch a rate rather than
@@ -41,7 +41,7 @@ class Bot::BroadcastPnlFormatTest < ActiveSupport::TestCase
     Utilities::Currency.expects(:exchange_rate).with(from: 'EUR', to: 'USD', cache_only: false)
                        .returns(Result::Success.new(1.1))
 
-    assert_includes tile_html, '+$27.50'
+    assert_includes tile_html, '+<small>$</small>27.50'
   end
 
   # The broadcast renders outside a request, so it cannot read the account's currency off
@@ -53,6 +53,6 @@ class Bot::BroadcastPnlFormatTest < ActiveSupport::TestCase
     Utilities::Currency.stubs(:exchange_rate).with(from: 'USD', to: 'PLN')
                        .returns(Result::Success.new(4.0))
 
-    assert_includes tile_html, '+100.00 zł'
+    assert_includes tile_html, '+100.00 <small>zł</small>'
   end
 end

--- a/test/models/denomination_test.rb
+++ b/test/models/denomination_test.rb
@@ -12,7 +12,7 @@ class DenominationTest < ActiveSupport::TestCase
     denomination = Denomination.for('USD')
 
     assert_equal 'USD', denomination.currency
-    assert_equal '$25.00', denomination.format(25)
+    assert_equal '<small>$</small>25.00', denomination.format(25)
   end
 
   test 'no preference at all is USD' do
@@ -24,22 +24,22 @@ class DenominationTest < ActiveSupport::TestCase
   test 'another currency converts at its USD rate' do
     stub_rate('PLN', 3.8)
 
-    assert_equal '95.00 zł', Denomination.for('PLN').format(25)
+    assert_equal '95.00 <small>zł</small>', Denomination.for('PLN').format(25)
   end
 
   test 'the symbol trails the amount where the currency is written that way' do
     stub_rate('CHF', 0.8)
     stub_rate('EUR', 0.9)
 
-    assert_equal '20.00 CHF', Denomination.for('CHF').format(25)
-    assert_equal '€22.50', Denomination.for('EUR').format(25)
+    assert_equal '20.00 <small>CHF</small>', Denomination.for('CHF').format(25)
+    assert_equal '<small>€</small>22.50', Denomination.for('EUR').format(25)
   end
 
   test 'a loss keeps its minus sign in either layout' do
     stub_rate('PLN', 4)
 
-    assert_equal '-40.00 zł', Denomination.for('PLN').format(-10)
-    assert_equal '-$10.00', Denomination.for('USD').format(-10)
+    assert_equal '-40.00 <small>zł</small>', Denomination.for('PLN').format(-10)
+    assert_equal '-<small>$</small>10.00', Denomination.for('USD').format(-10)
   end
 
   # A złoty sign on a dollar figure would be a lie, and the dollar figure is the one we have.
@@ -50,12 +50,26 @@ class DenominationTest < ActiveSupport::TestCase
     denomination = Denomination.for('PLN')
 
     assert_equal 'USD', denomination.currency
-    assert_equal '$25.00', denomination.format(25)
+    assert_equal '<small>$</small>25.00', denomination.format(25)
   end
 
   # The callers hand it whatever they have, including the "rate not cached yet" nil.
   test 'no figure formats to nothing' do
     assert_nil Denomination.for('USD').format(nil)
+    assert_nil Denomination.for('USD').format_plain(nil)
+  end
+
+  # The tag has to survive ERB, or every tile on the page shows the markup as words.
+  test 'the figure is rendered, not escaped' do
+    assert_predicate Denomination.for('USD').format(25), :html_safe?
+  end
+
+  # A label and a sentence are read, not drawn: a tag there is spelled out.
+  test 'the plain form carries no markup' do
+    stub_rate('PLN', 3.8)
+
+    assert_equal '$25.00', Denomination.for('USD').format_plain(25)
+    assert_equal '95.00 zł', Denomination.for('PLN').format_plain(25)
   end
 
   # Utilities::Currency caches answers, never failures, so without a backoff of its own every


### PR DESCRIPTION
Follow-up to #263, which put the ticker in `<small>` in the bot log and the tracker's fee column. The currency symbol beside a converted figure was still full size, and so were the two prices a helper builds as a string.

`Denomination#format` now wraps the unit and returns an HTML-safe string, so one change covers every figure it renders:

- tracker tiles — invested, value, fees, realised and unrealised P/L
- holdings values and the positions table (invested, average buy, price, cash)
- the global P/L headline and each bot tile's P/L

Two callers hand that figure to an `aria-label` instead of drawing it — the tile hint and the holdings note — where a tag is read out rather than rendered. They use the new `format_plain`.

`tracker_figure(value, unit)` joins an amount to a `<small>` unit. The venue's own price was assembled as `"600.00 USDC"` inside `tracker_row_price`, so no view could wrap it; that price, the cash price and the fee now share the helper.

Tests: `Denomination` asserts the markup and that it survives ERB unescaped; the tracker page asserts a real `<small>` element and that no escaped tag reaches the body; the price cell asserts its unit is the small half of the figure.
