### PR TITLE
Let a segmented control remember the choice, and open both charts on P/L

### DIFF
--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -20,10 +20,11 @@ export default class extends Controller {
   };
 
   connect() {
-    // The whole chart is broadcast-replaced every metrics cycle (~5 min), which destroys this
-    // controller and re-renders the switch on VALUE. Without somewhere outside the element to
-    // remember it, a user reading RETURN gets thrown back to VALUE while looking at it.
-    this.currentMode = this.#storedMode();
+    // PnL is what the chart opens on, and the switch is rendered on it. A reader who picked VALUE
+    // gets it back from the `segmented` control's own memory, which replays the choice as a click
+    // — including after the ~5-minute metrics broadcast that destroys this controller and
+    // re-renders the switch on its default.
+    this.currentMode = "pnl";
     // Seeded synchronously: the ResizeObserver below is debounced by 100ms, and a mode click
     // inside that window would otherwise rebuild with an undefined budget (Array(NaN) throws,
     // leaving the buttons in one mode and the summary in the other).
@@ -61,11 +62,6 @@ export default class extends Controller {
       }, 100); // 100ms delay
     });
     this.resizeObserver.observe(this.element);
-
-    // After the child control has connected, so the chip moves with it.
-    if (this.#pnlMode) {
-      requestAnimationFrame(() => this.element.querySelector('[data-value="pnl"]')?.click());
-    }
   }
 
   disconnect() {
@@ -91,7 +87,6 @@ export default class extends Controller {
     if (event.detail.value !== "value" && event.detail.value !== "pnl") return;
 
     this.currentMode = event.detail.value;
-    this.#remember(this.currentMode);
     this.#buildChart();
     this.#renderSummary();
   }
@@ -258,32 +253,6 @@ export default class extends Controller {
 
     const [value, invested] = this.#series;
     return value.map((amount, i) => (amount === null ? null : amount - invested[i]));
-  }
-
-  // Per tab, not per browser: a mode is a way of reading this page now, not a preference.
-  get #storageKey() {
-    return `bot-chart-mode:${this.botValue}`;
-  }
-
-  #storedMode() {
-    // Hiding balances leaves RETURN as the only mode — VALUE plots the money — so the stored
-    // choice is not consulted at all. Ahead of the try: a session that last read VALUE must not
-    // come back to it.
-    if (this.pnlOnlyValue) return "pnl";
-
-    try {
-      return sessionStorage.getItem(this.#storageKey) === "pnl" ? "pnl" : "value";
-    } catch {
-      return "value"; // storage can be denied outright (private mode, embedded webview)
-    }
-  }
-
-  #remember(mode) {
-    try {
-      sessionStorage.setItem(this.#storageKey, mode);
-    } catch {
-      // Not being able to remember the mode is not a reason to fail switching it.
-    }
   }
 
   // Requires an actual curve: the plot falls back to VALUE when there is none.

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -18,6 +18,11 @@ import { Controller } from "@hotwired/stimulus";
 // The trailing action can carry a list of its own. Expanded that list is a box hanging off the
 // action; collapsed it is the dropdown's second pane, which slides in over the options and back
 // out again — one box, two panes, so the reader never loses the thing they opened.
+//
+// Given a `data-segmented-key` it also REMEMBERS: the last choice comes back on the next visit,
+// through the same select path a click takes, so every consumer hears about it the only way it
+// knows how. Naming the key is what opts a control in — see the partial for why a control gets
+// one or does not.
 export default class extends Controller {
   static targets = ["thumb", "option", "dropdown"];
 
@@ -46,6 +51,9 @@ export default class extends Controller {
     // The room is the PARENT's, never the control's own: once collapsed the control is only as
     // wide as its trigger, and a control measuring itself would never learn that it fits again.
     this.observer.observe(this.element.parentElement);
+
+    // Last, so the click it may fire lands on a control that is wired and measured.
+    this.#restore();
   }
 
   disconnect() {
@@ -108,7 +116,45 @@ export default class extends Controller {
       }
     });
     this.#layout();
+    this.#remember(chosen.dataset.value);
     this.dispatch("change", { detail: { value: chosen.dataset.value } });
+  }
+
+  // --- memory -----------------------------------------------------------------------
+  //
+  // A CLICK, not a state assignment: the choice has to travel the same path a real one does, or
+  // the chart would come back on a mode its curve is not drawn in and the log on a tab its rows
+  // are not filtered to. Everything downstream is already listening for that.
+  //
+  // A remembered value whose option is not here is no value at all — a bot's log loses the tab
+  // its last order left, a range outlives the history it fitted — and the server's own default
+  // stands untouched.
+  #restore() {
+    const stored = this.#stored;
+    if (!stored) return;
+
+    const option = this.optionTargets.find((target) => target.dataset.value === stored);
+    if (option && !option.classList.contains("is-on")) option.click();
+  }
+
+  get #stored() {
+    if (!this.element.dataset.segmentedKey) return null;
+
+    try {
+      return localStorage.getItem(`segmented:${this.element.dataset.segmentedKey}`);
+    } catch {
+      return null; // storage can be denied outright (private mode, embedded webview)
+    }
+  }
+
+  #remember(value) {
+    if (!this.element.dataset.segmentedKey) return;
+
+    try {
+      localStorage.setItem(`segmented:${this.element.dataset.segmentedKey}`, value);
+    } catch {
+      // Not being able to remember a choice is not a reason to fail making it.
+    }
   }
 
   // A single-choice group is arrowed through, not tabbed through.

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -51,22 +51,24 @@
         bot__chart_pnl_only_value: hide_money
       } do %>
         <%# The switch sits on the date line, opposite it: one row across the top of the plot.
-            VALUE always climbs for a DCA bot because the money going in climbs; PnL makes the
-            invested line the zero line, so the curve is performance with the deposits divided
-            out. Both modes carry the SAME headline — only the curve changes — which is why
-            neither needs a caption. A bot that has never held anything has no curve to offer,
-            and a switch with one usable side is furniture — which is also why hiding balances
-            takes the switch away rather than disabling it: VALUE is the money view. %>
+            PnL FIRST and on by default: VALUE always climbs for a DCA bot because the money going
+            in climbs, which makes it the flattering view rather than the informative one; PnL
+            makes the invested line the zero line, so the curve is performance with the deposits
+            divided out — the question the reader came with. Both modes carry the SAME headline —
+            only the curve changes — which is why neither needs a caption. A bot that has never
+            held anything has no curve to offer, and a switch with one usable side is furniture —
+            which is also why hiding balances takes the switch away rather than disabling it:
+            VALUE is the money view. %>
         <div class="widget--chart__head">
           <div class="widget--chart__modes" data-action="segmented:change->bot--chart#mode">
             <% if !hide_money && metrics[:chart][:series][1].any? { |spent| spent.to_f.positive? } %>
             <%# Fluid: "Value" and the locales' Profit/Loss wording are nowhere near the same
                 width, and equal columns would give both the width of the longer one — wide
                 enough to push the header off a phone. %>
-            <%= render 'shared/segmented', fluid: true,
+            <%= render 'shared/segmented', fluid: true, key: 'chart-mode',
                        label: t('bot.details.stats.chart.modes'),
-                       options: [{ value: 'value', label: t('bot.details.stats.chart.value'), active: true },
-                                 { value: 'pnl', label: t('bot.details.stats.chart.pnl') }] %>
+                       options: [{ value: 'pnl', label: t('bot.details.stats.chart.pnl'), active: true },
+                                 { value: 'value', label: t('bot.details.stats.chart.value') }] %>
             <% end %>
           </div>
           <div class="widget--chart__summary" data-bot--chart-target="summary">

--- a/app/views/bots/orders/_order_filters.html.erb
+++ b/app/views/bots/orders/_order_filters.html.erb
@@ -18,7 +18,7 @@
      data-order-filter-default="<%= default_order_filter(tabs) %>"
      data-action="segmented:change->order-filter#filter">
   <% if show_filters %>
-    <%= render 'shared/segmented', fluid: true, label: t('order_filters.all'),
+    <%= render 'shared/segmented', fluid: true, label: t('order_filters.all'), key: 'order-filter',
                options: tabs.select(&:last).map { |value, label, _|
                  { value: value, label: label, active: order_filter == value }
                } %>

--- a/app/views/shared/_segmented.html.erb
+++ b/app/views/shared/_segmented.html.erb
@@ -8,6 +8,11 @@
                 an action without one is an empty pill; `label` names it for a screen reader.
                 `menu` is optional [{label:, href:, icon:, data:}]: given one, the action OPENS
                 that list instead of following its href.
+      key     - optional. What the reader's choice is remembered under, in localStorage. Naming one
+                is what opts a control into memory: the option SET is no key (a bot gains a tab, a
+                range outgrows the history) and neither is the translated label. NAVIGATION groups
+                take none — their state is the URL, and a remembered pick would override the link
+                the reader followed.
       fluid   - false (default): identical columns, right when the labels are the same length and
                 a chip that changed width would read as a glitch (VALUE / RETURN).
                 true: every option takes the width of its own label and the chip follows — the
@@ -25,7 +30,8 @@
 <%= tag.div class: ['segmented', ('segmented--fluid' if fluid)],
             role: (links ? nil : 'radiogroup'),
             aria: { label: label },
-            data: { controller: 'segmented', action: 'click->segmented#toggle' }.merge(local_assigns[:data] || {}) do %>
+            data: { controller: 'segmented', action: 'click->segmented#toggle',
+                    segmented_key: local_assigns[:key] }.merge(local_assigns[:data] || {}) do %>
   <span class="segmented__thumb" data-segmented-target="thumb"></span>
   <%# display: contents while the control is expanded — the panes and the box around them are
       only boxes once the control has collapsed and they become the dropdown. %>

--- a/app/views/tracker/_chart.html.erb
+++ b/app/views/tracker/_chart.html.erb
@@ -32,8 +32,8 @@
       controller: 'bot--chart',
       action: 'mouseover@document->bot--chart#focus mouseleave@document->bot--chart#blur ' \
               'click@document->bot--chart#select',
-      # Not a bot, but the controller keys its remembered mode by this — a stable value keeps the
-      # tracker's choice out of every bot's.
+      # Not a bot, but the controller pins a hovered asset by this — a stable value keeps the
+      # tracker's pin out of every bot's.
       bot__chart_bot_value: 0,
       bot__chart_quote_value: @denomination.currency,
       bot__chart_decimals_value: 2,
@@ -53,15 +53,16 @@
         <div class="widget--chart__modes" data-action="segmented:change->bot--chart#mode">
           <% unless hide_money %>
             <% if series[1].any?(&:positive?) %>
-              <%= render 'shared/segmented', fluid: true,
+              <%= render 'shared/segmented', fluid: true, key: 'chart-mode',
                          label: t('bot.details.stats.chart.modes'),
-                         options: [{ value: 'value', label: t('bot.details.stats.chart.value'), active: true },
-                                   { value: 'pnl', label: t('bot.details.stats.chart.pnl') }] %>
+                         options: [{ value: 'pnl', label: t('bot.details.stats.chart.pnl'), active: true },
+                                   { value: 'value', label: t('bot.details.stats.chart.value') }] %>
             <% end %>
             <% ranges = chart_range_options(history) %>
             <% if ranges.any? %>
               <div class="filters" data-action="segmented:change->bot--chart#range">
-                <%= render 'shared/segmented', label: t('tracker.range.all'), options: ranges %>
+                <%= render 'shared/segmented', label: t('tracker.range.all'), key: 'chart-range',
+                           options: ranges %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -9,7 +9,7 @@
     `order-filter` scope, which is what lets one control filter the rows underneath it. %>
 <div class="tracker-record" data-controller="tracker--record">
   <div class="tracker-record__switch filters" data-action="segmented:change->tracker--record#mark segmented:change->tracker--record#show segmented:change->tracker--record#hold">
-    <%= render 'shared/segmented', fluid: true, label: t('tracker.positions'),
+    <%= render 'shared/segmented', fluid: true, label: t('tracker.positions'), key: 'tracker-record',
                options: [{ value: 'pos', label: t('tracker.positions'), active: true },
                          { value: 'tx', label: t('tracker.transactions') }] %>
   </div>
@@ -21,7 +21,8 @@
         the offset the browser has already clamped, which is the jump itself. %>
     <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if type_filters.any? %>
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'), options: type_filters %>
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'),
+                   key: 'tracker-type', options: type_filters %>
       <% end %>
     </div>
     <div class="tracker-record__table widget widget--table widget--table--tracker">
@@ -66,7 +67,8 @@
         the offset the browser has already clamped, which is the jump itself. %>
     <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if status_filters.any? %>
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'), options: status_filters %>
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'),
+                   key: 'tracker-status', options: status_filters %>
       <% end %>
     </div>
     <div class="tracker-record__table widget widget--table widget--table--tracker tracker-positions">

--- a/app/views/tracker/imports/new.html.erb
+++ b/app/views/tracker/imports/new.html.erb
@@ -14,7 +14,7 @@
           renders buttons, so the hidden field beside it is what the form posts. %>
       <div class="filters" data-controller="form--segmented-field"
            data-action="segmented:change->form--segmented-field#set">
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.import.format'),
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.import.format'), key: 'import-format',
                    options: Import::Run::FORMATS.keys.map { |key|
                      { value: key, label: t("tracker.import.format_#{key}"),
                        active: key == Import::Run::DEFAULT_FORMAT }

--- a/test/controllers/bots/segmented_filters_test.rb
+++ b/test/controllers/bots/segmented_filters_test.rb
@@ -27,6 +27,9 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     assert_select 'a.segmented__option.is-on[aria-current="page"]', 1 do |option|
       assert_equal 'active', option.first['data-value']
     end
+    # No memory on a link group: the filter is in the URL, and a remembered one would send the
+    # reader somewhere other than the page they asked for.
+    assert_select '.segmented[data-segmented-key]', 0
   end
 
   test 'the order filters are a fluid segmented control the order-filter controller still drives' do
@@ -42,6 +45,8 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     assert_select 'button.segmented__option', 3
     assert_select '[data-value="all"].is-on', 1
     assert_select 'button[data-value="other"]', 1
+    # The log tab, on the other hand, is a way of reading and is remembered.
+    assert_select '.segmented[data-segmented-key="order-filter"]', 1
   end
 
   test 'a bot with only one category of orders shows no filter at all' do

--- a/test/controllers/bots/show_chart_test.rb
+++ b/test/controllers/bots/show_chart_test.rb
@@ -95,8 +95,9 @@ class Bots::ShowChartTest < ActionDispatch::IntegrationTest
   end
 
   # A radiogroup, not two independently-pressable toggles: the chart is in one mode at a time.
-  # VALUE is the one showing, so it is the one checked and the only one in the tab order.
-  test 'chart offers the value/pnl switch with value selected' do
+  # P/L is the one showing, so it is the one checked and the only one in the tab order — the
+  # question a DCA chart answers is how the money did, not how much of it went in.
+  test 'chart offers the pnl/value switch with pnl selected' do
     data = @bot.metrics.deep_dup
     data[:chart][:labels] = [Time.utc(2026, 1, 1), Time.utc(2026, 2, 1)]
     data[:chart][:series] = [[100.0, 260.0], [100.0, 200.0]]
@@ -106,8 +107,13 @@ class Bots::ShowChartTest < ActionDispatch::IntegrationTest
 
     assert_select '#chart [role="radiogroup"]', 1
     assert_select '#chart [role="radio"]', 2
-    assert_select '#chart [role="radio"][data-value="value"][aria-checked="true"][tabindex="0"]', 1
-    assert_select '#chart [role="radio"][data-value="pnl"][aria-checked="false"][tabindex="-1"]', 1
+    assert_select '#chart [role="radio"][data-value="pnl"][aria-checked="true"][tabindex="0"]', 1
+    assert_select '#chart [role="radio"][data-value="value"][aria-checked="false"][tabindex="-1"]', 1
+    # First in the track as well as first on screen: the default sits at the head of the row.
+    assert_select '#chart .segmented__menu > *:first-child[data-value="pnl"]', 1
+    # And the reader's own choice outlives the page: one key, so a mode picked on one bot is the
+    # mode every chart opens on.
+    assert_select '#chart .segmented[data-segmented-key="chart-mode"]', 1
     # The shared control owns the chip and the aria; the chart only listens for the choice.
     assert_select '#chart [data-action="segmented:change->bot--chart#mode"]', 1
     # Fluid: "Value" and the locales' Profit/Loss wording are nowhere near the same width, and

--- a/test/integration/tracker_history_test.rb
+++ b/test/integration/tracker_history_test.rb
@@ -37,17 +37,23 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
     assert_equal 3, JSON.parse(node['data-bot--chart-labels-value']).size
     assert_equal [[31_000.0, 32_000.0, 33_000.0], [30_000.0, 30_000.0, 30_000.0]], JSON.parse(node['data-bot--chart-series-value'])
     assert_equal [1_000.0, 2_000.0, 3_000.0], JSON.parse(node['data-bot--chart-pnl-value'])
-    assert_equal '0', node['data-bot--chart-bot-value'], 'not a bot — a stable key for the mode memory'
+    assert_equal '0', node['data-bot--chart-bot-value'], 'not a bot — a stable id for the asset pin'
     assert_equal 'USD', node['data-bot--chart-quote-value']
     assert_equal 'false', node['data-bot--chart-pnl-only-value']
     assert_select '.widget--chart__plot canvas[data-bot--chart-target="analyzerChart"]'
-    assert_select '.widget--chart__modes[data-action*="bot--chart#mode"] > .segmented .segmented__option[data-value="pnl"]'
+    # P/L first and P/L on: the tracker chart opens on the same mode a bot's does, under the same
+    # remembered key — one preference, not one per chart.
+    assert_select '.widget--chart__modes[data-action*="bot--chart#mode"] > .segmented[data-segmented-key="chart-mode"]' do
+      assert_select '.segmented__menu > *:first-child.is-on[data-value="pnl"]', 1
+      assert_select '.segmented__option[data-value="value"]:not(.is-on)', 1
+    end
     # Both controls on the head line, opposite the readout: the mode redraws the curve, the range
     # narrows the window, and neither belongs below the plot.
     assert_select '.widget--chart__head > .widget--chart__modes', 1
     assert_select '.widget--chart__ranges', 0
     assert_select '.widget--chart__modes .filters[data-action*="bot--chart#range"] > .segmented .segmented__option[data-value="30"]'
-    assert_select '.widget--chart__modes .filters[data-action*="bot--chart#range"] > .segmented .segmented__option.is-on[data-value="all"]'
+    assert_select '.widget--chart__modes .filters[data-action*="bot--chart#range"] > ' \
+                  '.segmented[data-segmented-key="chart-range"] .segmented__option.is-on[data-value="all"]'
     assert_select '.widget__placeholder', false
   end
 

--- a/test/integration/tracker_import_test.rb
+++ b/test/integration/tracker_import_test.rb
@@ -46,6 +46,9 @@ class TrackerImportTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".segmented__option[data-value='deltabadger'].is-on"
     assert_select ".segmented__option[data-value='binance']"
+    # Whoever imports from one venue imports from it again: the format is remembered, and the
+    # remembered pick moves the hidden field with it.
+    assert_select ".segmented[data-segmented-key='import-format']", 1
     # The buttons post nothing on their own; the hidden field is what carries the choice.
     assert_select "input[name=format][value='deltabadger']"
     # Everything else is derived, so nothing else is asked.

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -178,6 +178,10 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
 
     assert_select '.tracker-record .filters > .segmented .segmented__option[data-value="tx"]'
     assert_select '.tracker-record .filters > .segmented .segmented__option[data-value="pos"]'
+    # Every one of these three is a way of reading the page, so every one of them is remembered.
+    assert_select '.tracker-record__switch > .segmented[data-segmented-key="tracker-record"]', 1
+    assert_select '.tracker-record .segmented[data-segmented-key="tracker-type"]', 1
+    assert_select '.tracker-record .segmented[data-segmented-key="tracker-status"]', 1
     assert_select '.tracker-record [data-controller~="order-filter"]', 2
     # The types this account actually holds, in the ledger's own order — not a fixed five. A
     # transfer option appears only once a linked pair is on the page.
@@ -337,6 +341,9 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     get tracker_path(exchange_id: @binance.id)
 
     assert_select '.tracker-exchanges a.segmented__option[aria-current="page"]', text: 'Binance'
+    # The scope is in the URL, so it is not in storage as well: a remembered venue would override
+    # the link the reader followed here.
+    assert_select '.tracker-exchanges .segmented[data-segmented-key]', 0
     assert_select '.tracker-holdings__row', 1
     assert_select '.tracker-holdings__row b', text: 'BTC'
     assert_select 'tr.tracker-row td', text: 'ETH', count: 0

--- a/test/views/segmented_test.rb
+++ b/test/views/segmented_test.rb
@@ -65,6 +65,23 @@ class SegmentedTest < ActionView::TestCase
     assert_select 'a[data-action="segmented#select"]', 1
   end
 
+  # The control remembers the reader's last choice, and the KEY is what it remembers it under.
+  # Not the option set — a bot gains a tab, a range outgrows the history — and not the aria label,
+  # which is translated. So the call site names it, and naming it is what opts the control in.
+  test 'a key is what the choice is remembered under' do
+    render_segmented(options: buttons, key: 'chart-mode')
+
+    assert_select '.segmented[data-segmented-key="chart-mode"]', 1
+  end
+
+  # Navigation has no choice to remember: the URL is the choice. A control that re-picked a
+  # remembered one on arrival would override the link the reader actually followed.
+  test 'no key, no memory' do
+    render_segmented(options: buttons)
+
+    assert_select '.segmented[data-segmented-key]', 0
+  end
+
   test 'the label names the group for a screen reader' do
     render_segmented(options: buttons, label: 'Chart mode')
 


### PR DESCRIPTION
Two changes to the segmented control and the two charts that use it.

## The control remembers the choice

`shared/_segmented` takes an optional `key`, rendered as `data-segmented-key`.
That is what the reader's choice is remembered under in `localStorage`. On
connect the controller replays the stored value as a real click, so the chip
moves and `segmented:change` fires through the wiring every consumer already
had — the chart redraws, the log re-filters, the hidden form field follows.
Nothing downstream changed.

A stored value whose option is no longer on the page is ignored and the
server's own default stands: a bot loses the tab its last order was in, a
range outlives the history it fitted.

Naming the key is what opts a control in. The option set is no key — it
changes with the data — and neither is the label, which is translated. Keys
in use: `chart-mode`, `chart-range`, `order-filter`, `tracker-record`,
`tracker-type`, `tracker-status`, `import-format`.

Three controls deliberately have no key:

- the bots-list filter and the tracker's exchange scope are **links**. The URL
  is the choice, and a remembered one would override the link the reader
  followed.
- the import dialog's "which account did this file come from" is a **per-file
  answer**. A remembered wrong one would file one venue's history under
  another.

This also replaces the bot chart's own copy of the same idea, which was per
bot and per tab. The mode is now one preference shared by every chart.

## Both charts open on P/L

Value always climbs for a DCA bot, because the money going in climbs — the
flattering view rather than the informative one. P/L puts the invested line at
zero, so the curve is performance with the deposits divided out. P/L is now
first in the track and the mode the charts open on; Value is one click away and
remembered like anything else.

## Tests

The Ruby side is covered: the key renders where it should and is absent where
it should be, and both charts render P/L first and selected. The restore click
itself has no harness in this repo and was checked in the browser — a choice
made on each control, then a reload, then the choice back with the chip placed
and the tables actually filtered.
