### PR TITLE
Give the unit in a table the quiet colour

### DIFF
--- a/app/assets/stylesheets/_styles.sass
+++ b/app/assets/stylesheets/_styles.sass
@@ -14,6 +14,8 @@
   font-size: 1.75rem
   thead
     color: var(--stone)
+  small
+    color: var(--stone)
 .pagination
   flex-direction: row
   gap: 0


### PR DESCRIPTION
Follow-up to #266: the unit now sits in `<small>`, and this gives it the quiet colour the table headers already use, so the figure keeps the eye and the currency stays behind it.

One rule, `.table small`, so every unit in every table picks it up — tickers in the bot log and the ledger, symbols on the converted figures.
