### PR TITLE
Write the tables' money to the cent

### DIFF
--- a/app/assets/stylesheets/_variables.sass
+++ b/app/assets/stylesheets/_variables.sass
@@ -61,7 +61,7 @@
     --paper-on-washed: #F5F6F8
     --white: #FFFFFF
     --grass: color(display-p3 0 0.7 0.45)
-    --berry: #EE0060
+    --berry: #db0049
     --highlight: var(--sky)
     --autocomplete: #cde
     --inputTextFocus: #0D223F
@@ -128,7 +128,7 @@
     --paper-on-washed: #122949
     --white: #FFFFFF
     --grass: color(display-p3 0 0.7 0.45)
-    --berry: #EE0060
+    --berry: #ff0055
     --highlight: var(--white)
     --autocomplete: #122b49
     --inputTextFocus: #fff

--- a/app/assets/stylesheets/new/_data-grid.sass
+++ b/app/assets/stylesheets/new/_data-grid.sass
@@ -2,66 +2,44 @@
 @use "sass:list"
 @use "../variables" as *
 
-// The grid paints its own dividers as background layers: one vertical hairline per column boundary,
-// plus a horizontal rule under the first row. Written by hand that is a gradient per boundary, and
-// a six-across row needs five of them — so they are generated instead, and every column count reads
-// the same way.
-//
-// The horizontal rule goes LAST so the per-layer size and position lists can be built alongside it.
+// The grid paints its own column dividers as background layers: one vertical hairline per column
+// boundary. Written by hand that is a gradient per boundary, and a six-across row needs five of
+// them — so they are generated instead, and every column count reads the same way.
 @function column-dividers($count)
   $layers: ()
   @for $i from 1 through $count - 1
     $at: math.percentage(math.div($i, $count))
     $layers: list.append($layers, linear-gradient(to right, transparent, transparent calc(#{$at} - 0.25rem), var(--widget-shadow-line) calc(#{$at} - 0.25rem), var(--widget-shadow-line) calc(#{$at}), transparent calc(#{$at})), comma)
-  @return list.append($layers, linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line)), comma)
+  @return $layers
 
-@function divider-sizes($count)
-  $sizes: ()
-  @for $i from 1 through $count - 1
-    $sizes: list.append($sizes, 100% 100%, comma)
-  @return list.append($sizes, 100% 0.25rem, comma)
-
-@function divider-positions($count)
-  $positions: ()
-  @for $i from 1 through $count - 1
-    $positions: list.append($positions, 0 0, comma)
-  @return list.append($positions, 0 var(--data-grid-row), comma)
-
-// Everything a column count needs: the tracks, the hairlines between them, and the row rule.
+// Everything a column count needs: the tracks, the hairlines between them, and a rule between rows.
+// The ROWS are never counted — an item that starts one draws its own top rule, so a grid of any
+// height is divided correctly and the bottom edge is never underlined. Each step clears the one
+// before it: at six across, the items that began rows while the grid was three across are mid-row.
 =columns($count)
   grid-template-columns: repeat($count, math.div(100%, $count))
   background-image: column-dividers($count)
-  background-size: divider-sizes($count)
-  background-position: divider-positions($count)
-  background-repeat: no-repeat
+  // Both halves carry an :nth-child so they weigh the same: a wider step's reset must never
+  // outrank a narrower one's rule, or the item it silenced keeps no divider at all.
+  > .data-grid__item:nth-child(n + #{$count + 1})
+    border-top: 0.25rem solid var(--widget-shadow-line)
+  > .data-grid__item:nth-child(-n + #{$count})
+    border-top: 0
 
 .data-grid
-    // One row, as the cells themselves compute it: label + gap + value, plus the item's own padding.
-    // The row divider is painted by the container, so it has to be told the height the items decide.
-    // It sits just BELOW the boundary and never repeats: on a single-row grid the bar then starts
-    // exactly at the bottom edge and is clipped away, instead of underlining the last row.
-    --data-grid-row: calc(5.5rem + 2 * var(--ui-padding) / 1.33)
     text-align: right
     display: grid
     gap: 0
-    grid-template-columns: repeat(2, 50%)
-    background-image: linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line))
-    background-size: 100% 100%, 100% 0.25rem
-    background-position: 0 0, 0 var(--data-grid-row)
-    background-repeat: no-repeat
+    +columns(2)
     &--two-columns
         grid-template-columns: repeat(2, 50%) !important
-        background-image: linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)) !important
+        background-image: column-dividers(2) !important
         .data-grid__item__value
             min-height: auto
     @container (min-width: 576px)
         +columns(3)
     @container (min-width: 768px)
-        grid-template-columns: repeat(4, 25%)
-        background-image: linear-gradient(to right, transparent, transparent calc(25% - 0.25rem), var(--widget-shadow-line) calc(25% - 0.25rem), var(--widget-shadow-line) calc(25%), transparent calc(25%)), linear-gradient(to right, transparent, transparent calc(50% - 0.25rem), var(--widget-shadow-line) calc(50% - 0.25rem), var(--widget-shadow-line) calc(50%), transparent calc(50%)), linear-gradient(to right, transparent, transparent calc(75% - 0.25rem), var(--widget-shadow-line) calc(75% - 0.25rem), var(--widget-shadow-line) calc(75%), transparent calc(75%)), linear-gradient(var(--widget-shadow-line), var(--widget-shadow-line))
-        background-size: 100% 100%, 100% 100%, 100% 100%, 100% 0.25rem
-        background-position: 0 0, 0 0, 0 0, 0 var(--data-grid-row)
-        background-repeat: no-repeat
+        +columns(4)
     // Six figures, three shapes: 2 x 3 when narrow, 3 x 2 in the middle, and all six on ONE row once
     // there is room — which is where the eye can add them up without moving. The ordinary grid's
     // four-across step is skipped entirely: four of six leaves two empty cells.
@@ -91,8 +69,6 @@
                 fill: var(--stone)
             svg
                 width: 3rem
-            small
-                color: var(--stone)
             // A figure that is neither good nor bad news reads in the caption's colour rather than
             // the ink the outcomes are set in.
             &--quiet

--- a/app/assets/stylesheets/new/_dca-multi-asset.sass
+++ b/app/assets/stylesheets/new/_dca-multi-asset.sass
@@ -4,15 +4,19 @@
     display: flex
     flex-direction: column
     gap: 0.75rem
-
     &__total
+        font-size: 1.5rem
+        text-transform: uppercase
         display: flex
         align-items: center
         justify-content: flex-end
         flex-wrap: wrap
         gap: 1rem
         color: var(--concrete)
-
+        font-weight: 600
+        span
+            span
+                font-weight: 700
         &--off [data-bot--allocation-target="total"]
             color: var(--berry)
 
@@ -65,9 +69,6 @@
         position: relative
         top: 0.5rem
         box-shadow: none
-
-    &__add
-        margin-top: 1rem
 
 .bot-locked
     .asset-allocation__remove,

--- a/app/assets/stylesheets/new/_hamburger.sass
+++ b/app/assets/stylesheets/new/_hamburger.sass
@@ -11,8 +11,8 @@
 
 #hamburger
   position: absolute
-  width: 8rem
-  height: 8rem
+  width: 6rem
+  height: 6rem
   background: red
   opacity: 0
   top: 0

--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -107,7 +107,7 @@
             min-width: 100%
             padding: 0.75rem
             background: var(--dropdown-bg)
-            border-radius: 1rem
+            border-radius: 1.5rem
             box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
         // The selected option is already the trigger, wearing the chip. Listing it again would
         // offer the reader the thing they are looking at.
@@ -121,6 +121,11 @@
         .segmented__option--action
             margin-top: 0.5rem
             margin-left: 0
+            min-height: 3rem
+            justify-content: center
+            @media (max-width: 767.9px)
+                background: var(--silver)
+                box-shadow: none
         &.is-open
             .segmented__menu
                 display: flex

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -311,7 +311,6 @@
     &__cash
         color: var(--stone)
         font-weight: 450
-        margin-left: 0.75rem
     // A correction, not a routine action: it appears on the row it corrects, when the pointer is
     // on it. Focus-within keeps it reachable from the keyboard.
     &__action

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -181,6 +181,8 @@
             // its content. Text needs no help: half-leading centres it in its own line box.
             > *
                 vertical-align: middle
+            small:first-child
+                margin-right: 0.25rem
         td, th
             text-align: right
             border: none

--- a/app/assets/stylesheets/new2/_colors.sass
+++ b/app/assets/stylesheets/new2/_colors.sass
@@ -28,4 +28,4 @@
         --washed: #FFFFFF
         --white: #FFFFFF
         --grass: color(display-p3 0 0.7 0.45)
-        --berry: #CF0000
+        --berry: #ff0055

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -141,7 +141,7 @@ module TrackerHelper
   def tracker_note(note)
     hidden = current_user.hide_balances?
     # A cash note's quantities are money too.
-    quantity = ->(units) { hidden && Tax::PriceService.money?(note.symbol) ? '•••' : tracker_amount(units) }
+    quantity = ->(units) { hidden && Tax::PriceService.money?(note.symbol) ? '•••' : tracker_amount(units, note.symbol) }
     t("tracker.notes.#{note.kind}", symbol: note.symbol, exchange: note.exchange || t('tracker.notes.your_exchanges'),
                                     history: quantity.call(note.history), held: quantity.call(note.held),
                                     amount: hidden ? '•••' : @denomination.format_plain(note.amount_usd))
@@ -231,16 +231,20 @@ module TrackerHelper
 
   # A figure and the unit it is in, the unit in <small>: the number is what the column is read for.
   def tracker_figure(value, unit)
-    safe_join([tracker_amount(value), ' ', tag.small(unit)])
+    safe_join([tracker_amount(value, unit), ' ', tag.small(unit)])
   end
 
-  # A quantity or a price. Two decimals once it is worth more than a unit, eight below that, where
-  # two would round the whole number away.
-  def tracker_amount(value)
+  # A quantity or a price, in the unit named beside it. Money is written to the cent — the same rule,
+  # off the same list, as the bot tables' `round_amount`: a column of figures a reader is meant to
+  # compare cannot have the venue choosing a different precision per row. Anything else gets two
+  # decimals once it is worth more than a unit and eight below that, where two would round a whole
+  # token away.
+  def tracker_amount(value, currency = nil)
     return unless value
 
     value = value.to_d
-    return number_with_precision(value, precision: 2, delimiter: ',') if value.abs >= 1
+    cents = value.abs >= 1 || Tax::PriceService.money?(currency)
+    return number_with_precision(value, precision: 2, delimiter: ',') if cents
 
     number_with_precision(value, precision: 8, strip_insignificant_zeros: true)
   end
@@ -249,17 +253,6 @@ module TrackerHelper
   # and far too long for a label sitting in a bar next to a button.
   def tracker_synced_ago(time)
     t('tracker.synced_ago', ago: time_ago_in_words(time, highest_measures: 1))
-  end
-
-  # A price in the display currency. Two decimals above a unit, eight below it — an average buy of
-  # $0.00 is what a two-decimal rule makes of every sub-dollar coin, and it says nothing at all.
-  # Zero is the exception: it is not a small number, it is no number, and eight decimals of nothing
-  # is just noise in the column.
-  def tracker_price(usd_amount)
-    return unless usd_amount
-
-    value = usd_amount.to_d
-    @denomination.format(value, precision: value.nonzero? && value.abs < 1 ? 8 : 2)
   end
 
   # How long a position was held, in the largest unit that still says something.

--- a/app/views/tracker/_positions_row.html.erb
+++ b/app/views/tracker/_positions_row.html.erb
@@ -9,15 +9,15 @@
   <td class="text-left"><span class="<%= pill_class(row[:status]) %>"><%= t("tracker.record.#{row[:status]}") %></span></td>
   <% unless hide_money %>
     <td><%= @denomination.format(row[:invested]) %></td>
-    <td><%= tracker_price(row[:avg_buy]) %></td>
-    <td><%= tracker_price(row[:price]) %></td>
+    <td><%= @denomination.format(row[:avg_buy]) %></td>
+    <td><%= @denomination.format(row[:price]) %></td>
+    <%# The percentage is the reading and stays while balances are hidden; the cash before it is
+        the balance, and goes — column and all. Its cell is still drawn on a row with no reading,
+        so the columns stay in line. %>
+    <td class="tracker-row__cash"><% if row[:cash] %><%= '+' unless row[:cash].negative? %><%= @denomination.format(row[:cash]) %><% end %></td>
   <% end %>
-  <%# The percentage is the reading and stays while balances are hidden; the cash beside it is the
-      balance, and goes. %>
   <% if row[:percent] %>
-    <td class="<%= row[:percent].negative? ? 'text-danger' : 'text-success' %>">
-      <%= tracker_percent(row[:percent]) %><% unless hide_money %><span class="tracker-row__cash"><%= '+' unless row[:cash].negative? %><%= @denomination.format(row[:cash]) %></span><% end %>
-    </td>
+    <td class="<%= row[:percent].negative? ? 'text-danger' : 'text-success' %>"><%= tracker_percent(row[:percent]) %></td>
   <% else %>
     <td title="<%= t('tracker.basis_incomplete') %>"><%= no_value %></td>
   <% end %>

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -84,6 +84,8 @@
                 <th><%= t('tracker.columns.invested') %></th>
                 <th><%= t('tracker.columns.avg_buy') %></th>
                 <th><%= t('tracker.columns.price') %></th>
+                <%# The cash P/L runs unheaded beside the percentage: one heading over the pair. %>
+                <th></th>
               <% end %>
               <th><%= t('data_labels.pnl') %></th>
               <th><%= t('tracker.columns.hold') %></th>

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -31,7 +31,7 @@
     <% end %>
   </td>
   <td class="text-left"><span class="tracker-row__asset"><% if asset %><%= render 'assets/logo', image_url: asset.image_url, color: asset.color %><% end %><%= at.base_currency %></span></td>
-  <% unless hide_money %><td><%= tracker_amount(at.base_amount) %></td><% end %>
+  <% unless hide_money %><td><%= tracker_amount(at.base_amount, at.base_currency) %></td><% end %>
   <td class="tracker-row__price tracker-row__price--<%= source || 'none' %>">
     <% if source == :exchange %>
       <%= price %>
@@ -60,7 +60,7 @@
     <% end %>
   </td>
   <% unless hide_money %>
-    <td class="tracker-row__value"><%= tracker_amount(value) || no_value %></td>
+    <td class="tracker-row__value"><%= tracker_amount(value, denomination.currency) || no_value %></td>
     <td class="tracker-row__fee"><%= at.fee_amount.present? ? tracker_figure(at.fee_amount, at.fee_currency) : no_value %></td>
   <% end %>
   <td>

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -5,6 +5,10 @@ class TrackerHelperTest < ActionView::TestCase
 
   Holding = Struct.new(:asset, :value)
 
+  def setup
+    @denomination = Denomination.new('USD', 1.to_d)
+  end
+
   def holding(symbol, category, value)
     Holding.new(Asset.new(symbol: symbol, category: category), value.to_d)
   end
@@ -20,5 +24,34 @@ class TrackerHelperTest < ActionView::TestCase
     assert_empty holdings_type_shares([holding('BTC', 'Cryptocurrency', 0)])
     assert_equal [['Crypto', 100]],
                  holdings_type_shares([holding('BTC', 'Cryptocurrency', 10_000), holding('AAPL', 'Stock', 1)])
+  end
+
+  # == money is written to the cent, here too ==
+  #
+  # The bot tables round money to the cent whatever the venue publishes; the tracker kept eight
+  # places, so the same USDC balance read 0.22812533 on one page and 0.23 on the other. The UNIT
+  # decides: a figure written in a currency is written in its cents, whatever it is a figure OF.
+  # A quantity of a coin still keeps eight — two would round most tokens away.
+  test 'a quantity of a stablecoin is written to the cent' do
+    assert_equal '0.23', tracker_amount(0.22812533.to_d, 'USDC')
+  end
+
+  test 'a figure in fiat keeps its cents, trailing zeros and all' do
+    assert_equal '0.20', tracker_amount(0.2.to_d, 'EUR')
+    assert_equal '0.00', tracker_amount(0.003.to_d, 'EUR')
+  end
+
+  test 'a quantity of a coin keeps the decimals it is published with' do
+    assert_equal '0.00000008', tracker_amount(0.00000008.to_d, 'BTC')
+    assert_equal '0.00000008', tracker_amount(0.00000008.to_d)
+  end
+
+  test 'a price written in a currency is written in its cents, coin or not' do
+    assert_equal '0.09 <small>USDC</small>', tracker_figure(0.09078826.to_d, 'USDC')
+    assert_equal '0.86 <small>EUR</small>', tracker_figure(0.859107.to_d, 'EUR')
+  end
+
+  test 'a fee in a coin keeps its decimals' do
+    assert_equal '0.00000008 <small>BTC</small>', tracker_figure(0.00000008.to_d, 'BTC')
   end
 end


### PR DESCRIPTION
Four passes over the tables and the surfaces around them.

## Money is written to the cent

The bot tables round money to the cent whatever precision the venue publishes it at; the tracker did not. The same USDC balance read `0.22812533` on one page and `0.23` on the other, and a Value column ran `0.2` beside `0` beside `0.19` — figures a reader is meant to compare, written three different ways.

The **unit** decides, not what the figure is a quantity of: anything written in a currency is written in that currency's cents. `tracker_amount` now takes the unit beside it and asks the same `Tax::PriceService.money?` that the bot tables' `round_amount` asks, so the reading and the tax engine cannot drift apart on what counts as money. A quantity of a coin still keeps eight places, where two would round most tokens away.

| cell | before | after |
|---|---|---|
| a stablecoin amount | `0.22812533` | `0.23` |
| its price, in fiat | `0.85910653 EUR` | `0.86 EUR` |
| a value in fiat | `0.2`, `0` | `0.20`, `0.00` |
| a fee in a coin | `0.00000008 BTC` | unchanged |

That left `tracker_price` with nothing of its own to say — every price it formatted is in the display currency, so it was `Denomination#format` with an extra branch. It is gone.

## The cash P/L gets its own column

Two figures sharing the percentage cell could not line up with anything, and the right-hand one drifted with the width of the left. It moves into a column of its own, unheaded: one heading over the pair.

## A data grid divides at any height

The grid painted its dividers as background layers, and the horizontal one had to be told where the boundary was — a variable holding the row height, re-derived by hand from the items' own padding and line boxes. One rule was all it could draw, so a grid of more than two rows was divided only under its first.

The vertical hairlines stay generated. The horizontal rule becomes a `border-top` on any item that starts a row: no height to state and no rows to count, correct at any length, and it never underlines the bottom edge.

## Smaller corrections

- `--berry`, the ink every loss and error is written in, is set per theme: deeper on paper, brighter against the dark background, with the second palette no longer holding a third value of its own.
- The hamburger's invisible hit area was wider than the button it covers and overlapped its neighbour.
- A segmented dropdown's action option is a button, not an option, and is now built like one.
- The multi-asset allocation total — the figure the Start gate is decided on — reads as the heading it is.

Six new helper tests. 4677 tests green.
