### PR TITLE
Gather only the tail the icon cannot draw

### DIFF
--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -45,9 +45,9 @@ module TrackerHelper
   # Between slices. The menu draws the 24-unit viewBox at 24px, so a unit here is a screen pixel.
   ICON_GAP = 2.0
   # A round-capped dash of nothing is a dot as wide as the stroke, and that is the smallest a slice
-  # can be drawn. So a slice needs a gap and a stroke's worth of circumference to itself before it
-  # is a slice at all — below that it is dropped, and what is left is read as the whole again.
-  ICON_MIN_SPAN = ICON_GAP + ICON_STROKE
+  # can be drawn — so this, not the gap, is the floor. The gap gives way to it: a slice with no room
+  # for the full gap keeps whatever is left over, and its neighbours still hold their own half.
+  ICON_MIN_SPAN = ICON_STROKE
 
   # [{ color:, dash:, offset: }] for one dashed circle per slice, clockwise from twelve o'clock.
   def allocation_icon_arcs(user)
@@ -442,37 +442,61 @@ module TrackerHelper
     position.avg_cost_usd * quantity
   end
 
-  # [value, color] pairs into dash offsets around one circle. A dashed circle starts at three
-  # o'clock and the card's ring is rotated a quarter turn to start at twelve, so the same quarter
-  # turn is walked into the first offset — no transform for the menu's sizing to survive. Offsets
-  # run negative from there because a negative offset is what walks a dash forward.
+  def icon_arcs(pairs) = icon_ring(icon_slices(pairs))
+
+  # [value, color] largest first, with the ones too thin to draw gathered into a neutral tail — the
+  # same neutral the card's ring uses, so the two pictures agree about what is held. The tail is the
+  # LAST of the portfolio and nothing more: everything that can be drawn keeps its own colour.
+  def icon_slices(pairs)
+    slices = pairs.select { |value, _| value.positive? }.sort_by { |value, _| -value }
+    total = slices.sum(0.to_d) { |value, _| value }
+    return [] unless total.positive?
+
+    large, small = slices.partition { |value, _| icon_span(value, total) >= ICON_MIN_SPAN }
+    # Nothing stands out, so nothing is "other": one neutral ring is the icon for a portfolio nobody
+    # has synced. Show the largest holdings that fit instead, read as the whole between them.
+    return drop_to_fit(slices) if large.empty?
+    # A single holding is not an "other" — there is nothing for it to be grouped with, and it
+    # cannot be drawn at this size either, so it goes and the rest is the whole.
+    return large if small.size < 2
+
+    folded = small.sum(0.to_d) { |value, _| value }
+    icon_span(folded, total) < ICON_MIN_SPAN ? large : large + [[folded, NEUTRAL_COLOR]]
+  end
+
+  # The slices laid out around one circle. Each is drawn inside its own span, half a gap and half a
+  # round cap in from each end, so no arc bleeds into its neighbour. A slice too tight for the full
+  # gap keeps what is left of its span and comes out as a single round dot.
   #
-  # A slice is drawn inside its own span, half a gap and half a round cap in from each end, so the
-  # dash is shorter than the share it stands for by exactly one `ICON_MIN_SPAN`.
-  def icon_arcs(pairs)
-    slices = drop_to_fit(pairs.select { |value, _| value.positive? })
+  # A dashed circle starts at three o'clock and the card's ring is rotated a quarter turn to start
+  # at twelve, so the same quarter turn is walked into the first offset — no transform for the
+  # menu's sizing to survive. Offsets run negative from there because a negative offset is what
+  # walks a dash forward.
+  def icon_ring(slices)
     total = slices.sum(0.to_d) { |value, _| value }
     walked = -ICON_CIRCUMFERENCE / 4
 
     slices.map do |value, color|
-      span = (value / total).to_f * ICON_CIRCUMFERENCE
-      length = span - ICON_MIN_SPAN
+      span = icon_span(value, total)
+      gap = [ICON_GAP, span - ICON_STROKE].min
+      length = span - gap - ICON_STROKE
       arc = { color: ensure_contrast(color.presence || NEUTRAL_COLOR),
               dash: "#{length.round(2)} #{(ICON_CIRCUMFERENCE - length).round(2)}",
-              offset: -(walked + (ICON_MIN_SPAN / 2)).round(2) }
+              offset: -(walked + ((gap + ICON_STROKE) / 2)).round(2) }
       walked += span
       arc
     end
   end
 
-  # Largest first, with the smallest dropped off the end — and the rest read as the whole again —
-  # until every slice left has room to be drawn. Dropping one lifts all the others, so this always
-  # lands, at worst on a single slice taking the whole ring.
-  def drop_to_fit(pairs)
-    slices = pairs.sort_by { |value, _| -value }
+  def icon_span(value, total) = (value / total).to_f * ICON_CIRCUMFERENCE
+
+  # The smallest dropped off the end — and the rest read as the whole again — until every slice
+  # left has room to be drawn. Dropping one lifts all the others, so this always lands, at worst
+  # on a single slice taking the whole ring.
+  def drop_to_fit(slices)
     while slices.any?
       total = slices.sum(0.to_d) { |value, _| value }
-      break if (slices.last.first / total).to_f * ICON_CIRCUMFERENCE >= ICON_MIN_SPAN
+      break if icon_span(slices.last.first, total) >= ICON_MIN_SPAN
 
       slices = slices[0..-2]
     end

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -65,15 +65,25 @@ class TrackerHelperTest < ActionView::TestCase
                            usd_price: value, usd_value: value, synced_at: Time.current)
   end
 
-  # The share the slice stands for: the dash is shorter than its span by one gap and one round cap.
+  # The share the slice stands for. Only valid for a slice wide enough to take the whole gap — a
+  # tighter one is a bare dot, and its dash carries no width to read a share back out of.
   def arc_share(arc)
     visible, rest = arc[:dash].split.map(&:to_f)
-    (visible + TrackerHelper::ICON_MIN_SPAN) / (visible + rest)
+    (visible + TrackerHelper::ICON_GAP + TrackerHelper::ICON_STROKE) / (visible + rest)
   end
 
-  # Where the slice's span begins, as a fraction of the ring clockwise from twelve o'clock.
+  # Where the slice's span begins, as a fraction of the ring clockwise from twelve o'clock. Same
+  # caveat as `arc_share`.
   def arc_start(arc)
-    ((-arc[:offset] - (TrackerHelper::ICON_MIN_SPAN / 2)) / TrackerHelper::ICON_CIRCUMFERENCE) + 0.25
+    inset = (TrackerHelper::ICON_GAP + TrackerHelper::ICON_STROKE) / 2
+    ((-arc[:offset] - inset) / TrackerHelper::ICON_CIRCUMFERENCE) + 0.25
+  end
+
+  # What survives the fold, as [percent, colour] — the composition, before any of it is drawn.
+  def icon_shares(pairs)
+    slices = icon_slices(pairs.map { |value, color| [value.to_d, color] })
+    total = slices.sum(0.to_d) { |value, _| value }
+    slices.map { |value, color| [(value / total * 100).round(1).to_f, color] }
   end
 
   test 'nothing to divide, no arcs: the icon stays a plain circle' do
@@ -112,27 +122,59 @@ class TrackerHelperTest < ActionView::TestCase
     assert_equal 1, allocation_icon_arcs(user).size
   end
 
-  # A round-capped dash of nothing is already a dot as wide as the stroke: below a gap plus a stroke
-  # there is no room left to draw, so the slice goes rather than shrinking into its neighbours.
-  test 'a slice with no room to be drawn is dropped, and the rest read as the whole' do
+  # == what is drawn, and what is gathered ==
+  #
+  # The floor is the stroke, not the gap: a round-capped dash of nothing is already a dot as wide as
+  # the stroke, and a slice too tight for the whole gap keeps whatever is left of its span. So only
+  # the genuine tail is gathered, and everything the ring can draw keeps its own colour.
+  test 'a holding too small for the gap is still drawn, as a dot' do
+    arcs = icon_arcs([[96, '#4C6B4C'], [4, '#1652F0']].map { |value, color| [value.to_d, color] })
+
+    assert_equal 2, arcs.size
+    # No dash left at all: what is drawn is the two round caps meeting, a dot as wide as the stroke.
+    assert_equal '0.0', arcs.last[:dash].split.first
+    assert_in_delta 0.96, arc_share(arcs.first), 0.001
+  end
+
+  # What the icon used to get wrong: it dropped everything it could not draw, handed that share to
+  # the largest holding and drew the whole ring in one colour. The tail is gathered now — but it is
+  # only the tail, so the two small holdings the card shows keep their own colours here too.
+  test 'only the undrawable tail is gathered, into one neutral slice, last' do
     user = create(:user)
-    icon_balance(user, '#F7931A', 98)
-    icon_balance(user, '#627EEA', 1)
-    icon_balance(user, '#26A17B', 1)
+    icon_balance(user, '#4C6B4C', 78)
+    icon_balance(user, '#1652F0', 4.5)
+    icon_balance(user, '#F7931A', 4)
+    9.times { icon_balance(user, '#888888', 1.5) }
 
     arcs = allocation_icon_arcs(user)
 
-    assert_equal 1, arcs.size
-    assert_in_delta 1.0, arc_share(arcs.first), 0.001
+    assert_equal([ensure_contrast('#4C6B4C'), ensure_contrast('#1652F0'), ensure_contrast('#F7931A'),
+                  ensure_contrast(TrackerHelper::NEUTRAL_COLOR)],
+                 arcs.map { |arc| arc[:color] })
+    assert_equal 13.5, icon_shares([[78, '#4C6B4C'], [4.5, '#1652F0'], [4, '#F7931A']] +
+                                   Array.new(9) { [1.5, '#888888'] }).last.first
   end
 
-  # Dropping one lifts every other share, so the floor has to be re-read after each: twenty equal
-  # holdings are 5% each and too thin, and only stop being thin once six of them have gone.
-  test 'the smallest go one at a time, until the smallest left has room' do
-    arcs = icon_arcs(Array.new(20) { [5.to_d, '#F7931A'] })
+  test 'a tail too thin even to gather is dropped, and the rest read as the whole' do
+    assert_equal [[100.0, '#F7931A']],
+                 icon_shares([[98, '#F7931A'], [1, '#627EEA'], [1, '#26A17B']])
+  end
 
-    assert_equal 14, arcs.size
-    assert_operator arc_share(arcs.last) * TrackerHelper::ICON_CIRCUMFERENCE, :>=, TrackerHelper::ICON_MIN_SPAN
+  # One holding is not an "other": there is nothing to gather it with, and it cannot be drawn at
+  # this size either, so it goes and the rest is the whole.
+  test 'a single holding below the floor is dropped rather than named a remainder' do
+    assert_equal [[60.6, '#F7931A'], [39.4, '#627EEA']],
+                 icon_shares([[60, '#F7931A'], [39, '#627EEA'], [1, '#26A17B']])
+  end
+
+  # With nothing above the floor there is nothing for a tail to be "other" than, and one neutral
+  # ring is the icon for a portfolio nobody has synced. So the largest that fit are shown instead,
+  # dropped one at a time — dropping one lifts every other share, so the floor is re-read after each.
+  test 'with no holding above the floor, the largest that fit are shown' do
+    arcs = icon_arcs(Array.new(40) { [2.5.to_d, '#F7931A'] })
+
+    assert_equal 28, arcs.size
+    assert_operator TrackerHelper::ICON_CIRCUMFERENCE / arcs.size, :>=, TrackerHelper::ICON_MIN_SPAN
   end
 
   test 'every slice keeps its whole share: the spans meet, and they close the ring' do


### PR DESCRIPTION
Follow-up to #274. The nav ring dropped every holding too thin to draw and read the survivors as the whole, so a portfolio with a long tail handed a fifth of its value to whatever was largest and came out as one solid coin — while the holdings card beside it drew four arcs of the same portfolio.

### The floor is the stroke, not the gap

A round-capped dash of zero length is already a dot as wide as the stroke, so the stroke is the real minimum a slice can occupy. The gap now gives way to it: a slice with no room for the full gap keeps whatever is left of its span, and its neighbours still hold their own half. That halves the floor — from `ICON_GAP + ICON_STROKE` to `ICON_STROKE` — so a holding worth a twenty-fifth of the portfolio is drawn rather than turned away, as a dot.

### The rest is gathered, not dropped

What still falls below that floor becomes one neutral slice, last, in the same neutral the card's ring uses — so the two pictures agree about what is held. Only the tail is gathered; everything the ring can draw keeps its own colour.

Three cases stay as they were:

- a tail too thin to draw even gathered is dust, and goes;
- a single holding below the floor has nothing to be gathered with, and goes;
- a portfolio where nothing at all clears the floor has no remainder to name, so the largest holdings that fit are shown instead — one neutral ring is the icon for a portfolio nobody has synced.

### Tests

`icon_slices` is now separable from the geometry, so the composition is asserted directly: which holdings survive, in which order, and what share the remainder carries. Alongside it, a holding too small for the gap drawn as a dot, dust dropped, a lone small holding dropped, and the no-dominant-holding fallback.
