### PR TITLE
Give the holdings fold long enough to be seen

### DIFF
--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -60,13 +60,16 @@
     &[open] > summary
         order: 1
     // The folded rows sit in this pseudo, which is a flex item of the default order 0 — so the
-    // summary's order: 1 still carries the toggle below them once open.
+    // summary's order: 1 still carries the toggle below them once open. Only Chromium runs
+    // transitions on this pseudo — Gecko and WebKit style it but open it in one frame, whatever
+    // property or duration is asked for — so the fold is an enhancement, never the thing that
+    // makes the rows reachable.
     &::details-content
         block-size: 0
         overflow: hidden
         // content-visibility is discrete and hidden while closed: without allow-discrete it flips
         // at frame one and the fold-up plays against an already-empty box.
-        transition: block-size 0.15s ease, content-visibility 0.15s allow-discrete
+        transition: block-size 0.25s ease, content-visibility 0.25s allow-discrete
         // The reset's reduced-motion rule is universal-selector only, and `*` never matches a pseudo.
         @media (prefers-reduced-motion: reduce)
             transition: none


### PR DESCRIPTION
The "Show more" fold on the tracker's Holdings widget is animated, but at `0.15s`
over a list that grows by roughly 350px the movement is nine tenths finished
within 80ms. It reads as a jump. This raises it to `0.25s`, which is enough for
the rows to travel.

Measured in Chrome before and after, sampling the widget's height every frame:

| | frames to reach full height |
|---|---|
| before | ~4 |
| after | ~14 |

### A note left in the stylesheet

Only Chromium runs transitions on `::details-content`. Firefox and Safari both
support the pseudo-element and apply its static styles — the fold is hidden when
closed and shown when open, correctly — but they open the disclosure in a single
frame regardless of which property is transitioned or for how long. Verified
against `grid-template-rows`, a plain-pixel `max-block-size` and `opacity`; all
three snap. `interpolate-size: allow-keywords` is also unsupported in both,
though it is not what blocks them.

So no duration here changes anything outside Chromium, and the comment now says
so, to save the next reader the same detour. Animating the fold in every engine
would mean moving it off the pseudo-element onto a real wrapper and holding the
`open` attribute through the closing transition, which is a larger change than
this one and not attempted here. Nothing about reaching the rows depends on it.
