### PR TITLE
Open the exchange list from the + instead of a full-page picker

### DIFF
--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -97,18 +97,39 @@
             align-items: center
             padding-right: 0.5rem
             color: var(--stone)
-        .segmented__menu
+        // The dropdown is the BOX; the panes inside it are what slides. Wide enough for the
+        // action's list, because the trigger's own width is no measure of what it opens.
+        .segmented__dropdown
             display: none
             position: absolute
             top: 4.5rem
             left: 0
             z-index: 1000
-            flex-direction: column
-            min-width: 100%
-            padding: 0.75rem
+            width: max(100%, 30rem)
+            overflow: hidden
             background: var(--dropdown-bg)
             border-radius: 1.5rem
             box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
+            // Height is set in pixels by the controller — the two panes are different heights and
+            // `auto` does not animate.
+            transition: height 0.22s cubic-bezier(0.22, 0.61, 0.36, 1)
+        // flex-start, not the default stretch: the box takes the height of the pane on screen, and
+        // a stretched short pane would measure as the tall one.
+        .segmented__panes
+            display: flex
+            align-items: flex-start
+            width: 200%
+            transition: transform 0.22s cubic-bezier(0.22, 0.61, 0.36, 1)
+        .segmented__menu, .segmented__submenu
+            display: flex
+            flex-direction: column
+            position: static
+            width: 50%
+            flex: none
+            padding: 0.75rem
+            background: none
+            box-shadow: none
+            border-radius: 0
         // The selected option is already the trigger, wearing the chip. Listing it again would
         // offer the reader the thing they are looking at.
         .segmented__option
@@ -118,22 +139,107 @@
                 display: none
         // Same separation, turned through the ninety degrees the menu turned: the gap goes above
         // it, and the indent that opened it on the track would only break this column's left edge.
+        // The collapse is MEASURED, so the folded look cannot hang off a breakpoint either.
         .segmented__option--action
             margin-top: 0.5rem
             margin-left: 0
             min-height: 3rem
             justify-content: center
-            @media (max-width: 767.9px)
-                background: var(--silver)
-                box-shadow: none
+            background: var(--silver)
+            box-shadow: none
+        // The whole row, not the glyph: a 3.5rem target at the head of a full-width list is
+        // something the reader has to aim at. The arrow sits where the icons below it sit.
+        .segmented__back
+            display: flex
+            align-items: center
+            width: 100%
+            min-height: 3.5rem
+            margin-bottom: 0.25rem
+            padding: 0 1rem
+            color: var(--stone)
+            background: none
+            border: 0
+            border-radius: 1rem
+            cursor: pointer
+            &:hover
+                color: var(--ink)
         &.is-open
-            .segmented__menu
-                display: flex
+            .segmented__dropdown
+                display: block
+        &.is-submenu
+            .segmented__dropdown
+                display: block
+            .segmented__panes
+                transform: translateX(-50%)
 
 // display: contents, so the expanded control is laid out exactly as it was — the options are
-// still the track's own grid items. The wrapper only becomes a box once it becomes a menu.
-.segmented__menu
+// still the track's own grid items. The wrappers only become boxes once they become a dropdown.
+.segmented__dropdown, .segmented__panes, .segmented__pane
     display: contents
+
+// The list the action opens. Expanded it is a box of its own hanging off the action at the end
+// of the track; collapsed the rules above turn it into the dropdown's second pane.
+.segmented__submenu
+    display: none
+    position: absolute
+    top: 4.5rem
+    right: 0
+    z-index: 1000
+    min-width: 30rem
+    // Anchored by its right edge to the action that opens it — except where the page itself is
+    // barely wider than the list. A switch narrower than what it opens would push the box off
+    // the left of the screen, and the app's hidden horizontal overflow simply cuts the logos
+    // off. There is always room to the RIGHT of a control that starts at the page's own inset.
+    @media (max-width: 767.9px)
+        right: auto
+        left: 0
+    padding: 0.75rem
+    background: var(--dropdown-bg)
+    border-radius: 1.5rem
+    box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
+.segmented.is-submenu .segmented__submenu
+    display: block
+
+// Same weight and case as an option, and the same hover: colour alone. A background here would
+// paint --dropdown-hover, which is the accent the action owns.
+.segmented__submenu-item
+    display: flex
+    align-items: center
+    gap: 1rem
+    padding: 0 1rem
+    min-height: 3.5rem
+    font-size: 1.5rem
+    font-weight: 600
+    text-indent: 0.1em
+    text-transform: uppercase
+    white-space: nowrap
+    color: var(--stone)
+    text-decoration: none
+    border-radius: 1rem
+    cursor: pointer
+    &:hover
+        color: var(--ink)
+
+.segmented__submenu-icon
+    display: flex
+    flex: none
+    width: 2rem
+    height: 2rem
+    svg
+        width: 100%
+        height: 100%
+        *
+            fill: currentColor
+
+// Only the folded menu has somewhere to go back TO: expanded, the list is its own box and the
+// click that opens it is the click that closes it.
+.segmented__back
+    display: none
+    svg
+        width: 2rem
+        height: 2rem
+        path
+            stroke: currentColor
 
 .segmented__caret
     display: none
@@ -200,6 +306,12 @@
         height: 1.75rem
     path
         fill: currentColor
+    &:hover
+        color: #fff
+        background: var(--sky)
+.segmented.is-submenu .segmented__option--action
+    color: #fff
+    background: var(--sky)
 
 // The control collapses when its options outgrow the room its PARENT gives it, so that parent
 // needs a width of its own. One that shrink-wraps to the collapsed trigger would report the

--- a/app/controllers/tracker_controller.rb
+++ b/app/controllers/tracker_controller.rb
@@ -17,6 +17,11 @@ class TrackerController < ApplicationController
     exchange_ids = (current_user.api_keys.pluck(:exchange_id) +
       current_user.account_transactions.distinct.pluck(:exchange_id)).uniq
     @exchanges = Exchange.where(id: exchange_ids).order(:name)
+    # What the + can still add. Retired venues are out — there is nothing left to connect to —
+    # and so is anything already on the switch. Brokers lead: they are the half of the list
+    # someone arriving from a stock holding is looking for, and there are only ever a few.
+    @connectable_exchanges = Exchange.tradeable.where.not(id: @exchanges.select(:id))
+                                     .order(:name).partition(&:stock_venue?).flatten
     @exchanges_with_valid_keys = reading_keys.to_set(&:exchange_id)
     @has_syncable_keys = @exchanges_with_valid_keys.any?
     user_transactions = AccountTransaction.for_user(current_user)

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -14,10 +14,28 @@ import { Controller } from "@hotwired/stimulus";
 // same track, same chip, now holding the selected label alone. That is measured rather than
 // keyed to a breakpoint: the labels are translated and the option count depends on the data, so
 // the width at which it stops fitting is not a number anyone could write down.
+//
+// The trailing action can carry a list of its own. Expanded that list is a box hanging off the
+// action; collapsed it is the dropdown's second pane, which slides in over the options and back
+// out again — one box, two panes, so the reader never loses the thing they opened.
 export default class extends Controller {
-  static targets = ["thumb", "option"];
+  static targets = ["thumb", "option", "dropdown"];
 
   connect() {
+    this.dismiss = (event) => {
+      if (event.key !== "Escape" && this.element.contains(event.target)) return;
+      // Escape is dismissed from the keyboard, with the cursor inside the very thing about to be
+      // hidden, so it has to be handed back somewhere visible. A click elsewhere has already put
+      // the cursor where the reader wanted it, and taking it back would be the rude version.
+      const stranded = event.key === "Escape" && this.element.contains(document.activeElement);
+      this.#close();
+      if (stranded) this.#action?.focus();
+    };
+    // Turbo restores the DOM exactly as it was cached — open menu, slid pane, measured height and
+    // all. A menu the reader left open on the page they navigated away from is not a state to
+    // come back into, and #layout only resets it when the fold itself changes.
+    this.#close();
+
     // The chip is measured in pixels, so anything that reflows a label has to re-measure it.
     // A ResizeObserver on the options catches every cause at once — the container resizing, a
     // longer label in another locale, and above all the webfont swap: `document.fonts.ready`
@@ -28,10 +46,6 @@ export default class extends Controller {
     // The room is the PARENT's, never the control's own: once collapsed the control is only as
     // wide as its trigger, and a control measuring itself would never learn that it fits again.
     this.observer.observe(this.element.parentElement);
-
-    this.dismiss = (event) => {
-      if (event.key === "Escape" || !this.element.contains(event.target)) this.#close();
-    };
   }
 
   disconnect() {
@@ -39,14 +53,43 @@ export default class extends Controller {
     this.#listen(false);
   }
 
-  // Opening is the collapsed control's only job. A click on an option is that option's own
-  // business — this just shuts the menu behind it.
+  // Opening is the collapsed control's only job. A click on anything inside is that control's
+  // own business — this only decides what happens to the box behind it.
   toggle(event) {
     if (!this.#collapsed) return;
-    if (event.target.closest(".segmented__option")) return this.#close();
+    // The action slides the box to its own list and back slides it home. Both leave it open.
+    if (event.target.closest(".segmented__option--action, .segmented__back")) return;
+    // Everything else in here navigates, so the box has done its job.
+    if (event.target.closest(".segmented__option, .segmented__submenu-item")) return this.#close();
 
     this.element.classList.toggle("is-open");
     this.#listen(this.element.classList.contains("is-open"));
+    this.#size();
+  }
+
+  // The action OPENS its list rather than following its href — and puts it away again, because
+  // the control the reader opened it with is the one they reach for to close it.
+  open(event) {
+    event.preventDefault();
+    if (this.element.classList.contains("is-submenu")) return this.back();
+
+    this.element.classList.add("is-submenu");
+    // Expanded, that list is a box of its own, so the options menu has nothing to do with it.
+    if (!this.#collapsed) this.element.classList.remove("is-open");
+    event.currentTarget.setAttribute("aria-expanded", "true");
+    this.#listen(true);
+    this.#size();
+  }
+
+  // Back to the options. Focus comes with it: the pane it was in is only slid out of sight, and
+  // a cursor parked there is one the reader cannot see. Dismissing still listens while the
+  // options menu itself is open — closing the list is not closing the menu.
+  back() {
+    this.element.classList.remove("is-submenu");
+    this.#action?.setAttribute("aria-expanded", "false");
+    this.#listen(this.element.classList.contains("is-open"));
+    this.#size();
+    this.#action?.focus();
   }
 
   // No preventDefault: a link-based group must still navigate. For those the class change is
@@ -87,8 +130,34 @@ export default class extends Controller {
   }
 
   #close() {
-    this.element.classList.remove("is-open");
+    this.element.classList.remove("is-open", "is-submenu");
+    this.#action?.setAttribute("aria-expanded", "false");
     this.#listen(false);
+    this.#size();
+  }
+
+  get #action() {
+    return this.element.querySelector(".segmented__option--action[aria-expanded]");
+  }
+
+  // The collapsed box holds one pane at a time and the two are different heights, so it cannot
+  // be sized by its content: `auto` does not animate, and the taller pane would leave the
+  // shorter one sitting in a half-empty box. Measured in pixels, like the chip.
+  #size() {
+    if (!this.hasDropdownTarget) return;
+
+    const sub = this.element.classList.contains("is-submenu");
+    const menu = this.element.querySelector(".segmented__menu");
+    const submenu = this.element.querySelector(".segmented__submenu");
+    // The pane that is off screen is CLIPPED, not hidden, so without this its links stay in the
+    // tab order behind the pane that is on screen — and a reader tabbing through them is
+    // focusing things nobody can see. Expanded there is only ever one of the two on screen.
+    submenu?.toggleAttribute("inert", !sub);
+    menu.toggleAttribute("inert", this.#collapsed && sub);
+
+    const pane = sub ? submenu : menu;
+    const showing = this.#collapsed && (sub || this.element.classList.contains("is-open"));
+    this.dropdownTarget.style.height = showing && pane ? `${pane.offsetHeight}px` : "";
   }
 
   #listen(on) {

--- a/app/views/shared/_segmented.html.erb
+++ b/app/views/shared/_segmented.html.erb
@@ -3,9 +3,11 @@
     locals:
       options - [{ value:, label:, active:, href: (optional), data: (optional) }]
       label   - what the group is, for a screen reader
-      action  - optional {href:, label:, icon:, data:}. A trailing ACTION rather than another
+      action  - optional {href:, label:, icon:, data:, menu:}. A trailing ACTION rather than another
                 option. `icon` is a partial path and is REQUIRED — the glyph IS the control, and
                 an action without one is an empty pill; `label` names it for a screen reader.
+                `menu` is optional [{label:, href:, icon:, data:}]: given one, the action OPENS
+                that list instead of following its href.
       fluid   - false (default): identical columns, right when the labels are the same length and
                 a chip that changed width would read as a glitch (VALUE / RETURN).
                 true: every option takes the width of its own label and the chip follows — the
@@ -25,41 +27,65 @@
             aria: { label: label },
             data: { controller: 'segmented', action: 'click->segmented#toggle' }.merge(local_assigns[:data] || {}) do %>
   <span class="segmented__thumb" data-segmented-target="thumb"></span>
-  <%# display: contents while the control is expanded, a menu box once it has collapsed. %>
-  <div class="segmented__menu">
-    <% options.each do |option| %>
-      <% classes = ['segmented__option', ('is-on' if option[:active])] %>
-      <% shared = { value: option[:value] }.merge(option[:data] || {}).merge('segmented-target': 'option') %>
-      <% if links %>
-        <%# Select but no arrow actions: a link group is tabbed through, not arrowed through, and
-            the server still decides what is current — this only moves the chip while the click
-            navigates, so the switch animates instead of teleporting with the new page. The
-            controller ignores a modified click, which opens a new tab and changes nothing here. %>
-        <%= link_to option[:label], option[:href], class: classes,
-                                                   aria: { current: ('page' if option[:active]) },
-                                                   data: shared.merge(action: 'segmented#select') %>
-      <% else %>
-        <%= tag.button option[:label], type: 'button', class: classes, role: 'radio',
-                                       aria: { checked: option[:active].present? },
-                                       tabindex: option[:active] ? 0 : -1,
-                                       data: shared.merge(action: 'segmented#select keydown->segmented#keys') %>
+  <%# display: contents while the control is expanded — the panes and the box around them are
+      only boxes once the control has collapsed and they become the dropdown. %>
+  <div class="segmented__dropdown" data-segmented-target="dropdown">
+    <div class="segmented__panes">
+      <div class="segmented__pane segmented__menu">
+        <% options.each do |option| %>
+          <% classes = ['segmented__option', ('is-on' if option[:active])] %>
+          <% shared = { value: option[:value] }.merge(option[:data] || {}).merge('segmented-target': 'option') %>
+          <% if links %>
+            <%# Select but no arrow actions: a link group is tabbed through, not arrowed through, and
+                the server still decides what is current — this only moves the chip while the click
+                navigates, so the switch animates instead of teleporting with the new page. The
+                controller ignores a modified click, which opens a new tab and changes nothing here. %>
+            <%= link_to option[:label], option[:href], class: classes,
+                                                       aria: { current: ('page' if option[:active]) },
+                                                       data: shared.merge(action: 'segmented#select') %>
+          <% else %>
+            <%= tag.button option[:label], type: 'button', class: classes, role: 'radio',
+                                           aria: { checked: option[:active].present? },
+                                           tabindex: option[:active] ? 0 : -1,
+                                           data: shared.merge(action: 'segmented#select keydown->segmented#keys') %>
+          <% end %>
+        <% end %>
+        <%# An ACTION, not an option: it DOES something instead of selecting something. It belongs to
+            the set it acts on, so it rides inside the menu — last, which puts it at the end of the
+            track and at the foot of the list once the control has folded. It carries the option's
+            class for the look and NONE of its wiring: no segmented-target, so the controller never
+            measures it, never parks the chip on it and never arrows onto it. %>
+        <% if action %>
+          <%# The label is the ATTRIBUTE, not text in the track: sitting at the end of the row it adds
+              to, the glyph is read in that company and needs no caption. A screen reader has no such
+              company, so the name has to come from somewhere. %>
+          <%= link_to action[:href], class: 'segmented__option segmented__option--action',
+                                     data: (action[:data] || {}).merge(action[:menu] ? { action: 'segmented#open' } : {}),
+                                     aria: { label: action[:label], expanded: (false if action[:menu]) } do %>
+            <%= render action[:icon] %>
+          <% end %>
+        <% end %>
+      </div>
+      <%# What the action opens. Expanded it is a box of its own hanging off the action; collapsed
+          it is the dropdown's second pane, one slide left behind the arrow that slides it back.
+          Either way the href on each row is the whole of its behaviour — this list navigates. %>
+      <% if action && action[:menu] %>
+        <div class="segmented__pane segmented__submenu">
+          <button type="button" class="segmented__back" data-action="segmented#back"
+                  aria-label="<%= t('button.back') %>">
+            <%= render 'svg/24x24_back' %>
+          </button>
+          <% action[:menu].each do |item| %>
+            <%= link_to item[:href], class: 'segmented__submenu-item', data: item[:data] do %>
+              <% if item[:icon] %>
+                <span class="segmented__submenu-icon"><%= render item[:icon] %></span>
+              <% end %>
+              <%= item[:label] %>
+            <% end %>
+          <% end %>
+        </div>
       <% end %>
-    <% end %>
-    <%# An ACTION, not an option: it DOES something instead of selecting something. It belongs to
-        the set it acts on, so it rides inside the menu — last, which puts it at the end of the
-        track and at the foot of the list once the control has folded. It carries the option's
-        class for the look and the click-closes-the-menu behaviour, and NONE of its wiring: no
-        segmented-target, so the controller never measures it, never parks the chip on it and
-        never arrows onto it. %>
-    <% if action %>
-      <%# The label is the ATTRIBUTE, not text in the track: sitting at the end of the row it adds
-          to, the glyph is read in that company and needs no caption. A screen reader has no such
-          company, so the name has to come from somewhere. %>
-      <%= link_to action[:href], class: 'segmented__option segmented__option--action',
-                                 data: action[:data], aria: { label: action[:label] } do %>
-        <%= render action[:icon] %>
-      <% end %>
-    <% end %>
+    </div>
   </div>
   <%= tag.span class: 'segmented__caret', aria: { hidden: true } do %>
     <%= render 'svg/16x16_down' %>

--- a/app/views/svg/_24x24_back.html.haml
+++ b/app/views/svg/_24x24_back.html.haml
@@ -1,2 +1,2 @@
-%svg.icon-24{xmlns: "http://www.w3.org/2000/svg", width: "24", height: "24", fill: "none"}
-  %path{stroke: "#2948A1", "stroke-linecap": "round", "stroke-linejoin": "round", "stroke-width": "2", d: "m10 19-7-7 7-7M3 12h18", style: "stroke:#2948A1;stroke:color(display-p3 .16 .2839 .6317);stroke-opacity:1"}
+%svg.icon-24{xmlns: "http://www.w3.org/2000/svg", viewbox: "0 0 24 24", fill: "none"}
+  %path{stroke: "currentColor", "stroke-linecap": "round", "stroke-linejoin": "round", "stroke-width": "2", d: "m10 19-7-7 7-7M3 12h18"}

--- a/app/views/tracker/_exchange_filters.html.erb
+++ b/app/views/tracker/_exchange_filters.html.erb
@@ -9,11 +9,17 @@
         keeps the control that says so. %>
     <% broken = @exchanges.any? { |exchange| !@exchanges_with_valid_keys.include?(exchange.id) && !exchange.retired? } %>
     <%# The + belongs to the venues it adds to, so it rides INSIDE the switch — a glyph stranded at
-        the far end of the row is a control the reader has to guess at. One destination either way:
-        the picker modal, which searches every venue we support and prints its fees. A dropdown of
-        its own would have to open inside the switch's own menu once that folds. %>
+        the far end of the row is a control the reader has to guess at. It opens the venues
+        themselves: a modal to pick one from is a page-sized answer to a one-tap question, and the
+        list is short enough to read whole. Each row goes straight to that venue's key form; the
+        picker modal stays the fallback for anyone arriving without a venue chosen. %>
     <% connect = { href: new_tracker_pick_exchange_path, label: t('tracker.connect_exchange'),
-                   icon: 'svg/24x24_plus', data: { turbo_frame: 'modal' } } %>
+                   icon: 'svg/24x24_plus', data: { turbo_frame: 'modal' },
+                   menu: @connectable_exchanges.map do |exchange|
+                     { label: exchange.name, icon: "svg/exchange-#{exchange.name_id}",
+                       href: new_tracker_add_api_key_path(exchange_id: exchange.id),
+                       data: { turbo_frame: 'modal' } }
+                   end.presence } %>
     <% if @exchanges.many? || broken %>
       <% options = [{ value: 'all', label: t('tracker.filters.all'), active: @scope_exchange.nil?,
                       href: tracker_path(from: params[:from], to: params[:to]) }] %>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -28,6 +28,7 @@ bg:
         start: 'Стартирай'
         stop: 'Спри'
         next: 'Напред'
+        back: 'Назад'
         connect: 'Свържи'
         reconnect: 'Добави нови ключове'
         understand: 'Разбрах!'

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -28,6 +28,7 @@ cs:
         start: 'Spustit'
         stop: 'Zastavit'
         next: 'Další'
+        back: 'Zpět'
         connect: 'Připojit'
         reconnect: 'Přidat nové klíče'
         understand: 'Rozumím!'

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -28,6 +28,7 @@ da:
         start: 'Start'
         stop: 'Stop'
         next: 'Næste'
+        back: 'Tilbage'
         connect: 'Forbind'
         reconnect: 'Tilføj nye nøgler'
         understand: 'Forstået!'

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -28,6 +28,7 @@ de:
         start: 'Starten'
         stop: 'Stoppen'
         next: 'Weiter'
+        back: 'Zurück'
         connect: "Verbinden"
         reconnect: 'Neue Schlüssel hinzufügen'
         get_started: Loslegen

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -28,6 +28,7 @@ el:
         start: 'Έναρξη'
         stop: 'Διακοπή'
         next: 'Επόμενο'
+        back: 'Πίσω'
         connect: 'Σύνδεση'
         reconnect: 'Προσθήκη νέων κλειδιών'
         understand: 'Κατάλαβα!'

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -28,6 +28,7 @@ en:
         start: 'Start'
         stop: 'Stop'
         next: 'Next'
+        back: 'Back'
         connect: 'Connect'
         reconnect: 'Add new keys'
         understand: 'Got it!'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -28,6 +28,7 @@ es:
         start: 'Empezar'
         stop: 'Detener'
         next: 'Siguiente'
+        back: 'Atrás'
         connect: 'Conectar'
         reconnect: 'Añadir nuevas claves'
         get_started: Empezar

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -28,6 +28,7 @@ fr:
         start: 'Démarrer'
         stop: 'Arrêter'
         next: 'Suivant'
+        back: 'Retour'
         connect: 'Connecter'
         reconnect: 'Ajouter de nouvelles clés'
         get_started: Commencer

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -28,6 +28,7 @@ it:
         start: 'Inizia'
         stop: 'Ferma'
         next: 'Avanti'
+        back: 'Indietro'
         connect: 'Connetti'
         reconnect: 'Aggiungi nuove chiavi'
         get_started: Inizia

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -28,6 +28,7 @@ nl:
         start: 'Starten'
         stop: 'Stoppen'
         next: 'Volgende'
+        back: 'Terug'
         connect: 'Verbinden'
         reconnect: 'Nieuwe sleutels toevoegen'
         get_started: Beginnen

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -28,6 +28,7 @@ pl:
         start: 'Start'
         stop: 'Stop'
         next: 'Dalej'
+        back: 'Wstecz'
         connect: 'Połącz'
         reconnect: 'Dodaj nowe klucze'
         get_started: Zacznij

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -28,6 +28,7 @@ pt:
         start: 'Iniciar'
         stop: 'Parar'
         next: 'Seguinte'
+        back: 'Voltar'
         connect: 'Conectar'
         reconnect: 'Adicionar novas chaves'
         get_started: Começar

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -28,6 +28,7 @@ ru:
         start: 'Начать'
         stop: 'Остановить'
         next: 'Далее'
+        back: 'Назад'
         connect: 'Подключить'
         reconnect: 'Добавить новые ключи'
         get_started: Начать

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -28,6 +28,7 @@ sk:
         start: 'Spustiť'
         stop: 'Zastaviť'
         next: 'Ďalej'
+        back: 'Späť'
         connect: 'Pripojiť'
         reconnect: 'Pridať nové kľúče'
         understand: 'Rozumiem!'

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -28,6 +28,7 @@ sv:
         start: 'Starta'
         stop: 'Stoppa'
         next: 'Nästa'
+        back: 'Tillbaka'
         connect: 'Anslut'
         reconnect: 'Lägg till nya nycklar'
         understand: 'Uppfattat!'

--- a/test/controllers/tracker_controller_test.rb
+++ b/test/controllers/tracker_controller_test.rb
@@ -351,6 +351,29 @@ class TrackerControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'taxOptions', disclaimer['data-tracker-export-target']
   end
 
+  # The + used to open a full-page picker. It now opens the venues themselves, so the list it
+  # offers has to be exactly the ones there is something to do with.
+  test 'the + offers the venues that can still be added, brokers first' do
+    # A second connected venue, so the switch — and the + inside it — renders at all.
+    create(:api_key, user: @user, exchange: create(:coinbase_exchange))
+    create(:kraken_exchange)
+    create(:alpaca_exchange)
+    create(:ibkr_exchange)
+    create(:bitmart_exchange)
+
+    get tracker_path
+
+    assert_response :success
+    venues = css_select('.segmented__submenu-item')
+    # Brokers lead, each group by name. Binance and Coinbase are already on the switch, and
+    # Bitmart is retired — there is nothing left to connect to.
+    assert_equal(['Alpaca', 'Interactive Brokers', 'Kraken'], venues.map { |a| a.text.strip })
+    assert_equal new_tracker_add_api_key_path(exchange_id: Exchange.find_by(name: 'Alpaca').id),
+                 venues.first['href']
+    # The + opens that list instead of following its href to the picker modal.
+    assert_equal 'segmented#open', css_select('.segmented__option--action').first['data-action']
+  end
+
   # A sync failure is persisted on the key but the banner was only ever broadcast, so a user who
   # reloaded the page saw a tracker that looked healthy while an exchange contributed nothing.
   test 'a persisted sync failure banners on page load' do


### PR DESCRIPTION
Connecting an exchange from the tracker opened a full-page modal — a search field, a fee table, and every venue we support — to answer a question with fifteen possible answers, of which only a handful are still open to the reader.

The **+** now opens those venues themselves.

- **Expanded**, the list is a box hanging off the + at the end of the track.
- **Collapsed**, the switch is already a dropdown, so the list becomes that dropdown's second pane: the + slides it in, a back arrow slides it home. One box, so the reader never loses what they opened.

Each row goes straight to that venue's key form. The picker modal stays reachable for anyone arriving without a venue chosen.

### What the list contains

Venues that are `available`, not retired — there is nothing left to connect to — and not already on the switch. Brokers lead, each group by name: a stock venue is what somebody arriving from a stock holding is looking for, and there are only ever a few of them.

### Structure

The dropdown box moves off `.segmented__menu` onto a new `.segmented__dropdown`, which holds two panes. All three wrappers are `display: contents` while the control is expanded, so the track is laid out exactly as before — the options are still the grid's own items.

`shared/_segmented` grows one optional key: an `action` may carry a `menu:`, and when it does the action opens that list instead of following its `href`. Nothing else that renders a segmented control passes one, so nothing else changes.

The pane that is off screen is clipped rather than hidden, so it is marked `inert` — otherwise its links stay in the tab order behind the pane on screen. Back and Escape both hand focus back to the +; a click elsewhere leaves focus where the reader put it.

### Also fixed

- The segmented control was restored from Turbo's page cache with its menu still open — the control now clears that transient state on connect. This applied to every segmented control, not only this one.
- The folded control's action pill took its background from a `max-width` breakpoint, while the fold itself is measured. It now follows the fold.
- `svg/24x24_back` had its stroke hardcoded and no `viewBox`; it inherits `currentColor` and scales now. Nothing else rendered it.

### Tests

`bin/rails test` — 4691 runs, 17884 assertions, 0 failures. One new test covers the offered list: order, exclusions, the destination of a row, and that the + opens the list rather than navigating.
