### PR TITLE
Say the quiet parts quietly in every table

### DIFF
--- a/app/assets/stylesheets/_styles.sass
+++ b/app/assets/stylesheets/_styles.sass
@@ -16,6 +16,20 @@
     color: var(--stone)
   small
     color: var(--stone)
+// When a row happened is how the row is found, not what it says. It sits back in the caption
+// colour — and so does the time beside it, which `.table small` would otherwise leave darker than
+// the date it belongs to. Two classes deep so it also outranks `.tracker-row__when small`, which
+// is imported after this file.
+.table .table__when
+  color: var(--concrete)
+  white-space: nowrap
+  small
+    color: inherit
+    margin-left: 0.75rem
+// A dash stands where a value would be. Dimmed, so a row with nothing to say never reads as
+// loudly as the rows that do.
+.no-value
+  color: var(--concrete)
 .pagination
   flex-direction: row
   gap: 0

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -49,6 +49,9 @@
 .tracker-holdings__more
     display: flex
     flex-direction: column
+    // `auto` is not a length, so a plain height transition to it does nothing — allow-keywords is
+    // what turns the pseudo's 0 → auto into a real interpolation, and it inherits down to it.
+    interpolate-size: allow-keywords
     summary
         cursor: pointer
         text-align: center
@@ -56,6 +59,19 @@
         order: 0
     &[open] > summary
         order: 1
+    // The folded rows sit in this pseudo, which is a flex item of the default order 0 — so the
+    // summary's order: 1 still carries the toggle below them once open.
+    &::details-content
+        block-size: 0
+        overflow: hidden
+        // content-visibility is discrete and hidden while closed: without allow-discrete it flips
+        // at frame one and the fold-up plays against an already-empty box.
+        transition: block-size 0.15s ease, content-visibility 0.15s allow-discrete
+        // The reset's reduced-motion rule is universal-selector only, and `*` never matches a pseudo.
+        @media (prefers-reduced-motion: reduce)
+            transition: none
+    &[open]::details-content
+        block-size: auto
     &__close
         display: none
     &[open]
@@ -94,6 +110,7 @@
         font-size: 1.1rem
         font-weight: 800
         text-indent: 0
+        line-height: 1
 
 // ── the holdings card ─────────────────────────────────────────────────────────────────────
 .tracker-holdings

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,29 @@ module ApplicationHelper
     EXCHANGE_SVGS[exchange_name_id]
   end
 
+  # The dash a cell shows when there is nothing to show. It is the absence of a figure, not a
+  # figure, so it never carries the ink of the numbers beside it — one helper so every table
+  # reads the same, and so the colour is decided once.
+  def no_value
+    tag.span('—', class: 'no-value')
+  end
+
+  # One date shape for every table on the app: year first, in the reader's own zone. A reader
+  # moving between the bot log and the tracker is not re-learning the format on the way.
+  #
+  # The zone is passed in rather than read off `current_user`: these rows are also rendered from a
+  # model broadcast, where there is no request and the user arrives as a partial LOCAL — which a
+  # helper method cannot see. Making it an argument is what keeps one formatter for both paths.
+  def table_date(time, zone)
+    time.in_time_zone(zone).strftime('%Y/%m/%d')
+  end
+
+  # When a row happened: the date, with the clock time behind it in <small>. The date is what a
+  # row is found by and the time is the detail, so they are not set at the same weight.
+  def table_when(time, zone)
+    safe_join([table_date(time, zone), ' ', tag.small(time.in_time_zone(zone).strftime('%H:%M'))])
+  end
+
   def ticker_class(asset)
     ticker_class_for(category: asset&.category, color: asset&.color)
   end

--- a/app/helpers/bot_helper.rb
+++ b/app/helpers/bot_helper.rb
@@ -152,8 +152,8 @@ module BotHelper
     return t('bot_activity.transactions.cancelled') if order.cancelled? || order.abandoned?
 
     pending = order.open? || order.unknown?
-    base_amount = round_amount(display_amount(order.amount_exec, order.amount, pending:), decimals[order.base])
-    quote_amount = round_amount(display_amount(order.quote_amount_exec, order.quote_amount, pending:), decimals[order.quote])
+    base_amount = round_amount(display_amount(order.amount_exec, order.amount, pending:), decimals[order.base], order.base)
+    quote_amount = round_amount(display_amount(order.quote_amount_exec, order.quote_amount, pending:), decimals[order.quote], order.quote)
     key = if order.sell?
             pending ? 'open_sell' : 'sold'
           else
@@ -336,8 +336,14 @@ module BotHelper
 
   private
 
-  def round_amount(value, decimals)
-    return value if value.nil? || decimals.nil?
+  # Money is written to the cent, whatever precision the venue happens to publish for the pair: a
+  # column of dollars is read by comparing the figures in it, and 10.0 beside 9.99 beside 0.001407
+  # cannot be. Anything else keeps the venue's decimals, where the difference between eight places
+  # and two is the difference between a quantity and nothing at all.
+  def round_amount(value, decimals, currency = nil)
+    return value if value.nil?
+    return number_with_precision(value, precision: 2) if Tax::PriceService.money?(currency)
+    return value if decimals.nil?
 
     value.round(decimals)
   end
@@ -346,8 +352,8 @@ module BotHelper
   # failed); otherwise (e.g. a price-fetch failure) fall back to a plain message.
   def transaction_failed_summary(order, decimals)
     error = order.error_messages.to_sentence
-    base_amount = round_amount(order.amount, decimals[order.base])
-    quote_amount = round_amount(order.quote_amount, decimals[order.quote])
+    base_amount = round_amount(order.amount, decimals[order.base], order.base)
+    quote_amount = round_amount(order.quote_amount, decimals[order.quote], order.quote)
 
     # Failed rows are the one kind of sentence the Other tab still shows while balances are
     # hidden, and the attempted amounts are the only money in them — dropping them leaves the
@@ -372,7 +378,7 @@ module BotHelper
   def format_activity_time(value)
     return value if value.blank?
 
-    Time.iso8601(value.to_s).in_time_zone(current_user.time_zone).strftime('%Y-%m-%d %I:%M %p')
+    Time.iso8601(value.to_s).in_time_zone(current_user.time_zone).strftime('%Y/%m/%d %H:%M')
   rescue ArgumentError
     value
   end

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -141,7 +141,7 @@ module TrackerHelper
   def tracker_note(note)
     hidden = current_user.hide_balances?
     # A cash note's quantities are money too.
-    quantity = ->(units) { hidden && money?(note.symbol) ? '•••' : tracker_amount(units) }
+    quantity = ->(units) { hidden && Tax::PriceService.money?(note.symbol) ? '•••' : tracker_amount(units) }
     t("tracker.notes.#{note.kind}", symbol: note.symbol, exchange: note.exchange || t('tracker.notes.your_exchanges'),
                                     history: quantity.call(note.history), held: quantity.call(note.held),
                                     amount: hidden ? '•••' : @denomination.format_plain(note.amount_usd))
@@ -166,7 +166,7 @@ module TrackerHelper
   # Over the row's SIZE: a split is one signed net delta, and a reverse split has a price like any
   # other row — the sign belongs to the amount, and Value carries it. Only a row of nothing has none.
   def tracker_row_price(record, denomination)
-    return [in_display(1.to_d, record.base_currency, record, denomination), :cash] if money?(record.base_currency)
+    return [in_display(1.to_d, record.base_currency, record, denomination), :cash] if Tax::PriceService.money?(record.base_currency)
 
     amount = record.base_amount.to_d.abs
     return [nil, nil] if amount.zero?
@@ -354,12 +354,6 @@ module TrackerHelper
         nil
       end
     end
-  end
-
-  def money?(currency)
-    currency.present? &&
-      (Tax::PriceService::FIAT_CURRENCIES.include?(currency) ||
-       Tax::PriceService::STABLECOINS.include?(currency))
   end
 
   # [value, cost] over every holding whose quantity the ledger can vouch for. Cash and anything

--- a/app/javascript/controllers/tracker/record_controller.js
+++ b/app/javascript/controllers/tracker/record_controller.js
@@ -8,9 +8,63 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["pane"];
 
+  // The padding is a transient hold, not page state — but Turbo snapshots the DOM BEFORE the
+  // controller disconnects, so without this a restored Back page comes back carrying the blank
+  // tail and none of the scroll listener that was supposed to eat it.
+  connect() {
+    this.uncache = () => this.#release();
+    document.addEventListener("turbo:before-cache", this.uncache);
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-cache", this.uncache);
+    this.#release();
+  }
+
   show(event) {
     this.paneTargets.forEach((pane) => {
       pane.classList.toggle("tracker-record__pane--off", pane.dataset.pane !== event.detail.value);
     });
+  }
+
+  // A filter that drops most of the rows yanks the page up under the reader: the browser clamps
+  // scroll to the shorter document the moment layout is flushed, and that clamp IS the jump.
+  //
+  // Reading the offset is itself a layout flush, so it cannot be done after the rows are hidden —
+  // it would return the already-clamped value, the slack below would come out zero, and the jump
+  // this exists to stop would happen anyway. Hence two halves, wired either side of the filter.
+  mark() {
+    this.top = window.scrollY;
+  }
+
+  // Pad the block back to the height it had, so the table's header stays where it was on screen.
+  hold() {
+    const y = this.top ?? window.scrollY;
+    this.#release();
+    const slack = y + window.innerHeight - document.documentElement.scrollHeight;
+    if (slack <= 0) return; // page grew, or never scrolled past the fold
+
+    this.element.style.paddingBottom = `${slack}px`;
+    // `behavior: instant` because the page sets `scroll-behavior: smooth` globally: an animated
+    // restore would still be travelling when the listener below starts trimming, and the trim
+    // would settle on the offset it was passing through rather than the one being restored.
+    if (window.scrollY !== y) window.scrollTo({ top: y, left: window.scrollX, behavior: "instant" });
+    window.addEventListener("scroll", this.#shrink, { passive: true });
+  }
+
+  // The void is only ever eaten, never handed back — growing it would let a reader scrolling DOWN
+  // extend it forever.
+  #shrink = () => {
+    const pad = parseFloat(this.element.style.paddingBottom) || 0;
+    const floor = document.documentElement.scrollHeight - pad;
+    const needed = Math.max(0, window.scrollY + window.innerHeight - floor);
+    if (needed >= pad) return;
+    if (needed) this.element.style.paddingBottom = `${needed}px`;
+    else this.#release();
+  };
+
+  #release() {
+    this.element.style.paddingBottom = "";
+    window.removeEventListener("scroll", this.#shrink);
   }
 }

--- a/app/models/tax/price_service.rb
+++ b/app/models/tax/price_service.rb
@@ -15,6 +15,12 @@ module Tax
     OUT_LEGS = %w[sell swap_out].freeze
     private_constant :TRADE_TYPES, :IN_LEGS, :OUT_LEGS
 
+    # Money, as against a position: anything settled in a national currency or a coin pegged to
+    # one. The reading and the tax engine both ask this, so they cannot drift apart on the answer.
+    def self.money?(currency)
+      currency.present? && (FIAT_CURRENCIES.include?(currency) || STABLECOINS.include?(currency))
+    end
+
     # The order every reader of the ledger walks it in. A swap's two legs share an instant, and the
     # venue decides which is stored first: the out-leg has to be seen first or its basis has nothing
     # to travel into. So a group sits where its first-stored leg was, out-legs ahead of in-legs

--- a/app/views/bots/_assets_table.html.erb
+++ b/app/views/bots/_assets_table.html.erb
@@ -30,13 +30,13 @@
         <td class="table__logo"><%= render 'assets/logo', image_url: row[:asset]&.image_url, color: row[:asset]&.color %></td>
         <td scope="row"><%= row[:symbol] %></td>
         <% unless hide_money %><td><%= row[:amount] %></td><% end %>
-        <td><%= row[:avg_price] || '-' %></td>
+        <td><%= row[:avg_price] || no_value %></td>
         <% unless hide_money %>
           <td>
             <% if loading %>
               <div class="loader--small" style="position: unset; float:right"></div>
             <% else %>
-              <%= row[:value] || '-' %>
+              <%= row[:value] || no_value %>
             <% end %>
           </td>
         <% end %>
@@ -46,7 +46,7 @@
           <% elsif pnl %>
             <b><%= pnl.negative? ? '' : '+' %><%= format_percent(pnl, precision: 1) %></b>
           <% else %>
-            -
+            <%= no_value %>
           <% end %>
         </td>
         <% if actions %><td class="table__action"><%= row[:action] %></td><% end %>

--- a/app/views/bots/orders/_activity.html.erb
+++ b/app/views/bots/orders/_activity.html.erb
@@ -5,6 +5,6 @@
     their own, so nothing here is dropped. %>
 <% hidden = hide_balances?(activity.bot) %>
 <%= tag.tr id: dom_id(activity), class: "text-inactive", data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: hidden ? "other" : "all" } do %>
-  <td scope="row"><%= activity.created_at.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></td>
+  <td scope="row" class="table__when"><%= table_when(activity.created_at, current_user.time_zone) %></td>
   <td colspan="<%= hidden ? 1 : 3 %>" style="text-align: left;"><%= bot_activity_summary(activity) %></td>
 <% end %>

--- a/app/views/bots/orders/_order.html.erb
+++ b/app/views/bots/orders/_order.html.erb
@@ -1,5 +1,5 @@
 <%= tag.tr id: dom_id(order), class: order.failed? ? 'text-danger' : (inactive_order_row?(order) ? 'text-inactive' : ''), data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: order_filter_type(order) } do %>
-  <td scope="row"><%= order.created_at.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></td>
+  <td scope="row" class="table__when"><%= table_when(order.created_at, current_user.time_zone) %></td>
 
   <% show_executed_amounts = order.submitted? && order.closed? %>
   <% executed_amount = order.amount_exec || order.amount %>
@@ -11,12 +11,12 @@
   <%# How much was traded and what it cost — the two balances in a log row. The unit price below
       survives them: it is a fact about the market, and it is all this row has left to say. %>
   <% unless hide_balances?(order.bot) %>
-    <td><%= amount.nil? ? '-' : decimals[order.base].nil? ? amount : amount.round(decimals[order.base]) %> <small><%= order.base %></small></td>
-    <td><%= quote_amount.nil? ? '-' : decimals[order.quote].nil? ? quote_amount : quote_amount.round(decimals[order.quote]) %> <small><%= order.quote %></small></td>
+    <td><%= amount.nil? ? no_value : round_amount(amount, decimals[order.base], order.base) %> <small><%= order.base %></small></td>
+    <td><%= quote_amount.nil? ? no_value : round_amount(quote_amount, decimals[order.quote], order.quote) %> <small><%= order.quote %></small></td>
   <% end %>
 
   <% unit_price = (amount && quote_amount && !amount.zero?) ? quote_amount / amount : nil %>
-  <td><% if unit_price.nil? %>-<% else %><%= decimals[order.quote].nil? ? unit_price : unit_price.round(decimals[order.quote]) %> <small><%= order.quote %></small><% end %></td>
+  <td><% if unit_price.nil? %><%= no_value %><% else %><%= round_amount(unit_price, decimals[order.quote], order.quote) %> <small><%= order.quote %></small><% end %></td>
 
   <td>
     <% if order.open? %>

--- a/app/views/bots/orders/_order_timeline.html.erb
+++ b/app/views/bots/orders/_order_timeline.html.erb
@@ -16,7 +16,7 @@
 <% else %>
   <% row_class = order.failed? ? 'text-danger' : (inactive_order_row?(order) ? 'text-inactive' : '') %>
   <%= tag.tr id: dom_id(order, :timeline), class: row_class, data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: hidden ? "other" : (order.other? ? "all other" : "all") } do %>
-    <td scope="row"><%= order.created_at.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></td>
+    <td scope="row" class="table__when"><%= table_when(order.created_at, current_user.time_zone) %></td>
     <td colspan="<%= hidden ? 1 : 3 %>" style="text-align: left;"><%= transaction_summary(order, decimals) %></td>
     <td>
       <% if order.open? %>

--- a/app/views/tracker/_holding_row.html.erb
+++ b/app/views/tracker/_holding_row.html.erb
@@ -30,7 +30,7 @@
   <% if pnl %>
     <span class="tracker-holdings__pl <%= pnl.negative? ? 'text-danger' : 'text-success' %>"><%= tracker_percent(pnl) %></span>
   <% else %>
-    <span class="tracker-holdings__pl" title="<%= t('tracker.basis_incomplete') %>">—</span>
+    <span class="tracker-holdings__pl" title="<%= t('tracker.basis_incomplete') %>"><%= no_value %></span>
   <% end %>
   <%# Always rendered, so the grid keeps its column; empty on a row with nothing to say. %>
   <% if note %>

--- a/app/views/tracker/_positions_row.html.erb
+++ b/app/views/tracker/_positions_row.html.erb
@@ -1,9 +1,8 @@
 <% type = row[:asset] && holding_type_label(row[:asset]) %>
-<% zone = ->(time) { time.in_time_zone(current_user.time_zone).strftime('%Y/%m/%d') } %>
 <tr class="tracker-row" data-order-filter-target="row" data-order-type="all <%= row[:status] %>">
-  <td class="text-left tracker-row__when">
-    <%= zone.call(row[:opened]) if row[:opened] %>
-    <% if row[:closed] %><small>→ <%= zone.call(row[:closed]) %></small><% end %>
+  <td class="text-left tracker-row__when table__when">
+    <%= table_date(row[:opened], current_user.time_zone) if row[:opened] %>
+    <% if row[:closed] %><small>→ <%= table_date(row[:closed], current_user.time_zone) %></small><% end %>
   </td>
   <td class="text-left"><span class="tracker-row__asset"><% if row[:asset] %><%= render 'assets/logo', image_url: row[:asset].image_url, color: row[:asset].color %><% end %><%= row[:symbol] %></span></td>
   <td class="text-left"><% if type %><span class="pill pill--quiet"><%= type %></span><% end %></td>
@@ -20,7 +19,7 @@
       <%= tracker_percent(row[:percent]) %><% unless hide_money %><span class="tracker-row__cash"><%= '+' unless row[:cash].negative? %><%= @denomination.format(row[:cash]) %></span><% end %>
     </td>
   <% else %>
-    <td title="<%= t('tracker.basis_incomplete') %>">—</td>
+    <td title="<%= t('tracker.basis_incomplete') %>"><%= no_value %></td>
   <% end %>
   <td><%= tracker_holding_period(row[:opened], row[:closed] || Time.current) if row[:opened] %></td>
 </tr>

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -8,7 +8,7 @@
     contextual filter sits up in the bar and its table below — while both stay inside the pane's
     `order-filter` scope, which is what lets one control filter the rows underneath it. %>
 <div class="tracker-record" data-controller="tracker--record">
-  <div class="tracker-record__switch filters" data-action="segmented:change->tracker--record#show">
+  <div class="tracker-record__switch filters" data-action="segmented:change->tracker--record#mark segmented:change->tracker--record#show segmented:change->tracker--record#hold">
     <%= render 'shared/segmented', fluid: true, label: t('tracker.positions'),
                options: [{ value: 'pos', label: t('tracker.positions'), active: true },
                          { value: 'tx', label: t('tracker.transactions') }] %>
@@ -16,7 +16,10 @@
 
   <div class="tracker-record__pane tracker-record__pane--off" data-pane="tx"
        data-controller="order-filter" data-tracker--record-target="pane">
-    <div class="tracker-record__filters filters" data-action="segmented:change->order-filter#filter">
+    <%# The hold straddles the filter: `mark` reads the scroll offset while the layout is still
+        clean, `hold` measures the shortened document. Reading it after the rows are hidden returns
+        the offset the browser has already clamped, which is the jump itself. %>
+    <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if type_filters.any? %>
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'), options: type_filters %>
       <% end %>
@@ -58,7 +61,10 @@
 
   <div class="tracker-record__pane" data-pane="pos"
        data-controller="order-filter" data-tracker--record-target="pane">
-    <div class="tracker-record__filters filters" data-action="segmented:change->order-filter#filter">
+    <%# The hold straddles the filter: `mark` reads the scroll offset while the layout is still
+        clean, `hold` measures the shortened document. Reading it after the rows are hidden returns
+        the offset the browser has already clamped, which is the jump itself. %>
+    <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if status_filters.any? %>
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'), options: status_filters %>
       <% end %>

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -12,9 +12,8 @@
 <% price, source = tracker_row_price(at, denomination) %>
 <% value = tracker_row_value(at, denomination, price, source)&.round(2) %>
 <tr id="<%= dom_id(at) %>" class="tracker-row" data-order-filter-target="row" data-order-type="<%= tracker_row_types(at) %>">
-  <td class="text-left tracker-row__when">
-    <%= at.transacted_at.in_time_zone(current_user.time_zone).strftime('%Y/%m/%d') %>
-    <small><%= at.transacted_at.in_time_zone(current_user.time_zone).strftime('%H:%M') %></small>
+  <td class="text-left tracker-row__when table__when">
+    <%= table_when(at.transacted_at, current_user.time_zone) %>
   </td>
   <td class="tracker-exchange-icon"><%= render "svg/exchange-#{at.exchange.name_id}", title: at.exchange.name %></td>
   <td class="text-left">
@@ -37,7 +36,7 @@
     <% if source == :exchange %>
       <%= price %>
     <% elsif source == :cash %>
-      <%= price ? tracker_figure(price, denomination.currency) : '—' %>
+      <%= price ? tracker_figure(price, denomination.currency) : no_value %>
     <% else %>
       <%= form_with url: price_tracker_transaction_path(at), method: :patch,
                     data: { controller: 'form--submit' } do %>
@@ -61,14 +60,14 @@
     <% end %>
   </td>
   <% unless hide_money %>
-    <td class="tracker-row__value"><%= tracker_amount(value) || '—' %></td>
-    <td class="tracker-row__fee"><%= at.fee_amount.present? ? tracker_figure(at.fee_amount, at.fee_currency) : '—' %></td>
+    <td class="tracker-row__value"><%= tracker_amount(value) || no_value %></td>
+    <td class="tracker-row__fee"><%= at.fee_amount.present? ? tracker_figure(at.fee_amount, at.fee_currency) : no_value %></td>
   <% end %>
   <td>
     <% if at.bot_transaction.present? %>
       <%= link_to "##{at.bot_transaction.bot_id}", bot_path(at.bot_transaction.bot_id) %>
     <% else %>
-      —
+      <%= no_value %>
     <% end %>
   </td>
 </tr>

--- a/test/helpers/bot_helper_test.rb
+++ b/test/helpers/bot_helper_test.rb
@@ -15,7 +15,7 @@ class BotHelperTest < ActionView::TestCase
                                 base: 'CKB', quote: 'USDC',
                                 amount: 7107, amount_exec: 0, quote_amount: 10, quote_amount_exec: 0)
 
-    assert_equal 'Open order to buy 7107.0 CKB for 10.0 USDC', transaction_summary(order)
+    assert_equal 'Open order to buy 7107.0 CKB for 10.00 USDC', transaction_summary(order)
   end
 
   test 'pending limit sell shows open-order sell wording with requested amounts' do
@@ -23,7 +23,7 @@ class BotHelperTest < ActionView::TestCase
                                 base: 'CKB', quote: 'USDC',
                                 amount: 7107, amount_exec: 0, quote_amount: 10, quote_amount_exec: 0)
 
-    assert_equal 'Open order to sell 7107.0 CKB for 10.0 USDC', transaction_summary(order)
+    assert_equal 'Open order to sell 7107.0 CKB for 10.00 USDC', transaction_summary(order)
   end
 
   test 'filled buy shows bought wording with executed amounts' do
@@ -32,6 +32,28 @@ class BotHelperTest < ActionView::TestCase
                                 amount: 7107, amount_exec: 7107, quote_amount: 10, quote_amount_exec: 9.99)
 
     assert_equal 'Bought 7107.0 CKB for 9.99 USDC', transaction_summary(order)
+  end
+
+  # == money is written to the cent ==
+  #
+  # The venue publishes whatever precision it likes for a pair, which left a stablecoin column
+  # reading 10.0 next to 9.99 next to 0.001407. A quantity of a coin still keeps the venue's
+  # decimals: two places there would round most tokens away entirely.
+  test 'a stablecoin amount is written to the cent whatever the venue publishes' do
+    assert_equal '10.00', round_amount(10.to_d, 8, 'USDC')
+    assert_equal '9.99', round_amount(9.99.to_d, 8, 'USDT')
+  end
+
+  test 'a fiat amount is written to the cent' do
+    assert_equal '1234.50', round_amount(1234.5.to_d, 6, 'EUR')
+  end
+
+  test 'a coin amount keeps the decimals the venue publishes' do
+    assert_equal 0.001407.to_d, round_amount(0.0014069999.to_d, 6, 'BTC')
+  end
+
+  test 'no currency named falls back to the venue decimals' do
+    assert_equal 1.23.to_d, round_amount(1.2345.to_d, 2, nil)
   end
 
   # == abandoned external_status ==

--- a/test/integration/bots/transaction_unit_price_test.rb
+++ b/test/integration/bots/transaction_unit_price_test.rb
@@ -21,9 +21,10 @@ class Bots::TransactionUnitPriceTest < ActionDispatch::IntegrationTest
     decimals = { @bot.base_asset.symbol => 8, @bot.quote_asset.symbol => 4 }
     get bot_path(id: @bot.id, format: :turbo_stream), params: { decimals: decimals }
     assert_response :ok
-    # 27.000331 / 0.00694239 = ~3889.1505... rounded to 4 quote decimals
-    expected = (27.000331.to_d / 0.00694239.to_d).round(4)
-    assert_match(%r{#{expected}\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
+    # 27.000331 / 0.00694239 = 3889.1982..., and a fiat quote is written to the cent whatever
+    # `decimals` says. Still the EXECUTED amounts: the configured 50 / 0.001 would read 50000.00.
+    assert_match(%r{3889\.20\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
+    refute_match(%r{50000\.00\s+<small>#{@bot.quote_asset.symbol}</small>}, response.body)
   end
 
   test 'pending order renders unit price from configured amounts' do

--- a/test/views/table_placeholders_test.rb
+++ b/test/views/table_placeholders_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Two things in a table are not the table's content, and neither is set in its ink: a dash standing
+# where a value would be, and the date a row is filed under. Both are decided in one place — the
+# `no_value` helper and the `table__when` class — so every table on the bot and tracker pages says
+# it the same way.
+class TablePlaceholdersTest < ActionView::TestCase
+  setup do
+    @bot = create(:dca_single_asset)
+    # These rows are rendered for a signed-in user, and a view test has no request carrying one —
+    # Devise's own `current_user` helper is on the view, so the stand-in has to be too.
+    user = @bot.user
+    view.define_singleton_method(:current_user) { user }
+  end
+
+  test 'a cell with nothing to show carries the muted dash' do
+    render partial: 'bots/assets_table',
+           locals: { rows: [{ symbol: 'BTC', amount: '1', avg_price: nil, value: nil, pnl: nil }] }
+
+    # Average price, value and P/L — every column that has nothing to state.
+    assert_select 'td span.no-value', 3
+  end
+
+  test 'the date opening a row is marked as the caption it is' do
+    activity = @bot.bot_activity_logs.create!(event: 'started')
+
+    render partial: 'bots/orders/activity', locals: { activity: activity }
+
+    # A bare <tr> is not a document, and the fragment parser drops the row — so the markup is
+    # searched rather than a parsed tree.
+    assert_includes rendered, 'class="table__when"'
+    # One shape on both pages: year-first date, clock time behind it in <small>.
+    assert_match %r{\d{4}/\d{2}/\d{2} <small>\d{2}:\d{2}</small>}, rendered
+  end
+end


### PR DESCRIPTION
Four readings in the tables were louder, or shakier, than what they actually say.

## A dash is not a figure

A cell with nothing to state wrote its dash in the same ink as the numbers beside it, and wrote it two different ways: a hyphen on the bot pages, an em dash on the tracker. Both now come from one `no_value` helper and read in the caption's colour.

The date a row is filed under is a handle for finding the row, not something the row states, so it reads in that same quiet colour — the clock time behind it in `<small>`, at the same weight as the date it belongs to.

## One date shape

The two pages disagreed on both the separator and the clock: the bot log wrote `2026-08-27 07:29 AM`, the tracker `2026/08/27 07:29`. Six inline `strftime` calls are now `table_date` / `table_when`, so a reader moving between the pages is not re-learning the format.

The positions row keeps its second, smaller date. Where a position closed is worth saying, and the smaller weight is what marks it as the later half of a span rather than a second row.

The zone is passed in rather than read off `current_user`. These rows also render from a model broadcast, where there is no request and the user arrives as a partial local — which a helper method cannot see. Making it an argument is what lets one formatter serve both paths.

## Money to the cent

A venue publishes whatever precision it likes for a pair, which left a stablecoin column reading `10.0` beside `9.99` beside `0.001407` — figures a reader is meant to compare down the column. Fiat and stablecoin amounts are now written to two decimals.

`round_amount` asks `Tax::PriceService.money?` for that, which moved out of a private tracker helper to sit with the two lists it reads, so the reading and the tax engine cannot drift apart on what counts as a currency. A quantity of a coin still keeps the venue's decimals, where two places would round most tokens away entirely.

One known consequence: a unit price below a cent now displays as `0.00`. `tracker_price` takes the opposite view for prices on the tracker (eight decimals below one), so the two pages differ on that case.

## Holdings unfolds

"Show more" jumped open. It now animates, via `::details-content` with `interpolate-size: allow-keywords` — no JavaScript and no markup change. Browsers without the pseudo-element keep today's instant open, and `prefers-reduced-motion` drops the transition (the reset's rule is universal-selector only, and `*` never matches a pseudo-element).

## The record no longer yanks the page

Switching a filter that hides most of a table shortens the document, the browser clamps the scroll offset to the new maximum, and that clamp is the jump — the header the reader was looking at leaves the screen.

The offset is captured before the rows are hidden, because reading it afterwards is itself a layout flush and returns the already-clamped value. The block is then padded back to the height it had, so the table header stays where it was even when the new filter leaves three rows and a blank tail below them. That tail is eaten as the reader scrolls up and never handed back — growing it would let a reader scrolling down extend it forever.

The restore is `behavior: "instant"`: the page sets `scroll-behavior: smooth` globally, and an animated restore would still be travelling when the trim starts. The padding is cleared on `turbo:before-cache` as well as on disconnect, since Turbo snapshots the DOM before a controller disconnects and a restored Back page would otherwise carry the blank tail with nothing left to eat it.