### PR TITLE
Key a cached ledger by its shape, clear finished jobs, fill the Normalize button

### DIFF
--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -27,18 +27,20 @@
     justify-content: center
     align-items: center
     text-decoration: none
-    &--danger
+    // The filled variants: a colour carries the meaning, so the label is white on all of them and
+    // stays white on hover — the default's link colour would read as unfilled halfway through.
+    &--primary, &--danger, &--success
         color: #fff
-        background: var(--berry)
         &:hover
             color: #fff
+    &--primary
+        background: var(--sky)
+    &--danger
+        background: var(--berry)
     // The affirmative half of a two-answer prompt. Paired with --danger rather than with the
     // default: side by side, one styled and one not reads as a disabled button next to a live one.
     &--success
-        color: #fff
         background: var(--grass)
-        &:hover
-            color: #fff
     // Square, for a button whose whole label is its glyph.
     &--icon
         padding: 0 1rem

--- a/app/models/tracker/ledger.rb
+++ b/app/models/tracker/ledger.rb
@@ -198,6 +198,12 @@ module Tracker
       # balances happens at render time).
       def cached(user, exchange: nil)
         Rails.cache.read(cache_key(user, exchange))
+      rescue TypeError
+        # Belt to the braces of the shape-derived key: a shape the key cannot see — a Data nested
+        # deeper, an Asset whose columns moved — reads as a COLD cache rather than raising, and the
+        # caller warms it. Restores what the rest of this file already assumes: an unusable cache
+        # entry is worth nothing, not worth a 500 on /tracker and in the nightly snapshot.
+        nil
       end
 
       def compute!(user, exchange: nil)
@@ -261,8 +267,28 @@ module Tracker
       # again — which for a position they have closed is never.
       def cache_key(user, exchange)
         scope = transactions(user, exchange)
-        "tracker_ledger_v7_#{user.id}_#{exchange&.id || 'all'}_" \
+        "tracker_ledger_v8_#{shape}_#{user.id}_#{exchange&.id || 'all'}_" \
           "#{scope.maximum(:updated_at)&.utc&.iso8601(6)}_#{scope.count}_#{HistoricalPrice.generation}"
+      end
+
+      # The payload's SHAPE, beside the hand-bumped version rather than instead of it — the two
+      # answer different questions and only one of them can be automated.
+      #
+      # `v8` still means "the FIGURES changed": a calculation the members cannot see (v2 and v3 were
+      # both bumped for exactly that). Forgetting it serves a stale number until the transactions
+      # move — visible, and self-limiting.
+      #
+      # `shape` means "the PAYLOAD changed", and forgetting that is neither. What is cached is a
+      # Marshal'd Data, so its member list is part of the payload: add a member and every entry the
+      # previous build wrote becomes unreadable — Marshal raises TypeError, which Rails does NOT
+      # degrade to nil the way it degrades an ArgumentError payload. One release carrying two member
+      # lists under one version is enough to leave both in the cache at once, and a read of the
+      # older one raises through this class rather than missing. That half needs no memory now.
+      #
+      # Read off the live constants rather than frozen into one, so the digest cannot be stale.
+      # Recomputed per call, next to two SQL aggregates in the same method — the hash is free.
+      def shape
+        Digest::SHA256.hexdigest([Summary, Position, RoundTrip].map(&:members).join(','))[0, 8]
       end
 
       def transactions(user, exchange)

--- a/app/views/bots/dca_multi_assets/settings/_main.html.erb
+++ b/app/views/bots/dca_multi_assets/settings/_main.html.erb
@@ -87,7 +87,7 @@
     <% unless composition_locked %>
       <%= button_tag t('bot.dca_multi_asset.normalize'), type: :submit,
                      name: 'bots_dca_multi_asset[normalize_allocations]', value: '1',
-                     class: 'rbutton rbutton--small asset-allocations__normalize',
+                     class: 'rbutton rbutton--small rbutton--primary asset-allocations__normalize',
                      hidden: allocations_balanced %>
     <% end %>
   </div>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -80,6 +80,23 @@ production:
     class: Ibkr::CheckActivationJob
     schedule: "17 */6 * * *"  # Every 6 hours — flips IBKR keys to :correct once IBKR activates them
 
+  # Solid Queue keeps finished jobs forever by default (SolidQueue.preserve_finished_jobs) and
+  # leaves the clearing to the host — its own generator ships this task, and this app never had it.
+  # Nothing here ages out on its own: the self-rescheduling limit-check chains enqueue one job per
+  # minute per waiting bot, so an instance left running accumulates millions of finished rows and a
+  # queue database of several GB, none of it readable by anything. Clearing them is safe —
+  # Automation::Schedulable#active_job? only joins the four LIVE execution tables — so the day of
+  # history SolidQueue.clear_finished_jobs_after keeps, which is what /jobs shows, is all we need.
+  #
+  # `queue:` is required, not decoration: a `command:` task runs as SolidQueue::RecurringJob, whose
+  # own queue is `solid_queue_recurring`, and the workers below name their queues explicitly with no
+  # wildcard — so without this the cleanup would queue up unclaimed forever, adding to the very
+  # backlog it exists to remove.
+  clear_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    queue: low_priority
+    schedule: "40 * * * *"  # Hourly at :40, clear of the other ticks
+
 development:
   sync_all_tickers_and_assets_job:
     class: Exchange::SyncAllTickersAndAssetsJob

--- a/test/models/tracker/ledger_cache_shape_test.rb
+++ b/test/models/tracker/ledger_cache_shape_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+# A cached Summary is a Marshal'd Data, so its MEMBER LIST is part of the payload. Add a member and
+# every entry the previous build wrote becomes unreadable: Marshal raises TypeError, and Rails
+# degrades only ArgumentError payloads to nil (Cache::Store#deserialize_entry rescues
+# DeserializationError, which SerializerWithFallback raises for ArgumentError alone). So the key has
+# to follow the shape on its own, and a read that lands on a shape it cannot parse has to come back
+# cold rather than raise into the request that asked for it.
+class Tracker::LedgerCacheShapeTest < ActiveSupport::TestCase
+  setup do
+    Tax::EcbFxRates.stubs(:ensure_loaded!)
+    @user = create(:user)
+    # The test env is :null_store; MemoryStore round-trips through Marshal, so a shape mismatch
+    # fails here exactly as it does in production.
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  test 'the cache key moves when the summary gains a member' do
+    before = Tracker::Ledger.send(:cache_key, @user, nil)
+
+    with_summary_shape(Tracker::Ledger::Summary.members + [:extra]) do
+      assert_not_equal before, Tracker::Ledger.send(:cache_key, @user, nil)
+    end
+  end
+
+  test 'the cache key moves when a nested position gains a member' do
+    before = Tracker::Ledger.send(:cache_key, @user, nil)
+
+    with_shape(:Position, Tracker::Ledger::Position.members + [:extra]) do
+      assert_not_equal before, Tracker::Ledger.send(:cache_key, @user, nil)
+    end
+  end
+
+  test 'the cache key is stable across processes for one shape' do
+    assert_equal Tracker::Ledger.send(:cache_key, @user, nil), Tracker::Ledger.send(:cache_key, @user, nil)
+    assert_match(/\Atracker_ledger_v\d+_[0-9a-f]{8}_/, Tracker::Ledger.send(:cache_key, @user, nil))
+  end
+
+  test 'an entry written under an older shape reads as nil, not a raise' do
+    key = Tracker::Ledger.send(:cache_key, @user, nil)
+    with_summary_shape(%i[positions]) { Rails.cache.write(key, Tracker::Ledger::Summary.new(positions: [])) }
+
+    assert_nil Tracker::Ledger.cached(@user)
+  end
+
+  private
+
+  def with_summary_shape(members, &)
+    with_shape(:Summary, members, &)
+  end
+
+  def with_shape(name, members)
+    original = Tracker::Ledger.const_get(name)
+    Tracker::Ledger.send(:remove_const, name)
+    Tracker::Ledger.const_set(name, Data.define(*members))
+    yield
+  ensure
+    Tracker::Ledger.send(:remove_const, name)
+    Tracker::Ledger.const_set(name, original)
+  end
+end


### PR DESCRIPTION
Three unrelated fixes.

## A cached ledger could raise instead of miss

`Tracker::Ledger::Summary` is cached as a Marshal'd `Data`, so its member list is part of the payload. When a release adds a member, every entry the previous build wrote becomes unreadable — and Marshal signals that with a `TypeError`, which Rails does not degrade to `nil` the way it degrades an `ArgumentError` payload. The read raises into whatever asked for it: the tracker page, and the job that builds the day's snapshot row. The entry stays poisoned until the transactions move or the 30-day TTL runs out.

The key carried a hand-bumped version, which only holds while someone remembers to bump it — and the two things a bump can mean are not equally forgiving:

- **the figures changed** — a calculation the member list cannot see. Forgetting serves a stale number until the transactions move. Visible, and self-limiting.
- **the payload changed** — forgetting raises on every read of that key.

The version keeps the first job. A short digest of the live member lists (`Summary`, `Position`, `RoundTrip`) takes the second, where no memory is involved. It is read off the constants rather than frozen into one, so it cannot go stale, and it costs a hash next to two SQL aggregates already in the same method.

`Tracker::Ledger.cached` now also treats a payload it cannot parse as a cold cache rather than an exception — what the rest of the class already assumes an unusable entry is worth. A shape the key cannot see (a `Data` nested deeper, a record whose columns moved) comes back `nil` and the caller warms it.

## Finished jobs were never cleared

Solid Queue preserves finished jobs by default and leaves the clearing to the host; its own installer ships a recurring task for it, and this app never had one. Nothing here ages out on its own, and the self-rescheduling limit checks enqueue a job per minute per waiting bot, so the queue database grows without bound.

Clearing them is safe: the only reader of the job tables, `Automation::Schedulable#active_job?`, joins the four live execution tables and never the finished ones. The day of history `SolidQueue.clear_finished_jobs_after` keeps is what `/jobs` shows.

The queue assignment is load-bearing rather than decoration. A `command:` task runs as `SolidQueue::RecurringJob`, whose own queue is `solid_queue_recurring`, and the workers in `config/queue.yml` name their queues explicitly with no wildcard — left alone, the cleanup would queue up unclaimed and add to the backlog it exists to remove.

## The Normalize button read as inert

Normalize is the action a multi-asset bot's allocation row asks for once the weights drift off 100%, and it was the only unstyled button in a form full of styled ones. It becomes a filled `--primary`, joining `--danger` and `--success`; the three now share one rule for the white label, since a colour block wearing the default link colour reads as half-styled, and only the fill differs.
