### PR TITLE
Give the ring's gaps and its smallest slice priority over its accuracy

### DIFF
--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -44,10 +44,12 @@ module TrackerHelper
   ICON_STROKE = 2
   # Between slices. The menu draws the 24-unit viewBox at 24px, so a unit here is a screen pixel.
   ICON_GAP = 2.0
-  # A round-capped dash of nothing is a dot as wide as the stroke, and that is the smallest a slice
-  # can be drawn — so this, not the gap, is the floor. The gap gives way to it: a slice with no room
-  # for the full gap keeps whatever is left over, and its neighbours still hold their own half.
-  ICON_MIN_SPAN = ICON_STROKE
+  # What every slice is given whatever it is worth: the whole gap beside it, and a round-capped dash
+  # of nothing, which draws as a dot the width of the stroke. The ring keeps those two before it
+  # keeps the last percent of the reading — a gap that closes or a slice that vanishes is a worse
+  # lie about the portfolio than a small holding drawn slightly large.
+  ICON_MIN_SPAN = ICON_GAP + ICON_STROKE
+  ICON_MAX_SLICES = (ICON_CIRCUMFERENCE / ICON_MIN_SPAN).floor
 
   # [{ color:, dash:, offset: }] for one dashed circle per slice, clockwise from twelve o'clock.
   def allocation_icon_arcs(user)
@@ -444,63 +446,82 @@ module TrackerHelper
 
   def icon_arcs(pairs) = icon_ring(icon_slices(pairs))
 
-  # [value, color] largest first, with the ones too thin to draw gathered into a neutral tail — the
-  # same neutral the card's ring uses, so the two pictures agree about what is held. The tail is the
-  # LAST of the portfolio and nothing more: everything that can be drawn keeps its own colour.
+  # [value, color] largest first, with the tail the card's ring also gathers — everything under
+  # RING_MIN_SHARE, deliberately the same threshold — as one neutral slice, last. ONLY the tail:
+  # every holding above it keeps its own colour, however small the ring has to draw it.
   def icon_slices(pairs)
     slices = pairs.select { |value, _| value.positive? }.sort_by { |value, _| -value }
     total = slices.sum(0.to_d) { |value, _| value }
     return [] unless total.positive?
 
-    large, small = slices.partition { |value, _| icon_span(value, total) >= ICON_MIN_SPAN }
+    large, tail = slices.partition { |value, _| value / total >= RING_MIN_SHARE }
     # Nothing stands out, so nothing is "other": one neutral ring is the icon for a portfolio nobody
-    # has synced. Show the largest holdings that fit instead, read as the whole between them.
-    return drop_to_fit(slices) if large.empty?
-    # A single holding is not an "other" — there is nothing for it to be grouped with, and it
-    # cannot be drawn at this size either, so it goes and the rest is the whole.
-    return large if small.size < 2
+    # has synced. Show the largest holdings instead, read as the whole between them.
+    return slices.first(ICON_MAX_SLICES) if large.empty?
 
-    folded = small.sum(0.to_d) { |value, _| value }
-    icon_span(folded, total) < ICON_MIN_SPAN ? large : large + [[folded, NEUTRAL_COLOR]]
+    gathered = tail.sum(0.to_d) { |value, _| value }
+    # A single holding is not an "other" — there is nothing to gather it with — and a tail worth
+    # less than one holding is dust. Both just go, and the rest is read as the whole.
+    return large.first(ICON_MAX_SLICES) if tail.size < 2 || gathered / total < RING_MIN_SHARE
+
+    large.first(ICON_MAX_SLICES - 1) + [[gathered, NEUTRAL_COLOR]]
   end
 
-  # The slices laid out around one circle. Each is drawn inside its own span, half a gap and half a
-  # round cap in from each end, so no arc bleeds into its neighbour. A slice too tight for the full
-  # gap keeps what is left of its span and comes out as a single round dot.
+  # The span each slice is laid out in, in the order given. Every slice is guaranteed its minimum
+  # and only what is left over is shared out by value, so the gaps and the smallest dot are the
+  # same size wherever they fall — the small slices come out a little large and the big ones a
+  # little short. Lifting one takes circumference from the others and can push another under the
+  # minimum, so the pass repeats; it lifts at least one slice each time, so it cannot run away.
+  def icon_spans(slices)
+    return [] if slices.empty?
+
+    total = slices.sum(0.to_d) { |value, _| value }
+    shares = slices.map { |value, _| (value / total).to_f }
+    lifted = []
+    loop do
+      short = icon_short_spans(shares, lifted)
+      break if short.empty?
+
+      lifted.concat(short)
+    end
+    return Array.new(shares.size, ICON_CIRCUMFERENCE / shares.size) if lifted.size == shares.size
+
+    spare, weight = icon_spare(shares, lifted)
+    shares.each_index.map { |i| lifted.include?(i) ? ICON_MIN_SPAN : (shares[i] / weight) * spare }
+  end
+
+  # Which of the slices not yet lifted cannot pay for their own minimum out of what is left.
+  def icon_short_spans(shares, lifted)
+    spare, weight = icon_spare(shares, lifted)
+    shares.each_index.reject { |i| lifted.include?(i) }
+          .select { |i| (shares[i] / weight) * spare < ICON_MIN_SPAN }
+  end
+
+  # What the slices still paying their own way have to share, and what they are worth between them.
+  def icon_spare(shares, lifted)
+    [ICON_CIRCUMFERENCE - (lifted.size * ICON_MIN_SPAN),
+     shares.each_with_index.sum { |share, i| lifted.include?(i) ? 0.0 : share }]
+  end
+
+  # The slices drawn. Each sits inside its own span, half a gap and half a round cap in from each
+  # end, so no arc bleeds into its neighbour and every gap is the same.
   #
   # A dashed circle starts at three o'clock and the card's ring is rotated a quarter turn to start
   # at twelve, so the same quarter turn is walked into the first offset — no transform for the
   # menu's sizing to survive. Offsets run negative from there because a negative offset is what
   # walks a dash forward.
   def icon_ring(slices)
-    total = slices.sum(0.to_d) { |value, _| value }
+    spans = icon_spans(slices)
     walked = -ICON_CIRCUMFERENCE / 4
 
-    slices.map do |value, color|
-      span = icon_span(value, total)
-      gap = [ICON_GAP, span - ICON_STROKE].min
-      length = span - gap - ICON_STROKE
+    slices.each_with_index.map do |(_, color), index|
+      length = spans[index] - ICON_MIN_SPAN
       arc = { color: ensure_contrast(color.presence || NEUTRAL_COLOR),
               dash: "#{length.round(2)} #{(ICON_CIRCUMFERENCE - length).round(2)}",
-              offset: -(walked + ((gap + ICON_STROKE) / 2)).round(2) }
-      walked += span
+              offset: -(walked + (ICON_MIN_SPAN / 2)).round(2) }
+      walked += spans[index]
       arc
     end
-  end
-
-  def icon_span(value, total) = (value / total).to_f * ICON_CIRCUMFERENCE
-
-  # The smallest dropped off the end — and the rest read as the whole again — until every slice
-  # left has room to be drawn. Dropping one lifts all the others, so this always lands, at worst
-  # on a single slice taking the whole ring.
-  def drop_to_fit(slices)
-    while slices.any?
-      total = slices.sum(0.to_d) { |value, _| value }
-      break if icon_span(slices.last.first, total) >= ICON_MIN_SPAN
-
-      slices = slices[0..-2]
-    end
-    slices
   end
 
   def ring_arc_path(from, to)

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -462,7 +462,12 @@ module TrackerHelper
     gathered = tail.sum(0.to_d) { |value, _| value }
     # A single holding is not an "other" — there is nothing to gather it with — and a tail worth
     # less than one holding is dust. Both just go, and the rest is read as the whole.
-    return large.first(ICON_MAX_SLICES) if tail.size < 2 || gathered / total < RING_MIN_SHARE
+    kept = large.first(ICON_MAX_SLICES)
+    return kept if tail.size < 2 || gathered / total < RING_MIN_SHARE
+    # The remainder takes its place by value like anything else: a full ring of holdings that all
+    # outweigh it keeps them. Where it does survive it still displaces the smallest, and is drawn
+    # last whatever it is worth.
+    return kept if kept.size == ICON_MAX_SLICES && gathered <= kept.last.first
 
     large.first(ICON_MAX_SLICES - 1) + [[gathered, NEUTRAL_COLOR]]
   end

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -65,18 +65,16 @@ class TrackerHelperTest < ActionView::TestCase
                            usd_price: value, usd_value: value, synced_at: Time.current)
   end
 
-  # The share the slice stands for. Only valid for a slice wide enough to take the whole gap — a
-  # tighter one is a bare dot, and its dash carries no width to read a share back out of.
+  # The share of the RING the slice was given — its own share of the portfolio, unless it was too
+  # small to draw and had to be lifted.
   def arc_share(arc)
     visible, rest = arc[:dash].split.map(&:to_f)
-    (visible + TrackerHelper::ICON_GAP + TrackerHelper::ICON_STROKE) / (visible + rest)
+    (visible + TrackerHelper::ICON_MIN_SPAN) / (visible + rest)
   end
 
-  # Where the slice's span begins, as a fraction of the ring clockwise from twelve o'clock. Same
-  # caveat as `arc_share`.
+  # Where the slice's span begins, as a fraction of the ring clockwise from twelve o'clock.
   def arc_start(arc)
-    inset = (TrackerHelper::ICON_GAP + TrackerHelper::ICON_STROKE) / 2
-    ((-arc[:offset] - inset) / TrackerHelper::ICON_CIRCUMFERENCE) + 0.25
+    ((-arc[:offset] - (TrackerHelper::ICON_MIN_SPAN / 2)) / TrackerHelper::ICON_CIRCUMFERENCE) + 0.25
   end
 
   # What survives the fold, as [percent, colour] — the composition, before any of it is drawn.
@@ -124,22 +122,35 @@ class TrackerHelperTest < ActionView::TestCase
 
   # == what is drawn, and what is gathered ==
   #
-  # The floor is the stroke, not the gap: a round-capped dash of nothing is already a dot as wide as
-  # the stroke, and a slice too tight for the whole gap keeps whatever is left of its span. So only
-  # the genuine tail is gathered, and everything the ring can draw keeps its own colour.
-  test 'a holding too small for the gap is still drawn, as a dot' do
+  # The ring keeps its gaps and its smallest dot before it keeps the last percent of the reading, so
+  # a holding worth less than a slice is drawn slightly large and the rest give up the difference.
+  test 'a holding too small to draw at its own size is lifted to the smallest slice' do
     arcs = icon_arcs([[96, '#4C6B4C'], [4, '#1652F0']].map { |value, color| [value.to_d, color] })
 
     assert_equal 2, arcs.size
     # No dash left at all: what is drawn is the two round caps meeting, a dot as wide as the stroke.
     assert_equal '0.0', arcs.last[:dash].split.first
-    assert_in_delta 0.96, arc_share(arcs.first), 0.001
+    assert_in_delta TrackerHelper::ICON_MIN_SPAN / TrackerHelper::ICON_CIRCUMFERENCE,
+                    arc_share(arcs.last), 0.001
+    # And the ring still closes: what the dot was given, the holding above it gave up.
+    assert_in_delta 1.0, arcs.sum { |arc| arc_share(arc) }, 0.001
+  end
+
+  test 'every gap is the whole gap, whatever the portfolio' do
+    arcs = icon_arcs(([[80, '#4C6B4C']] + Array.new(6) { [3.33, '#1652F0'] })
+                     .map { |value, color| [value.to_d, color] })
+
+    assert_equal 7, arcs.size
+    starts = arcs.map { |arc| arc_start(arc) } + [1.0]
+    spans = starts.each_cons(2).map { |from, to| (to - from) * TrackerHelper::ICON_CIRCUMFERENCE }
+
+    spans.each { |span| assert_operator span, :>=, TrackerHelper::ICON_MIN_SPAN - 0.001 }
   end
 
   # What the icon used to get wrong: it dropped everything it could not draw, handed that share to
   # the largest holding and drew the whole ring in one colour. The tail is gathered now — but it is
   # only the tail, so the two small holdings the card shows keep their own colours here too.
-  test 'only the undrawable tail is gathered, into one neutral slice, last' do
+  test 'only the tail is gathered, into one neutral slice, last' do
     user = create(:user)
     icon_balance(user, '#4C6B4C', 78)
     icon_balance(user, '#1652F0', 4.5)
@@ -155,26 +166,33 @@ class TrackerHelperTest < ActionView::TestCase
                                    Array.new(9) { [1.5, '#888888'] }).last.first
   end
 
-  test 'a tail too thin even to gather is dropped, and the rest read as the whole' do
+  test 'a tail worth less than one holding is dust, and is dropped' do
     assert_equal [[100.0, '#F7931A']],
-                 icon_shares([[98, '#F7931A'], [1, '#627EEA'], [1, '#26A17B']])
+                 icon_shares([[99.5, '#F7931A'], [0.25, '#627EEA'], [0.25, '#26A17B']])
   end
 
-  # One holding is not an "other": there is nothing to gather it with, and it cannot be drawn at
-  # this size either, so it goes and the rest is the whole.
-  test 'a single holding below the floor is dropped rather than named a remainder' do
+  # One holding is not an "other": there is nothing to gather it with, so it goes and the rest is
+  # the whole.
+  test 'a single holding below the threshold is dropped rather than named a remainder' do
     assert_equal [[60.6, '#F7931A'], [39.4, '#627EEA']],
                  icon_shares([[60, '#F7931A'], [39, '#627EEA'], [1, '#26A17B']])
   end
 
-  # With nothing above the floor there is nothing for a tail to be "other" than, and one neutral
-  # ring is the icon for a portfolio nobody has synced. So the largest that fit are shown instead,
-  # dropped one at a time — dropping one lifts every other share, so the floor is re-read after each.
-  test 'with no holding above the floor, the largest that fit are shown' do
+  # The gaps and the smallest dot are what cap the count. Past it the ring is a summary and says so
+  # by dropping, rather than sweeping a third of the portfolio into a remainder.
+  test 'more holdings than the ring can hold: the smallest go' do
     arcs = icon_arcs(Array.new(40) { [2.5.to_d, '#F7931A'] })
 
-    assert_equal 28, arcs.size
-    assert_operator TrackerHelper::ICON_CIRCUMFERENCE / arcs.size, :>=, TrackerHelper::ICON_MIN_SPAN
+    assert_equal TrackerHelper::ICON_MAX_SLICES, arcs.size
+  end
+
+  # With nothing above the threshold there is nothing for a tail to be "other" than, and one neutral
+  # ring is the icon for a portfolio nobody has synced. The largest are shown instead.
+  test 'with no holding above the threshold, the largest are shown' do
+    shares = icon_shares(Array.new(200) { [0.5, '#F7931A'] })
+
+    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
+    assert_equal ['#F7931A'], shares.map(&:last).uniq
   end
 
   test 'every slice keeps its whole share: the spans meet, and they close the ring' do

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -186,6 +186,24 @@ class TrackerHelperTest < ActionView::TestCase
     assert_equal TrackerHelper::ICON_MAX_SLICES, arcs.size
   end
 
+  # The remainder is not privileged: it queues by value with everything else. A ring already full of
+  # holdings that all outweigh it keeps them and says nothing about the rest.
+  test 'a remainder smaller than every holding on a full ring does not displace one' do
+    shares = icon_shares(Array.new(TrackerHelper::ICON_MAX_SLICES) { [7, '#F7931A'] } +
+                         Array.new(2) { [1, '#627EEA'] })
+
+    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
+    assert_equal ['#F7931A'], shares.map(&:last).uniq
+  end
+
+  test 'a remainder larger than the smallest holding on a full ring takes its place' do
+    shares = icon_shares(Array.new(TrackerHelper::ICON_MAX_SLICES) { [5, '#F7931A'] } +
+                         Array.new(30) { [1, '#627EEA'] })
+
+    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
+    assert_equal TrackerHelper::NEUTRAL_COLOR, shares.last.last
+  end
+
   # With nothing above the threshold there is nothing for a tail to be "other" than, and one neutral
   # ring is the icon for a portfolio nobody has synced. The largest are shown instead.
   test 'with no holding above the threshold, the largest are shown' do


### PR DESCRIPTION
Follow-up to #275. A slice too small for the whole gap was giving the gap up in order to fit, so two small holdings next to each other were drawn all but touching and the white space around the ring came out uneven.

### Legibility first, accuracy second

Every slice is now given the whole gap and a round-capped dot of its own whatever it is worth, and only what is left over is shared out by value. Lifting one slice takes circumference from the others, which can push another under the minimum, so the pass repeats until nobody is short.

Small holdings are therefore drawn a little large and the big ones give up the difference — on a 78 / 4.5 / 4 / 13.5 portfolio the dominant holding is drawn at 73% and the two small ones at 7% each. At 24px a gap that closes, or a slice that vanishes, says something less true about the portfolio than a few percent of foreshortening does.

### The remainder is only the tail

Guaranteeing every slice a minimum fixes how many the ring can hold (`ICON_MAX_SLICES`), so the remainder no longer has to absorb whatever does not fit. It is what the card's ring gathers and nothing else: everything under `RING_MIN_SHARE`, deliberately the same threshold, so the two agree about what counts as a holding and what counts as the rest.

Past the ring's capacity the smallest holdings are dropped rather than swept into the remainder, which would otherwise make the remainder the largest thing on it. The remainder queues by value like anything else: a full ring of holdings that all outweigh it keeps them, and where it does survive it displaces the smallest and is still drawn last.

### Tests

Uniform gaps across a lopsided portfolio, a holding lifted to the smallest slice with the ring still closing, the tail gathered while the holdings above it keep their colours, dust dropped, a lone small holding dropped, the capacity cap, and the remainder both losing and winning its place on a full ring.
