### PR TITLE
Mark the buys under the bot chart with the assets they bought

### DIFF
--- a/app/assets/stylesheets/new/_toggle.sass
+++ b/app/assets/stylesheets/new/_toggle.sass
@@ -129,6 +129,18 @@ input[type=checkbox]
     .label
         font-size: 2rem
 
+// A toggle and its label on ONE line, the label being the hit area: the tracker's "Show cash"
+// and the chart's "Show orders" are the same control in two places, and were two copies of the
+// same five lines drifting apart. Opt-in rather than `label:has(> .toggle)`, which outranks
+// `.toggle-group__label` on specificity and would re-align every settings widget — those align
+// to `flex-start` on purpose, so a label running to two lines keeps its switch on the first.
+.toggle-inline
+    display: flex
+    align-items: center
+    gap: 1rem
+    cursor: pointer
+    white-space: nowrap
+
 .bot-option-info
     font-size: 1.75rem
     font-weight: 500

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -163,6 +163,17 @@ $stack-open: 0.2s ease-out
                     height: 100%
                     opacity: 0
                     transition: opacity $stack-open
+            // The purchase standing up out of its logo, drawn only while one asset is in view.
+            // Rises from the disc's top edge, so the disc reads as its foot rather than something
+            // the bar passes through.
+            &__bar
+                position: absolute
+                bottom: 100%
+                left: 50%
+                width: 0.75rem
+                margin-left: -0.375rem
+                border-radius: 0.375rem 0.375rem 0 0
+                pointer-events: none
                 // `of-type`, NOT `last-child`: the card is the stack's last child, so the top
                 // mark — a span among spans — is the last of ITS type and nothing else is.
                 &:last-of-type .asset-logo

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -113,22 +113,24 @@
                 font-size: 2.5rem
                 line-height: 2.5rem
         &__plot
-            width: 100%
-            aspect-ratio: 10 / 2
-        // The buys under the plot. Absolutely positioned from the chart's x scale, so this box
-        // only has to be the same width as the canvas and as tall as the tallest CLOSED stack —
-        // the controller sets that height, and an empty row collapses to nothing.
-        &__buys
             position: relative
             width: 100%
-            // Anchored at the BOTTOM, so opening a stack lifts its slivers up over the plot
-            // instead of pushing the page around: the big buy wearing the logo never moves.
+            aspect-ratio: 10 / 2
+        // The buys, hanging off the FLOOR of the plot they belong to. The row has no height of
+        // its own — the stacks are anchored to its baseline and grow upward over the curve — so
+        // turning the marks on never moves the chart, the toggle under it, or the page.
+        &__buys
+            position: absolute
+            left: 0
+            right: 0
+            bottom: 0
+            height: 0
             &__stack
                 position: absolute
                 bottom: 0
                 display: flex
                 flex-direction: column
-                // The open stack is drawn over its neighbours, not woven between them.
+                // The open stack, and its card, are drawn over the neighbours either side.
                 &:hover
                     z-index: 2
             // One buy. The disc is the asset's colour and is always there; the logo on top of it
@@ -143,7 +145,7 @@
                 border-radius: 50%
                 box-shadow: var(--shadow-paper)
                 // Closed, each mark behind the top one shows a 0.5rem sliver; open, 1rem of each.
-                // `LOGO_STEP` in the controller measures the closed box from the same number.
+                // `LOGO_STEP` in the controller measures the closed stack from the same number.
                 + .widget--chart__buys__mark
                     margin-top: -1.5rem
                 .asset-logo
@@ -153,20 +155,59 @@
                     height: 100%
                     opacity: 0
                     transition: opacity 0.15s ease-out
-                &:last-child .asset-logo
+                // `of-type`, NOT `last-child`: the card is the stack's last child, so the top
+                // mark — a span among spans — is the last of ITS type and nothing else is.
+                &:last-of-type .asset-logo
                     opacity: 1
             &__stack:hover &__mark
                 + .widget--chart__buys__mark
                     margin-top: -1rem
                 .asset-logo
                     opacity: 1
-            // The bubble is a summary, not a sentence: left-aligned lines, its own line height.
+            // The card sits BESIDE the stack, not under it: the stack unfolds upward over the
+            // plot, and a card below would be the one thing covering the curve the reader is
+            // reading. Held open by the stack's own :hover, so moving between marks rewrites it
+            // rather than dismissing it.
             &__tip
-                text-align: center
-                line-height: 1.6
+                position: absolute
+                left: 100%
+                bottom: 0
+                margin-left: 1rem
+                opacity: 0
+                pointer-events: none
+                transition: opacity 0.1s ease-out
+                padding: 1.25rem 1.5rem
                 white-space: nowrap
+                text-align: left
+                line-height: 1.5
+                font-size: 1.75rem
+                font-weight: 600
+                // The dropdown's surface, so a card that appears over the page reads as the same
+                // kind of object as every other floating box here.
+                background: var(--dropdown-bg)
+                border-radius: 1rem
+                box-shadow: 0 0 0 0.125rem var(--dropdown-border) inset, 0 0.5rem 1rem 0 rgba(6, 26, 79, 0.10)
                 &__when
-                    opacity: 0.7
+                    color: var(--concrete)
+                    font-size: 1.5rem
+                &__price
+                    color: var(--concrete)
+            // Near the right edge there is no room on the right.
+            &__stack--flip &__tip
+                left: auto
+                right: 100%
+                margin-left: 0
+                margin-right: 1rem
+            &__stack:hover &__tip
+                opacity: 1
+        // The marks are a way of reading the chart, so their switch lives under it rather than
+        // beside the mode control, which changes what the curve IS.
+        &__orders
+            display: flex
+            justify-content: flex-end
+            .toggle-group
+                cursor: pointer
+                gap: 1rem
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -155,7 +155,7 @@ $stack-open: 0.2s ease-out
                 // Closed, each mark behind the top one shows a 0.5rem sliver; open, 1rem of each.
                 // `LOGO_STEP` in the controller measures the closed stack from the same number.
                 + .widget--chart__buys__mark
-                    margin-top: -1.5rem
+                    margin-top: -1.875rem
                 .asset-logo
                     position: absolute
                     inset: 0
@@ -190,6 +190,31 @@ $stack-open: 0.2s ease-out
                 line-height: 1.5
                 font-size: 1.75rem
                 font-weight: 600
+                // Every buy in the stack, all in ONE cell: the card takes the width and height of
+                // the widest and tallest of them, so swapping between marks never resizes it.
+                display: grid
+                &__buy
+                    grid-area: 1 / 1
+                    // Not `display: none` — a hidden block still has to claim its width, which is
+                    // the whole reason they are all here.
+                    visibility: hidden
+                    &.is-on
+                        visibility: visible
+                // The card opens with the asset, so the reader can see which mark they hit
+                // without matching a colour by eye.
+                &__logo
+                    display: block
+                    position: relative
+                    width: 2.5rem
+                    height: 2.5rem
+                    margin-bottom: 0.5rem
+                    border-radius: 50%
+                    box-shadow: var(--shadow-paper)
+                    .asset-logo
+                        position: absolute
+                        inset: 0
+                        width: 100%
+                        height: 100%
                 // The dropdown's surface, so a card that appears over the page reads as the same
                 // kind of object as every other floating box here.
                 background: var(--dropdown-bg)
@@ -213,6 +238,7 @@ $stack-open: 0.2s ease-out
         // Layout only — the switch itself is `.toggle-inline`, shared with the tracker's.
         &__orders
             display: flex
+            padding-top: 2rem
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -116,26 +116,57 @@
             width: 100%
             aspect-ratio: 10 / 2
         // The buys under the plot. Absolutely positioned from the chart's x scale, so this box
-        // only has to be the same width as the canvas and as tall as the tallest stack — the
-        // controller sets that height, and an empty row collapses to nothing.
+        // only has to be the same width as the canvas and as tall as the tallest CLOSED stack —
+        // the controller sets that height, and an empty row collapses to nothing.
         &__buys
             position: relative
             width: 100%
+            // Anchored at the BOTTOM, so opening a stack lifts its slivers up over the plot
+            // instead of pushing the page around: the big buy wearing the logo never moves.
             &__stack
                 position: absolute
-                top: 0
+                bottom: 0
                 display: flex
                 flex-direction: column
-                transform: translateX(-50%)
+                // The open stack is drawn over its neighbours, not woven between them.
+                &:hover
+                    z-index: 2
+            // One buy. The disc is the asset's colour and is always there; the logo on top of it
+            // is what fades in. Sorted smallest-first by the controller, so the LAST child — the
+            // biggest buy of the crowd, and the one painted over all the others — is the one
+            // showing a logo while the stack is closed.
+            &__mark
+                position: relative
+                flex: none
+                width: 2rem
+                height: 2rem
+                border-radius: 50%
+                box-shadow: var(--shadow-paper)
+                // Closed, each mark behind the top one shows a 0.5rem sliver; open, 1rem of each.
+                // `LOGO_STEP` in the controller measures the closed box from the same number.
+                + .widget--chart__buys__mark
+                    margin-top: -1.5rem
                 .asset-logo
-                    width: 2rem
-                    height: 2rem
-                    // Shingled: each logo covers 70% of the one above it, so a crowd of eleven
-                    // coins is a stack a third the height of eleven discs and still reads as
-                    // eleven. The step is 0.6rem — `LOGO_OVERLAP` in the controller measures the
-                    // box from the same number.
-                    + .asset-logo
-                        margin-top: -1.4rem
+                    position: absolute
+                    inset: 0
+                    width: 100%
+                    height: 100%
+                    opacity: 0
+                    transition: opacity 0.15s ease-out
+                &:last-child .asset-logo
+                    opacity: 1
+            &__stack:hover &__mark
+                + .widget--chart__buys__mark
+                    margin-top: -1rem
+                .asset-logo
+                    opacity: 1
+            // The bubble is a summary, not a sentence: left-aligned lines, its own line height.
+            &__tip
+                text-align: center
+                line-height: 1.6
+                white-space: nowrap
+                &__when
+                    opacity: 0.7
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -146,7 +146,11 @@ $stack-open: 0.2s ease-out
                 flex: none
                 width: 2rem
                 height: 2rem
-                border-radius: 50%
+                // With one asset in view the controller sets the height per purchase, and the
+                // mark becomes the bar: a rounded column standing out of the baseline. Capped
+                // here as well as there, so a bad number can never run up over the whole plot.
+                max-height: 5rem
+                border-radius: 1rem
                 box-shadow: var(--shadow-paper)
                 // One duration for everything a stack does — the marks sliding apart, their
                 // logos arriving, the card — so opening one reads as a single movement rather
@@ -156,24 +160,17 @@ $stack-open: 0.2s ease-out
                 // `LOGO_STEP` in the controller measures the closed stack from the same number.
                 + .widget--chart__buys__mark
                     margin-top: -1.875rem
+                // At the FOOT of the mark, not filling it: the mark grows upward out of the
+                // baseline, and a logo stretched to its height would make a tall purchase a tall
+                // logo. Square, so it stays a circle inside a column.
                 .asset-logo
                     position: absolute
-                    inset: 0
-                    width: 100%
-                    height: 100%
+                    bottom: 0
+                    left: 0
+                    width: 2rem
+                    height: 2rem
                     opacity: 0
                     transition: opacity $stack-open
-            // The purchase standing up out of its logo, drawn only while one asset is in view.
-            // Rises from the disc's top edge, so the disc reads as its foot rather than something
-            // the bar passes through.
-            &__bar
-                position: absolute
-                bottom: 100%
-                left: 50%
-                width: 0.75rem
-                margin-left: -0.375rem
-                border-radius: 0.375rem 0.375rem 0 0
-                pointer-events: none
                 // `of-type`, NOT `last-child`: the card is the stack's last child, so the top
                 // mark — a span among spans — is the last of ITS type and nothing else is.
                 &:last-of-type .asset-logo

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -115,6 +115,27 @@
         &__plot
             width: 100%
             aspect-ratio: 10 / 2
+        // The buys under the plot. Absolutely positioned from the chart's x scale, so this box
+        // only has to be the same width as the canvas and as tall as the tallest stack — the
+        // controller sets that height, and an empty row collapses to nothing.
+        &__buys
+            position: relative
+            width: 100%
+            &__stack
+                position: absolute
+                top: 0
+                display: flex
+                flex-direction: column
+                transform: translateX(-50%)
+                .asset-logo
+                    width: 2rem
+                    height: 2rem
+                    // Shingled: each logo covers 70% of the one above it, so a crowd of eleven
+                    // coins is a stack a third the height of eleven discs and still reads as
+                    // eleven. The step is 0.6rem — `LOGO_OVERLAP` in the controller measures the
+                    // box from the same number.
+                    + .asset-logo
+                        margin-top: -1.4rem
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -171,6 +171,16 @@ $stack-open: 0.2s ease-out
                     height: 2rem
                     opacity: 0
                     transition: opacity $stack-open
+                    // 2% further in than the 2.5% every logo is already cropped by. At 2rem a
+                    // source's own outer ring — a stray border, a hairline of background baked
+                    // into the file — is a pixel or two of noise around a small circle, and here
+                    // it sits against the mark's own colour where it reads as a rim. Eaten by the
+                    // crop rather than scaled, so the logo stays the size the layout expects.
+                    object-view-box: inset(4.5%)
+                    // The MARK casts the shadow; the logo lies on it. `.asset-logo` carries one
+                    // of its own for the tables, where it is the whole object — here that put a
+                    // second shadow inside the first. `!important` because the base rule is.
+                    box-shadow: none !important
                 // `of-type`, NOT `last-child`: the card is the stack's last child, so the top
                 // mark — a span among spans — is the last of ITS type and nothing else is.
                 &:last-of-type .asset-logo
@@ -223,6 +233,11 @@ $stack-open: 0.2s ease-out
                         inset: 0
                         width: 100%
                         height: 100%
+                        // Cropped like the marks', so the card shows the same face as the mark
+                        // the reader pointed at — and, like them, casting no shadow of its own
+                        // inside the disc that already casts one.
+                        object-view-box: inset(4.5%)
+                        box-shadow: none !important
                 // The dropdown's surface, so a card that appears over the page reads as the same
                 // kind of object as every other floating box here.
                 background: var(--dropdown-bg)

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -1,5 +1,9 @@
 @use "../variables" as *
 
+// How long a buy stack takes to open: the marks sliding apart, their logos arriving, and the
+// card. Named once so the three stay in step — they are one movement, not three.
+$stack-open: 0.2s ease-out
+
 .widget-group
     border-radius: 2rem
     overflow: hidden
@@ -144,6 +148,10 @@
                 height: 2rem
                 border-radius: 50%
                 box-shadow: var(--shadow-paper)
+                // One duration for everything a stack does — the marks sliding apart, their
+                // logos arriving, the card — so opening one reads as a single movement rather
+                // than three that happen to start together.
+                transition: margin-top $stack-open, opacity $stack-open
                 // Closed, each mark behind the top one shows a 0.5rem sliver; open, 1rem of each.
                 // `LOGO_STEP` in the controller measures the closed stack from the same number.
                 + .widget--chart__buys__mark
@@ -154,7 +162,7 @@
                     width: 100%
                     height: 100%
                     opacity: 0
-                    transition: opacity 0.15s ease-out
+                    transition: opacity $stack-open
                 // `of-type`, NOT `last-child`: the card is the stack's last child, so the top
                 // mark — a span among spans — is the last of ITS type and nothing else is.
                 &:last-of-type .asset-logo
@@ -175,7 +183,7 @@
                 margin-left: 1rem
                 opacity: 0
                 pointer-events: none
-                transition: opacity 0.1s ease-out
+                transition: opacity $stack-open
                 padding: 1.25rem 1.5rem
                 white-space: nowrap
                 text-align: left
@@ -204,10 +212,12 @@
         // beside the mode control, which changes what the curve IS.
         &__orders
             display: flex
-            justify-content: flex-end
-            .toggle-group
-                cursor: pointer
+            > label
+                display: flex
+                align-items: center
                 gap: 1rem
+                cursor: pointer
+                white-space: nowrap
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -210,14 +210,9 @@ $stack-open: 0.2s ease-out
                 opacity: 1
         // The marks are a way of reading the chart, so their switch lives under it rather than
         // beside the mode control, which changes what the curve IS.
+        // Layout only — the switch itself is `.toggle-inline`, shared with the tracker's.
         &__orders
             display: flex
-            > label
-                display: flex
-                align-items: center
-                gap: 1rem
-                cursor: pointer
-                white-space: nowrap
         // Spacing only — the control itself is .segmented. The switch is 4rem tall and the date
         // line beside it is 1.5rem at line-height 1.5 (2.25rem), so lifting it by half the
         // difference puts the two centre lines on the same row.

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -13,16 +13,12 @@ const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_tab
 // the reserved height, so guessing it wrong silently over-reserves the row and collapses marks
 // that do not visually overlap.
 const LOGO_SIZE = 16;
-// How far each mark behind the top one sticks out while the stack is closed: 0.5rem, the same
-// number `_widget.sass` shingles them by. Only the CLOSED step is needed here — opening a stack
-// is the stylesheet's business, and deliberately does not resize the row.
-const LOGO_STEP = 4;
 // Where the "Show orders" choice lives. Not keyed by bot: it is a way of reading a chart.
 const ORDERS_KEY = "bot-chart:orders";
-// How much of the plot the biggest buy's bar is allowed to stand up into. A share of the plot
-// rather than a fixed height: the plot keeps a 10:2 ratio, so on a phone a fixed bar would be
-// most of it and on a wide screen a stub.
-const BAR_HEIGHT = 0.4;
+// How tall the largest buy's mark stands: 5rem against this app's 8px root. Everything else is
+// a share of it, floored at `LOGO_SIZE` so the smallest buy is still a square holding its logo
+// rather than a sliver with a clipped one.
+const MARK_MAX_HEIGHT = 40;
 
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
@@ -588,31 +584,30 @@ export default class extends Controller {
       });
 
     const width = scale.right;
-    this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width, this.#bars(stacks))));
+    this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width, this.#sizing(stacks))));
   }
 
-  // How tall to draw each mark's bar, or null for no bars at all.
+  // The buy that sets the scale, or null to leave every mark its own square.
   //
-  // Only while ONE asset is in view — pinned from the holdings table, or a bot that only ever
-  // bought the one thing, which is the same question and so the same test. Across several assets
-  // a bar would invite a comparison it cannot support: the marks of a stack are already ranked by
-  // size, and bars of different assets rising from different stacks are not on any shared ruler.
+  // Marks grow only while ONE asset is in view — pinned from the holdings table, or a bot that
+  // only ever bought the one thing, which is the same question and so the same test. Across
+  // several assets a height would invite a comparison it cannot support: the marks of a stack are
+  // already ranked by size, and marks of different assets in different stacks share no ruler.
   //
-  // Normalized against the largest buy IN VIEW, so the tallest bar is always the same height and
+  // Normalized against the largest buy IN VIEW, so the tallest mark is always the same height and
   // the rest are read against it. Narrowing the range renormalizes — the question is which of
   // these buys was the big one, not how they measure against a month the reader has scrolled off.
-  #bars(stacks) {
+  #sizing(stacks) {
     const buys = stacks.flatMap((stack) => [...stack.assets.values()]);
     if (new Set(buys.map((buy) => buy.symbol)).size !== 1) return null;
 
+    // A zero total would divide by zero, and nothing bought is nothing to scale.
     const max = Math.max(...buys.map((buy) => buy.quote));
-    // Every buy the same size is not a reason to draw one tall bar and the rest at nothing, and
-    // a zero total would divide by zero.
-    return max > 0 ? { max, height: this.chart.chartArea.height * BAR_HEIGHT } : null;
+    return max > 0 ? max : null;
   }
 
   // A crowd of buys as one column, and the card that reads it out.
-  #stack({ from, to, assets }, width, bars) {
+  #stack({ from, to, assets }, width, scale) {
     const column = document.createElement("div");
     column.className = "widget--chart__buys__stack";
     // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
@@ -638,7 +633,7 @@ export default class extends Controller {
     // Opened on the one the reader can actually see: the logo on top is the mark they aimed at.
     this.#showBuy(card, buys.length - 1);
 
-    column.append(...buys.map((buy, i) => this.#mark(buy, i, bars)), card);
+    column.append(...buys.map((buy, i) => this.#mark(buy, i, scale)), card);
     // One card per stack, held open by the stack's own :hover — moving from one mark to the next
     // changes what it says instead of tearing it down and building it again a few pixels over.
     column.addEventListener("mouseover", (event) => {
@@ -652,21 +647,14 @@ export default class extends Controller {
   // in, so a closed stack shows one logo and a column of colours, and an open one shows them all.
   // A symbol the venue has no ticker for has no image and keeps the grey the tables fall back to,
   // rather than dropping the purchase.
-  #mark(buy, index, bars) {
+  // The mark IS the bar: with one asset in view it grows out of the baseline in that asset's own
+  // colour, with its logo sitting at the foot, so the size of a purchase is the shape of its mark
+  // rather than a second thing drawn next to it.
+  #mark(buy, index, scale) {
     const mark = this.#disc(buy.symbol, "widget--chart__buys__mark");
     mark.dataset.buy = index;
-    if (bars) mark.append(this.#bar(buy, bars));
+    if (scale) mark.style.height = `${Math.max(LOGO_SIZE, (buy.quote / scale) * MARK_MAX_HEIGHT)}px`;
     return mark;
-  }
-
-  // The purchase, standing up out of its own logo: same colour as the disc, because it is the
-  // same asset saying how much of itself was bought here.
-  #bar(buy, { max, height }) {
-    const bar = document.createElement("span");
-    bar.className = "widget--chart__buys__bar";
-    bar.style.height = `${(buy.quote / max) * height}px`;
-    bar.style.background = this.buyLogosValue[buy.symbol]?.color || "#8A9BA8";
-    return bar;
   }
 
   // A coloured disc carrying the asset's logo. The colour is always painted and the image sits

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -5,9 +5,16 @@ import "chartjs-adapter-date-fns";
 // The rows of both holdings tables — the index's constituents and the coins that left it.
 const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_table tr[data-symbol]";
 
+// The buy marks under the plot, in px. Read here rather than measured: the stacks are laid
+// out before the images have loaded, and an unloaded <img> measures 0.
+const LOGO_SIZE = 20;
+// How much of the logo above each one covers — the shingle in `_widget.sass`, in the one number
+// that has to agree with it.
+const LOGO_OVERLAP = 0.7;
+
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
-  static targets = ["analyzerChart", "summary", "date", "pnl", "percent"];
+  static targets = ["analyzerChart", "summary", "date", "pnl", "percent", "buys"];
   static values = {
     series: Array,
     labels: Array,
@@ -17,6 +24,7 @@ export default class extends Controller {
     pnl: Array,
     assets: Object,
     pnlOnly: Boolean,
+    buys: Array,
   };
 
   connect() {
@@ -477,6 +485,72 @@ export default class extends Controller {
         },
       },
     });
+    this.#renderBuys();
+  }
+
+  // --- the buys under the plot -------------------------------------------------------
+  //
+  // One logo per executed buy, placed on the chart's own x scale so a mark sits under the point
+  // it moved. Marks whose logos would overlap by more than half their width collapse into one
+  // vertical stack — and a stack carries each asset ONCE, so an index bot buying eleven coins in
+  // one second reads as eleven assets, not as however many fills the exchange happened to split
+  // them into.
+  #renderBuys() {
+    if (!this.hasBuysTarget) return;
+
+    const scale = this.chart.scales.x;
+    const size = LOGO_SIZE;
+    const from = this.#timestamps()[0];
+    const stacks = [];
+
+    this.buysValue
+      // Outside the window in view, or on an asset the reader is not looking at, there is nothing
+      // to mark: the curve above does not go there either.
+      .filter((buy) => (!this.focused || buy.symbol === this.focused) && new Date(buy.x).getTime() >= from)
+      .forEach((buy) => {
+        const x = scale.getPixelForValue(new Date(buy.x).getTime());
+        // Chained against the LAST mark, not the stack's first: a run of buys a few pixels apart
+        // is one crowd, and measuring from the stack's origin would let it drift apart again.
+        const stack = stacks.at(-1);
+        if (stack && x - stack.last < size / 2) {
+          stack.last = x;
+          stack.to = x;
+          stack.assets.set(buy.symbol, buy);
+        } else {
+          stacks.push({ from: x, to: x, last: x, assets: new Map([[buy.symbol, buy]]) });
+        }
+      });
+
+    const width = scale.right;
+    this.buysTarget.replaceChildren(
+      ...stacks.map((stack) => {
+        const column = document.createElement("div");
+        column.className = "widget--chart__buys__stack";
+        // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
+        const centre = (stack.from + stack.to) / 2;
+        column.style.left = `${Math.min(Math.max(centre, size / 2), width - size / 2)}px`;
+        column.append(...[...stack.assets.values()].map((buy) => this.#logo(buy)));
+        return column;
+      })
+    );
+    // Only as tall as the tallest stack: an empty row under a chart with no crowds is dead space.
+    const tallest = Math.max(0, ...stacks.map((stack) => stack.assets.size));
+    const step = size * (1 - LOGO_OVERLAP);
+    this.buysTarget.style.height = tallest ? `${size + (tallest - 1) * step}px` : "0";
+  }
+
+  #logo(buy) {
+    const logo = buy.image ? document.createElement("img") : document.createElement("span");
+    logo.className = "asset-logo";
+    logo.title = buy.symbol;
+    if (buy.image) {
+      logo.src = buy.image;
+      logo.alt = buy.symbol;
+      logo.loading = "lazy";
+    } else {
+      logo.style.background = buy.color;
+    }
+    return logo;
   }
 
   // What to draw for the mode in hand: the datasets, the y scale they need, how many points

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -604,18 +604,22 @@ export default class extends Controller {
     // crowd is the one wearing its logo while the stack is closed, and the also-rans are the
     // slivers behind it.
     const buys = [...assets.values()].sort((a, b) => a.quote - b.quote);
+    // EVERY buy's reading is in the card at once, stacked in one grid cell with all but one
+    // hidden. The card is therefore already as wide as the widest line it will ever hold, so
+    // moving between marks swaps the text inside a box that never changes size — measuring the
+    // strings would only guess at it, since a digit and a ticker are not the same width.
     const card = document.createElement("div");
     card.className = "widget--chart__buys__tip";
-    // Seeded with the one the reader can actually see: entering the stack anywhere has to put
-    // SOMETHING in the card, and the logo on top is the mark they were aiming at.
-    this.#fillTip(card, buys.at(-1));
+    card.append(...buys.map((buy) => this.#tipBuy(buy)));
+    // Opened on the one the reader can actually see: the logo on top is the mark they aimed at.
+    this.#showBuy(card, buys.length - 1);
 
     column.append(...buys.map((buy, i) => this.#mark(buy, i)), card);
     // One card per stack, held open by the stack's own :hover — moving from one mark to the next
     // changes what it says instead of tearing it down and building it again a few pixels over.
     column.addEventListener("mouseover", (event) => {
       const mark = event.target.closest(".widget--chart__buys__mark");
-      if (mark) this.#fillTip(card, buys[Number(mark.dataset.buy)]);
+      if (mark) this.#showBuy(card, Number(mark.dataset.buy));
     });
     return column;
   }
@@ -625,38 +629,57 @@ export default class extends Controller {
   // A symbol the venue has no ticker for has no image and keeps the grey the tables fall back to,
   // rather than dropping the purchase.
   #mark(buy, index) {
-    const asset = this.buyLogosValue[buy.symbol] || {};
-    const mark = document.createElement("span");
-    mark.className = "widget--chart__buys__mark";
-    mark.style.background = asset.color || "#8A9BA8";
+    const mark = this.#disc(buy.symbol, "widget--chart__buys__mark");
     mark.dataset.buy = index;
-
-    if (asset.image) {
-      const logo = document.createElement("img");
-      logo.className = "asset-logo";
-      logo.src = asset.image;
-      logo.alt = buy.symbol;
-      logo.loading = "lazy";
-      mark.append(logo);
-    }
     return mark;
   }
 
-  // What the crowd under this logo actually bought: when, what, how much, and at what it went
-  // through. The price is DERIVED from the two totals rather than read off a row, so a mark that
-  // stands for several fills states the price the money as a whole moved at.
-  #fillTip(card, buy) {
+  // A coloured disc carrying the asset's logo. The colour is always painted and the image sits
+  // over it, so a symbol the venue has no ticker for still gets a disc — in the grey the holdings
+  // tables fall back to — rather than the purchase silently going unmarked.
+  #disc(symbol, className) {
+    const asset = this.buyLogosValue[symbol] || {};
+    const disc = document.createElement("span");
+    disc.className = className;
+    disc.style.background = asset.color || "#8A9BA8";
+    if (!asset.image) return disc;
+
+    const logo = document.createElement("img");
+    logo.className = "asset-logo";
+    logo.src = asset.image;
+    logo.alt = symbol;
+    logo.loading = "lazy";
+    disc.append(logo);
+    return disc;
+  }
+
+  // What the crowd under one mark actually bought: which asset, when, how much, and the price it
+  // went through at. Opened by the logo, because the reader arrived here by pointing at one and
+  // the card has to say which one they hit. The price is DERIVED from the two totals rather than
+  // read off a row, so a mark standing for several fills states the price the money as a whole
+  // moved at.
+  #tipBuy(buy) {
     const when = buy.first === buy.last
       ? this.#date(buy.first)
       : `${this.#date(buy.first)} – ${this.#date(buy.last)}`;
     // The count only earns its place when the mark is standing for more than one buy.
     const fills = buy.fills > 1 ? ` · ×${buy.fills}` : "";
-    card.replaceChildren(
+    const block = document.createElement("div");
+    block.className = "widget--chart__buys__tip__buy";
+    block.append(
+      this.#disc(buy.symbol, "widget--chart__buys__tip__logo"),
       this.#tipLine(`${when}${fills}`, "widget--chart__buys__tip__when"),
       this.#tipLine(`${this.#amount(buy.amount)} ${buy.symbol}`),
-      this.#tipLine(`@ ${this.#money(buy.quote / buy.amount, { signed: false })}`,
+      this.#tipLine(this.#money(buy.quote / buy.amount, { signed: false }),
                     "widget--chart__buys__tip__price")
     );
+    return block;
+  }
+
+  // Every reading is present; exactly one is visible. `visibility`, not `display`, because a
+  // hidden block still has to take up its width — that is what holds the card still.
+  #showBuy(card, index) {
+    [...card.children].forEach((block, i) => block.classList.toggle("is-on", i === index));
   }
 
   #tipLine(text, className) {

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -17,10 +17,12 @@ const LOGO_SIZE = 16;
 // number `_widget.sass` shingles them by. Only the CLOSED step is needed here — opening a stack
 // is the stylesheet's business, and deliberately does not resize the row.
 const LOGO_STEP = 4;
+// Where the "Show orders" choice lives. Not keyed by bot: it is a way of reading a chart.
+const ORDERS_KEY = "bot-chart:orders";
 
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
-  static targets = ["analyzerChart", "summary", "date", "pnl", "percent", "buys"];
+  static targets = ["analyzerChart", "summary", "date", "pnl", "percent", "buys", "orders"];
   static values = {
     series: Array,
     labels: Array,
@@ -59,6 +61,11 @@ export default class extends Controller {
     // wide in the plot's top-left corner. Seeding previousWidth keeps that first delivery from
     // drawing it a second time; the observer's job is REDRAWING at a new width.
     this.previousWidth = this.element.offsetWidth;
+    // Restored before the first build, so the marks are either there from the start or never
+    // drawn at all. Like the mode switch, this outlives the ~5-minute broadcast that destroys
+    // this controller and re-renders the checkbox on its default.
+    this.showOrders = this.#storedOrders;
+    if (this.hasOrdersTarget) this.ordersTarget.checked = this.showOrders;
     this.#buildChart();
     this.resizeObserver = new ResizeObserver(() => {
       // Cancel any pending resize handlers
@@ -104,6 +111,29 @@ export default class extends Controller {
     this.currentMode = event.detail.value;
     this.#buildChart();
     this.#renderSummary();
+  }
+
+  // --- the buy marks, on or off ---------------------------------------------------
+  //
+  // Off by default: the marks hang over the curve, and a reader who came for the shape of the
+  // line should get the line. Remembered per browser, never per bot — it is a way of reading a
+  // chart, not a property of one.
+  toggleOrders() {
+    this.showOrders = this.ordersTarget.checked;
+    try {
+      localStorage.setItem(ORDERS_KEY, this.showOrders ? "1" : "0");
+    } catch {
+      // Not being able to remember a choice is not a reason to fail making it.
+    }
+    this.#renderBuys();
+  }
+
+  get #storedOrders() {
+    try {
+      return localStorage.getItem(ORDERS_KEY) === "1";
+    } catch {
+      return false; // storage can be denied outright (private mode, embedded webview)
+    }
   }
 
   // --- the window in view -----------------------------------------------------------
@@ -500,12 +530,16 @@ export default class extends Controller {
   // --- the buys under the plot -------------------------------------------------------
   //
   // One mark per executed buy, placed on the chart's own x scale so a mark sits under the point
-  // it moved. Marks whose logos would overlap by more than half their width collapse into one
-  // stack — and a stack carries each asset ONCE, summing what that asset bought across the
-  // crowd, so an index bot buying eleven coins in one second reads as eleven assets rather than
-  // as however many fills the exchange split them into.
+  // it moved, and hanging off the floor of the plot itself rather than in a strip below it.
+  // Marks whose logos would overlap by more than half their width collapse into one stack — and
+  // a stack carries each asset ONCE, summing what that asset bought across the crowd, so an
+  // index bot buying eleven coins in one second reads as eleven assets rather than as however
+  // many fills the exchange split them into.
   #renderBuys() {
     if (!this.hasBuysTarget) return;
+    // Nothing is drawn at all while the marks are off — on a twenty-asset index this is hundreds
+    // of elements, and hiding them in CSS would build them anyway on every redraw.
+    if (!this.showOrders) return this.buysTarget.replaceChildren();
 
     const scale = this.chart.scales.x;
     const size = LOGO_SIZE;
@@ -550,43 +584,52 @@ export default class extends Controller {
       });
 
     const width = scale.right;
-    this.buysTarget.replaceChildren(
-      ...stacks.map((stack) => {
-        const column = document.createElement("div");
-        column.className = "widget--chart__buys__stack";
-        // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
-        // Offset by half a logo here rather than with a translate: a transform would make this
-        // element the containing block for the tooltips' `position: fixed`.
-        const centre = (stack.from + stack.to) / 2;
-        column.style.left = `${Math.min(Math.max(centre, size / 2), width - size / 2) - size / 2}px`;
-        // SMALLEST first, because the last one painted is the one on top: the biggest buy of the
-        // crowd is the one wearing its logo while the stack is closed, and the also-rans are the
-        // slivers behind it.
-        const buys = [...stack.assets.values()].sort((a, b) => a.quote - b.quote);
-        column.append(...buys.map((buy) => this.#mark(buy)));
-        return column;
-      })
-    );
-    // Only as tall as the tallest CLOSED stack: opening one lifts its slivers up over the plot
-    // rather than growing the row, which would shove the whole page down on hover.
-    const tallest = Math.max(0, ...stacks.map((stack) => stack.assets.size));
-    this.buysTarget.style.height = tallest ? `${size + (tallest - 1) * LOGO_STEP}px` : "0";
+    this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width)));
+  }
+
+  // A crowd of buys as one column, and the card that reads it out.
+  #stack({ from, to, assets }, width) {
+    const column = document.createElement("div");
+    column.className = "widget--chart__buys__stack";
+    // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
+    // Offset by half a logo here rather than with a translate: a transform would make this the
+    // containing block for anything positioned against the viewport inside it.
+    const centre = Math.min(Math.max((from + to) / 2, LOGO_SIZE / 2), width - LOGO_SIZE / 2);
+    column.style.left = `${centre - LOGO_SIZE / 2}px`;
+    // The card sits on whichever side has the room. Decided from the mark's own place on the
+    // axis, so the one thing that could push it off-screen is the one thing it is measured on.
+    if (centre > width / 2) column.classList.add("widget--chart__buys__stack--flip");
+
+    // SMALLEST first, because the last one painted is the one on top: the biggest buy of the
+    // crowd is the one wearing its logo while the stack is closed, and the also-rans are the
+    // slivers behind it.
+    const buys = [...assets.values()].sort((a, b) => a.quote - b.quote);
+    const card = document.createElement("div");
+    card.className = "widget--chart__buys__tip";
+    // Seeded with the one the reader can actually see: entering the stack anywhere has to put
+    // SOMETHING in the card, and the logo on top is the mark they were aiming at.
+    this.#fillTip(card, buys.at(-1));
+
+    column.append(...buys.map((buy, i) => this.#mark(buy, i)), card);
+    // One card per stack, held open by the stack's own :hover — moving from one mark to the next
+    // changes what it says instead of tearing it down and building it again a few pixels over.
+    column.addEventListener("mouseover", (event) => {
+      const mark = event.target.closest(".widget--chart__buys__mark");
+      if (mark) this.#fillTip(card, buys[Number(mark.dataset.buy)]);
+    });
+    return column;
   }
 
   // A coloured disc wearing the asset's logo. The disc is the mark: the logo on top of it fades
   // in, so a closed stack shows one logo and a column of colours, and an open one shows them all.
   // A symbol the venue has no ticker for has no image and keeps the grey the tables fall back to,
   // rather than dropping the purchase.
-  #mark(buy) {
+  #mark(buy, index) {
     const asset = this.buyLogosValue[buy.symbol] || {};
     const mark = document.createElement("span");
     mark.className = "widget--chart__buys__mark";
     mark.style.background = asset.color || "#8A9BA8";
-    // The app's own hover card, so these read like every other tooltip on the page. Fixed, or the
-    // bubble would be cut off by the stack it belongs to.
-    mark.dataset.controller = "tooltip";
-    mark.dataset.tooltipFixedValue = "true";
-    mark.dataset.action = "mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip";
+    mark.dataset.buy = index;
 
     if (asset.image) {
       const logo = document.createElement("img");
@@ -596,27 +639,24 @@ export default class extends Controller {
       logo.loading = "lazy";
       mark.append(logo);
     }
-    mark.append(this.#markTooltip(buy));
     return mark;
   }
 
   // What the crowd under this logo actually bought: when, what, how much, and at what it went
   // through. The price is DERIVED from the two totals rather than read off a row, so a mark that
   // stands for several fills states the price the money as a whole moved at.
-  #markTooltip(buy) {
-    const tooltip = document.createElement("div");
-    tooltip.className = "tooltip tooltip--hint widget--chart__buys__tip";
+  #fillTip(card, buy) {
     const when = buy.first === buy.last
       ? this.#date(buy.first)
       : `${this.#date(buy.first)} – ${this.#date(buy.last)}`;
     // The count only earns its place when the mark is standing for more than one buy.
     const fills = buy.fills > 1 ? ` · ×${buy.fills}` : "";
-    tooltip.append(
+    card.replaceChildren(
       this.#tipLine(`${when}${fills}`, "widget--chart__buys__tip__when"),
       this.#tipLine(`${this.#amount(buy.amount)} ${buy.symbol}`),
-      this.#tipLine(`@ ${this.#money(buy.quote / buy.amount, { signed: false })}`)
+      this.#tipLine(`@ ${this.#money(buy.quote / buy.amount, { signed: false })}`,
+                    "widget--chart__buys__tip__price")
     );
-    return tooltip;
   }
 
   #tipLine(text, className) {

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -593,6 +593,16 @@ export default class extends Controller {
   // several assets a height would invite a comparison it cannot support: the marks of a stack are
   // already ranked by size, and marks of different assets in different stacks share no ruler.
   //
+  // Measured on the AMOUNT, not the money. A DCA bot spends the same figure every time — that is
+  // what makes it a DCA bot — and an index bot splits that same figure by fixed weights, so the
+  // quote of a given asset's buy is constant by construction and every mark would be the same
+  // height. What actually moves is how much the money bought, which is also the thing the reader
+  // came for: the weeks the price was low are the tall ones.
+  //
+  // Comparable only because this runs with ONE asset in view; across assets the amounts are in
+  // different units and only the money is a shared ruler, which is why the ORDER of marks within
+  // a stack is still by quote.
+  //
   // MIN-MAX against the buys IN VIEW: the smallest stands at `LOGO_SIZE` and the largest at
   // `MARK_MAX_HEIGHT`, whatever the numbers are, so the full height is always spent on the spread
   // that is actually there. Height is therefore a RANK within the window and not a quantity — a
@@ -600,18 +610,15 @@ export default class extends Controller {
   // apart being legibly apart. Narrowing the range renormalizes: the question is which of THESE
   // buys was the big one, not how they measure against a month scrolled off the side.
   //
-  // Buys that are all the same size have no spread to spend, and they are the COMMON case: a bot
-  // on a fixed contribution buys the same amount every time, and at any real width each buy gets
-  // a stack to itself rather than being summed with its neighbours. They are drawn at full
-  // height — every one of them is the largest — because the alternative reads as the marks
-  // having no sizes at all, which is how this went missing in the first place.
+  // Buys that really are all identical have no spread to spend and are drawn at full height:
+  // every one of them is the largest, and the alternative reads as the marks having no sizes.
   #sizing(stacks) {
     const buys = stacks.flatMap((stack) => [...stack.assets.values()]);
     if (new Set(buys.map((buy) => buy.symbol)).size !== 1) return null;
 
-    const quotes = buys.map((buy) => buy.quote);
-    const min = Math.min(...quotes);
-    return { min, span: Math.max(...quotes) - min };
+    const amounts = buys.map((buy) => buy.amount);
+    const min = Math.min(...amounts);
+    return { min, span: Math.max(...amounts) - min };
   }
 
   // A crowd of buys as one column, and the card that reads it out.
@@ -629,7 +636,9 @@ export default class extends Controller {
 
     // SMALLEST first, because the last one painted is the one on top: the biggest buy of the
     // crowd is the one wearing its logo while the stack is closed, and the also-rans are the
-    // slivers behind it.
+    // slivers behind it. By MONEY, not by amount: a stack holds different assets, and 800 of one
+    // token against 0.001 of another ranks nothing. Height, which only ever runs with a single
+    // asset in view, measures the amount instead — see `#sizing`.
     const buys = [...assets.values()].sort((a, b) => a.quote - b.quote);
     // EVERY buy's reading is in the card at once, stacked in one grid cell with all but one
     // hidden. The card is therefore already as wide as the widest line it will ever hold, so
@@ -663,7 +672,7 @@ export default class extends Controller {
     mark.dataset.buy = index;
     if (scale) {
       // No span is not a division to guard against, it is every buy tying for largest.
-      const share = scale.span ? (buy.quote - scale.min) / scale.span : 1;
+      const share = scale.span ? (buy.amount - scale.min) / scale.span : 1;
       mark.style.height = `${LOGO_SIZE + share * (MARK_MAX_HEIGHT - LOGO_SIZE)}px`;
     }
     return mark;

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -8,14 +8,15 @@ const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_tab
 // The buy marks under the plot, in px. Read here rather than measured: the stacks are laid
 // out before the images have loaded, and an unloaded <img> measures 0.
 //
-// This is `.widget--chart__buys__stack .asset-logo` in `_widget.sass` — 2rem against this app's
-// 8px root, so SIXTEEN, not the 20 a 16px root would give. It sets the overlap threshold, the
-// edge clamp and the reserved height, so guessing it wrong silently over-reserves the row and
-// collapses marks that do not visually overlap.
+// This is `.widget--chart__buys__mark` in `_widget.sass` — 2rem against this app's 8px root, so
+// SIXTEEN, not the 20 a 16px root would give. It sets the overlap threshold, the edge clamp and
+// the reserved height, so guessing it wrong silently over-reserves the row and collapses marks
+// that do not visually overlap.
 const LOGO_SIZE = 16;
-// How much of the logo above each one covers — the shingle in `_widget.sass`, in the one number
-// that has to agree with it.
-const LOGO_OVERLAP = 0.7;
+// How far each mark behind the top one sticks out while the stack is closed: 0.5rem, the same
+// number `_widget.sass` shingles them by. Only the CLOSED step is needed here — opening a stack
+// is the stylesheet's business, and deliberately does not resize the row.
+const LOGO_STEP = 4;
 
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
@@ -297,12 +298,14 @@ export default class extends Controller {
     });
   }
 
-  #money(value) {
+  // `signed` off for a PRICE: the headline is a profit and wants its sign, but "+84,000 USDT"
+  // as the price of a fill reads as a gain.
+  #money(value, { signed = true } = {}) {
     const decimals = Math.abs(value) >= 1 ? 2 : this.decimalsValue;
     return `${value.toLocaleString(this.#locale, {
       minimumFractionDigits: Math.min(2, decimals),
       maximumFractionDigits: decimals,
-      signDisplay: "exceptZero",
+      signDisplay: signed ? "exceptZero" : "auto",
     })} ${this.quoteValue}`;
   }
 
@@ -496,11 +499,11 @@ export default class extends Controller {
 
   // --- the buys under the plot -------------------------------------------------------
   //
-  // One logo per executed buy, placed on the chart's own x scale so a mark sits under the point
+  // One mark per executed buy, placed on the chart's own x scale so a mark sits under the point
   // it moved. Marks whose logos would overlap by more than half their width collapse into one
-  // vertical stack — and a stack carries each asset ONCE, so an index bot buying eleven coins in
-  // one second reads as eleven assets, not as however many fills the exchange happened to split
-  // them into.
+  // stack — and a stack carries each asset ONCE, summing what that asset bought across the
+  // crowd, so an index bot buying eleven coins in one second reads as eleven assets rather than
+  // as however many fills the exchange split them into.
   #renderBuys() {
     if (!this.hasBuysTarget) return;
 
@@ -524,18 +527,26 @@ export default class extends Controller {
         const time = new Date(at).getTime();
         return time >= from && time <= to;
       })
-      .forEach(([at, symbol]) => {
-        const x = scale.getPixelForValue(new Date(at).getTime());
+      .forEach(([at, symbol, amount, quote, fills]) => {
+        const time = new Date(at).getTime();
+        const x = scale.getPixelForValue(time);
         // Chained against the LAST mark, not the stack's first: a run of buys a few pixels apart
         // is one crowd, and measuring from the stack's origin would let it drift apart again.
-        const stack = stacks.at(-1);
-        if (stack && x - stack.last < size / 2) {
-          stack.last = x;
-          stack.to = x;
-          stack.assets.add(symbol);
-        } else {
-          stacks.push({ from: x, to: x, last: x, assets: new Set([symbol]) });
+        let stack = stacks.at(-1);
+        if (!stack || x - stack.last >= size / 2) {
+          stack = { from: x, to: x, last: x, assets: new Map() };
+          stacks.push(stack);
         }
+        stack.last = x;
+        stack.to = x;
+
+        const buy = stack.assets.get(symbol) ||
+          { symbol, amount: 0, quote: 0, fills: 0, first: time, last: time };
+        buy.amount += amount;
+        buy.quote += quote;
+        buy.fills += fills;
+        buy.last = time;
+        stack.assets.set(symbol, buy);
       });
 
     const width = scale.right;
@@ -544,33 +555,81 @@ export default class extends Controller {
         const column = document.createElement("div");
         column.className = "widget--chart__buys__stack";
         // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
+        // Offset by half a logo here rather than with a translate: a transform would make this
+        // element the containing block for the tooltips' `position: fixed`.
         const centre = (stack.from + stack.to) / 2;
-        column.style.left = `${Math.min(Math.max(centre, size / 2), width - size / 2)}px`;
-        column.append(...[...stack.assets].map((symbol) => this.#logo(symbol)));
+        column.style.left = `${Math.min(Math.max(centre, size / 2), width - size / 2) - size / 2}px`;
+        // SMALLEST first, because the last one painted is the one on top: the biggest buy of the
+        // crowd is the one wearing its logo while the stack is closed, and the also-rans are the
+        // slivers behind it.
+        const buys = [...stack.assets.values()].sort((a, b) => a.quote - b.quote);
+        column.append(...buys.map((buy) => this.#mark(buy)));
         return column;
       })
     );
-    // Only as tall as the tallest stack: an empty row under a chart with no crowds is dead space.
+    // Only as tall as the tallest CLOSED stack: opening one lifts its slivers up over the plot
+    // rather than growing the row, which would shove the whole page down on hover.
     const tallest = Math.max(0, ...stacks.map((stack) => stack.assets.size));
-    const step = size * (1 - LOGO_OVERLAP);
-    this.buysTarget.style.height = tallest ? `${size + (tallest - 1) * step}px` : "0";
+    this.buysTarget.style.height = tallest ? `${size + (tallest - 1) * LOGO_STEP}px` : "0";
   }
 
-  // A symbol the venue has no ticker for gets neither image nor colour; it still earns its disc,
-  // in the same grey the holdings tables fall back to, rather than silently dropping a purchase.
-  #logo(symbol) {
-    const asset = this.buyLogosValue[symbol] || {};
-    const logo = asset.image ? document.createElement("img") : document.createElement("span");
-    logo.className = "asset-logo";
-    logo.title = symbol;
+  // A coloured disc wearing the asset's logo. The disc is the mark: the logo on top of it fades
+  // in, so a closed stack shows one logo and a column of colours, and an open one shows them all.
+  // A symbol the venue has no ticker for has no image and keeps the grey the tables fall back to,
+  // rather than dropping the purchase.
+  #mark(buy) {
+    const asset = this.buyLogosValue[buy.symbol] || {};
+    const mark = document.createElement("span");
+    mark.className = "widget--chart__buys__mark";
+    mark.style.background = asset.color || "#8A9BA8";
+    // The app's own hover card, so these read like every other tooltip on the page. Fixed, or the
+    // bubble would be cut off by the stack it belongs to.
+    mark.dataset.controller = "tooltip";
+    mark.dataset.tooltipFixedValue = "true";
+    mark.dataset.action = "mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip";
+
     if (asset.image) {
+      const logo = document.createElement("img");
+      logo.className = "asset-logo";
       logo.src = asset.image;
-      logo.alt = symbol;
+      logo.alt = buy.symbol;
       logo.loading = "lazy";
-    } else {
-      logo.style.background = asset.color || "#8A9BA8";
+      mark.append(logo);
     }
-    return logo;
+    mark.append(this.#markTooltip(buy));
+    return mark;
+  }
+
+  // What the crowd under this logo actually bought: when, what, how much, and at what it went
+  // through. The price is DERIVED from the two totals rather than read off a row, so a mark that
+  // stands for several fills states the price the money as a whole moved at.
+  #markTooltip(buy) {
+    const tooltip = document.createElement("div");
+    tooltip.className = "tooltip tooltip--hint widget--chart__buys__tip";
+    const when = buy.first === buy.last
+      ? this.#date(buy.first)
+      : `${this.#date(buy.first)} – ${this.#date(buy.last)}`;
+    // The count only earns its place when the mark is standing for more than one buy.
+    const fills = buy.fills > 1 ? ` · ×${buy.fills}` : "";
+    tooltip.append(
+      this.#tipLine(`${when}${fills}`, "widget--chart__buys__tip__when"),
+      this.#tipLine(`${this.#amount(buy.amount)} ${buy.symbol}`),
+      this.#tipLine(`@ ${this.#money(buy.quote / buy.amount, { signed: false })}`)
+    );
+    return tooltip;
+  }
+
+  #tipLine(text, className) {
+    const line = document.createElement("div");
+    if (className) line.className = className;
+    line.textContent = text;
+    return line;
+  }
+
+  // A base amount, which has no decimals shipped with the chart — an index bot's holdings each
+  // have their own. Eight is the floor of what a crypto amount needs; trailing zeros are dropped.
+  #amount(value) {
+    return value.toLocaleString(this.#locale, { maximumFractionDigits: 8 });
   }
 
   // What to draw for the mode in hand: the datasets, the y scale they need, how many points

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -25,6 +25,7 @@ export default class extends Controller {
     assets: Object,
     pnlOnly: Boolean,
     buys: Array,
+    buyLogos: Object,
   };
 
   connect() {
@@ -500,24 +501,35 @@ export default class extends Controller {
 
     const scale = this.chart.scales.x;
     const size = LOGO_SIZE;
-    const from = this.#timestamps()[0];
+    const timestamps = this.#timestamps();
+    const from = timestamps[0];
+    // BOTH ends, not just the near one. The chart's metrics are cached for minutes while the
+    // transactions are read live, so a buy that landed since the last metrics pass is newer than
+    // the last label — and the clamp below would then park its logo on the final point, dating a
+    // purchase to a day it did not happen on. A mark the curve cannot place is not drawn.
+    const to = timestamps.at(-1);
     const stacks = [];
 
     this.buysValue
       // Outside the window in view, or on an asset the reader is not looking at, there is nothing
       // to mark: the curve above does not go there either.
-      .filter((buy) => (!this.focused || buy.symbol === this.focused) && new Date(buy.x).getTime() >= from)
-      .forEach((buy) => {
-        const x = scale.getPixelForValue(new Date(buy.x).getTime());
+      .filter(([at, symbol]) => {
+        if (this.focused && symbol !== this.focused) return false;
+
+        const time = new Date(at).getTime();
+        return time >= from && time <= to;
+      })
+      .forEach(([at, symbol]) => {
+        const x = scale.getPixelForValue(new Date(at).getTime());
         // Chained against the LAST mark, not the stack's first: a run of buys a few pixels apart
         // is one crowd, and measuring from the stack's origin would let it drift apart again.
         const stack = stacks.at(-1);
         if (stack && x - stack.last < size / 2) {
           stack.last = x;
           stack.to = x;
-          stack.assets.set(buy.symbol, buy);
+          stack.assets.add(symbol);
         } else {
-          stacks.push({ from: x, to: x, last: x, assets: new Map([[buy.symbol, buy]]) });
+          stacks.push({ from: x, to: x, last: x, assets: new Set([symbol]) });
         }
       });
 
@@ -529,7 +541,7 @@ export default class extends Controller {
         // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
         const centre = (stack.from + stack.to) / 2;
         column.style.left = `${Math.min(Math.max(centre, size / 2), width - size / 2)}px`;
-        column.append(...[...stack.assets.values()].map((buy) => this.#logo(buy)));
+        column.append(...[...stack.assets].map((symbol) => this.#logo(symbol)));
         return column;
       })
     );
@@ -539,16 +551,19 @@ export default class extends Controller {
     this.buysTarget.style.height = tallest ? `${size + (tallest - 1) * step}px` : "0";
   }
 
-  #logo(buy) {
-    const logo = buy.image ? document.createElement("img") : document.createElement("span");
+  // A symbol the venue has no ticker for gets neither image nor colour; it still earns its disc,
+  // in the same grey the holdings tables fall back to, rather than silently dropping a purchase.
+  #logo(symbol) {
+    const asset = this.buyLogosValue[symbol] || {};
+    const logo = asset.image ? document.createElement("img") : document.createElement("span");
     logo.className = "asset-logo";
-    logo.title = buy.symbol;
-    if (buy.image) {
-      logo.src = buy.image;
-      logo.alt = buy.symbol;
+    logo.title = symbol;
+    if (asset.image) {
+      logo.src = asset.image;
+      logo.alt = symbol;
       logo.loading = "lazy";
     } else {
-      logo.style.background = buy.color;
+      logo.style.background = asset.color || "#8A9BA8";
     }
     return logo;
   }

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -7,7 +7,12 @@ const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_tab
 
 // The buy marks under the plot, in px. Read here rather than measured: the stacks are laid
 // out before the images have loaded, and an unloaded <img> measures 0.
-const LOGO_SIZE = 20;
+//
+// This is `.widget--chart__buys__stack .asset-logo` in `_widget.sass` — 2rem against this app's
+// 8px root, so SIXTEEN, not the 20 a 16px root would give. It sets the overlap threshold, the
+// edge clamp and the reserved height, so guessing it wrong silently over-reserves the row and
+// collapses marks that do not visually overlap.
+const LOGO_SIZE = 16;
 // How much of the logo above each one covers — the shingle in `_widget.sass`, in the one number
 // that has to agree with it.
 const LOGO_OVERLAP = 0.7;

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -600,16 +600,18 @@ export default class extends Controller {
   // apart being legibly apart. Narrowing the range renormalizes: the question is which of THESE
   // buys was the big one, not how they measure against a month scrolled off the side.
   //
-  // Equal buys have no spread to spend, so they get no heights at all rather than a row of
-  // maximums claiming every one of them was the biggest. A single buy in view is that same case.
+  // Buys that are all the same size have no spread to spend, and they are the COMMON case: a bot
+  // on a fixed contribution buys the same amount every time, and at any real width each buy gets
+  // a stack to itself rather than being summed with its neighbours. They are drawn at full
+  // height — every one of them is the largest — because the alternative reads as the marks
+  // having no sizes at all, which is how this went missing in the first place.
   #sizing(stacks) {
     const buys = stacks.flatMap((stack) => [...stack.assets.values()]);
     if (new Set(buys.map((buy) => buy.symbol)).size !== 1) return null;
 
     const quotes = buys.map((buy) => buy.quote);
     const min = Math.min(...quotes);
-    const max = Math.max(...quotes);
-    return max > min ? { min, span: max - min } : null;
+    return { min, span: Math.max(...quotes) - min };
   }
 
   // A crowd of buys as one column, and the card that reads it out.
@@ -660,7 +662,8 @@ export default class extends Controller {
     const mark = this.#disc(buy.symbol, "widget--chart__buys__mark");
     mark.dataset.buy = index;
     if (scale) {
-      const share = (buy.quote - scale.min) / scale.span;
+      // No span is not a division to guard against, it is every buy tying for largest.
+      const share = scale.span ? (buy.quote - scale.min) / scale.span : 1;
       mark.style.height = `${LOGO_SIZE + share * (MARK_MAX_HEIGHT - LOGO_SIZE)}px`;
     }
     return mark;

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -19,6 +19,10 @@ const LOGO_SIZE = 16;
 const LOGO_STEP = 4;
 // Where the "Show orders" choice lives. Not keyed by bot: it is a way of reading a chart.
 const ORDERS_KEY = "bot-chart:orders";
+// How much of the plot the biggest buy's bar is allowed to stand up into. A share of the plot
+// rather than a fixed height: the plot keeps a 10:2 ratio, so on a phone a fixed bar would be
+// most of it and on a wide screen a stub.
+const BAR_HEIGHT = 0.4;
 
 // Connects to data-controller="bot--chart"
 export default class extends Controller {
@@ -584,11 +588,31 @@ export default class extends Controller {
       });
 
     const width = scale.right;
-    this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width)));
+    this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width, this.#bars(stacks))));
+  }
+
+  // How tall to draw each mark's bar, or null for no bars at all.
+  //
+  // Only while ONE asset is in view — pinned from the holdings table, or a bot that only ever
+  // bought the one thing, which is the same question and so the same test. Across several assets
+  // a bar would invite a comparison it cannot support: the marks of a stack are already ranked by
+  // size, and bars of different assets rising from different stacks are not on any shared ruler.
+  //
+  // Normalized against the largest buy IN VIEW, so the tallest bar is always the same height and
+  // the rest are read against it. Narrowing the range renormalizes — the question is which of
+  // these buys was the big one, not how they measure against a month the reader has scrolled off.
+  #bars(stacks) {
+    const buys = stacks.flatMap((stack) => [...stack.assets.values()]);
+    if (new Set(buys.map((buy) => buy.symbol)).size !== 1) return null;
+
+    const max = Math.max(...buys.map((buy) => buy.quote));
+    // Every buy the same size is not a reason to draw one tall bar and the rest at nothing, and
+    // a zero total would divide by zero.
+    return max > 0 ? { max, height: this.chart.chartArea.height * BAR_HEIGHT } : null;
   }
 
   // A crowd of buys as one column, and the card that reads it out.
-  #stack({ from, to, assets }, width) {
+  #stack({ from, to, assets }, width, bars) {
     const column = document.createElement("div");
     column.className = "widget--chart__buys__stack";
     // Centred on the crowd it stands for, then kept inside the plot so an edge mark is whole.
@@ -614,7 +638,7 @@ export default class extends Controller {
     // Opened on the one the reader can actually see: the logo on top is the mark they aimed at.
     this.#showBuy(card, buys.length - 1);
 
-    column.append(...buys.map((buy, i) => this.#mark(buy, i)), card);
+    column.append(...buys.map((buy, i) => this.#mark(buy, i, bars)), card);
     // One card per stack, held open by the stack's own :hover — moving from one mark to the next
     // changes what it says instead of tearing it down and building it again a few pixels over.
     column.addEventListener("mouseover", (event) => {
@@ -628,10 +652,21 @@ export default class extends Controller {
   // in, so a closed stack shows one logo and a column of colours, and an open one shows them all.
   // A symbol the venue has no ticker for has no image and keeps the grey the tables fall back to,
   // rather than dropping the purchase.
-  #mark(buy, index) {
+  #mark(buy, index, bars) {
     const mark = this.#disc(buy.symbol, "widget--chart__buys__mark");
     mark.dataset.buy = index;
+    if (bars) mark.append(this.#bar(buy, bars));
     return mark;
+  }
+
+  // The purchase, standing up out of its own logo: same colour as the disc, because it is the
+  // same asset saying how much of itself was bought here.
+  #bar(buy, { max, height }) {
+    const bar = document.createElement("span");
+    bar.className = "widget--chart__buys__bar";
+    bar.style.height = `${(buy.quote / max) * height}px`;
+    bar.style.background = this.buyLogosValue[buy.symbol]?.color || "#8A9BA8";
+    return bar;
   }
 
   // A coloured disc carrying the asset's logo. The colour is always painted and the image sits

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -15,9 +15,8 @@ const HOLDING_ROWS = "#assets_metrics_table tr[data-symbol], #exited_metrics_tab
 const LOGO_SIZE = 16;
 // Where the "Show orders" choice lives. Not keyed by bot: it is a way of reading a chart.
 const ORDERS_KEY = "bot-chart:orders";
-// How tall the largest buy's mark stands: 5rem against this app's 8px root. Everything else is
-// a share of it, floored at `LOGO_SIZE` so the smallest buy is still a square holding its logo
-// rather than a sliver with a clipped one.
+// How tall the largest buy's mark stands: 5rem against this app's 8px root. The smallest stands
+// at `LOGO_SIZE`, and everything between is spread across the difference — see `#sizing`.
 const MARK_MAX_HEIGHT = 40;
 
 // Connects to data-controller="bot--chart"
@@ -587,23 +586,30 @@ export default class extends Controller {
     this.buysTarget.replaceChildren(...stacks.map((stack) => this.#stack(stack, width, this.#sizing(stacks))));
   }
 
-  // The buy that sets the scale, or null to leave every mark its own square.
+  // The range the marks are drawn against, or null to leave every mark its own square.
   //
   // Marks grow only while ONE asset is in view — pinned from the holdings table, or a bot that
   // only ever bought the one thing, which is the same question and so the same test. Across
   // several assets a height would invite a comparison it cannot support: the marks of a stack are
   // already ranked by size, and marks of different assets in different stacks share no ruler.
   //
-  // Normalized against the largest buy IN VIEW, so the tallest mark is always the same height and
-  // the rest are read against it. Narrowing the range renormalizes — the question is which of
-  // these buys was the big one, not how they measure against a month the reader has scrolled off.
+  // MIN-MAX against the buys IN VIEW: the smallest stands at `LOGO_SIZE` and the largest at
+  // `MARK_MAX_HEIGHT`, whatever the numbers are, so the full height is always spent on the spread
+  // that is actually there. Height is therefore a RANK within the window and not a quantity — a
+  // buy half the size of another is not half as tall — which is the trade for two buys a hair
+  // apart being legibly apart. Narrowing the range renormalizes: the question is which of THESE
+  // buys was the big one, not how they measure against a month scrolled off the side.
+  //
+  // Equal buys have no spread to spend, so they get no heights at all rather than a row of
+  // maximums claiming every one of them was the biggest. A single buy in view is that same case.
   #sizing(stacks) {
     const buys = stacks.flatMap((stack) => [...stack.assets.values()]);
     if (new Set(buys.map((buy) => buy.symbol)).size !== 1) return null;
 
-    // A zero total would divide by zero, and nothing bought is nothing to scale.
-    const max = Math.max(...buys.map((buy) => buy.quote));
-    return max > 0 ? max : null;
+    const quotes = buys.map((buy) => buy.quote);
+    const min = Math.min(...quotes);
+    const max = Math.max(...quotes);
+    return max > min ? { min, span: max - min } : null;
   }
 
   // A crowd of buys as one column, and the card that reads it out.
@@ -653,7 +659,10 @@ export default class extends Controller {
   #mark(buy, index, scale) {
     const mark = this.#disc(buy.symbol, "widget--chart__buys__mark");
     mark.dataset.buy = index;
-    if (scale) mark.style.height = `${Math.max(LOGO_SIZE, (buy.quote / scale) * MARK_MAX_HEIGHT)}px`;
+    if (scale) {
+      const share = (buy.quote - scale.min) / scale.span;
+      mark.style.height = `${LOGO_SIZE + share * (MARK_MAX_HEIGHT - LOGO_SIZE)}px`;
+    }
     return mark;
   }
 

--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -32,7 +32,8 @@ module Bot::ChartSeries
   # metrics broadcast.
   MARK_BUCKETS = 500
 
-  # `[[time, symbol], ...]` oldest first: the buys the chart marks under the plot.
+  # `[[time, symbol, amount, quote, fills], ...]` oldest first: the buys the chart marks under
+  # the plot, each carrying what it bought so the mark can say so when hovered.
   #
   # The SAME rows `metrics` counts, and for the same reason — a mark is a claim that the bot
   # bought something there. An order still open, or cancelled before it filled, carries a price
@@ -49,14 +50,22 @@ module Bot::ChartSeries
       next if price.blank? || amount_exec.blank? || quote_amount_exec.blank?
       next if amount_exec.zero? || quote_amount_exec.zero?
 
-      [at, base]
+      # Amounts as EXECUTED, not as requested — `price` on the row is what was asked for, and a
+      # market order rarely gets exactly that. The fill price the tooltip shows is derived from
+      # these two, so it is the price the money actually moved at.
+      [at, base, amount_exec.to_d, quote_amount_exec.to_d, 1]
     end
     chart_thinned_marks(marks)
   end
 
-  # One mark per symbol per bucket, keeping the FIRST in each — so the first and last buys of the
-  # history both survive, and a symbol that only ever traded once is never thinned away. Applied
-  # only when there are more marks than buckets: the ordinary bot pays nothing for this.
+  # One mark per symbol per bucket, timed at the FIRST in each — so the first and last buys of
+  # the history both survive, and a symbol that only ever traded once is never thinned away.
+  # Applied only when there are more marks than buckets: the ordinary bot pays nothing for this.
+  #
+  # SUMMED, not sampled. The marks say what they bought, and a hovered mark that dropped half the
+  # fills underneath it would understate a purchase — a number being wrong is worse than a mark
+  # being a pixel off. Bucketed marks are ordered by their first fill because a Hash keeps
+  # insertion order and the rows arrive ascending.
   def chart_thinned_marks(marks)
     return marks if marks.size <= MARK_BUCKETS
 
@@ -64,8 +73,12 @@ module Bot::ChartSeries
     span = marks.last[0] - first
     return marks if span.zero?
 
-    seen = Set.new
-    marks.select { |at, base| seen.add?([((at - first) / span * MARK_BUCKETS).floor, base]) }
+    marks.each_with_object({}) do |(at, base, amount, quote, fills), buckets|
+      bucket = buckets[[((at - first) / span * MARK_BUCKETS).floor, base]] ||= [at, base, 0.to_d, 0.to_d, 0]
+      bucket[2] += amount
+      bucket[3] += quote
+      bucket[4] += fills
+    end.values
   end
 
   # The seam every candle fetch goes through. Overridable in tests, and the reason the index's

--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -23,6 +23,27 @@
 module Bot::ChartSeries
   extend ActiveSupport::Concern
 
+  # `[[time, symbol], ...]` oldest first: the buys the chart marks under the plot.
+  #
+  # The SAME rows `metrics` counts, and for the same reason — a mark is a claim that the bot
+  # bought something there. An order still open, or cancelled before it filled, carries a price
+  # and no execution: it would put a logo under a purchase that never happened. Filtered in Ruby
+  # through `Transaction.confirmed_exec_amounts` rather than in SQL, because a closed row is
+  # allowed to have its execution missing and is read back from amount * price — one branch, in
+  # one place, rather than the same rule spelled twice in two languages.
+  def chart_buy_marks
+    transactions.submitted.buy.order(:created_at)
+                .pluck(:created_at, :base, :price, :amount, :amount_exec, :quote_amount_exec, :external_status)
+                .filter_map do |at, base, price, amount, amount_exec, quote_amount_exec, external_status|
+      amount_exec, quote_amount_exec =
+        Transaction.confirmed_exec_amounts(external_status, price, amount, amount_exec, quote_amount_exec)
+      next if price.blank? || amount_exec.blank? || quote_amount_exec.blank?
+      next if amount_exec.zero? || quote_amount_exec.zero?
+
+      [at, base]
+    end
+  end
+
   # The seam every candle fetch goes through. Overridable in tests, and the reason the index's
   # bounded-parallel fetch can be exercised without touching the cache.
   def fetch_candle_series(ticker:, since:, timeframe:)

--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -23,6 +23,15 @@
 module Bot::ChartSeries
   extend ActiveSupport::Concern
 
+  # How finely the buy marks are worth shipping. The marks collapse into stacks by PIXEL
+  # proximity in the browser, and the plot is a few hundred CSS pixels wide, so two marks landing
+  # in the same 1/500th of the history are inside the same stack at any width this app renders —
+  # shipping both only costs bytes. It bounds the payload, which is otherwise one tuple per fill
+  # for the life of the bot: a five-minute smart-interval bot buying twenty assets makes millions
+  # of them, and every one would be serialized into a data attribute on every render AND on every
+  # metrics broadcast.
+  MARK_BUCKETS = 500
+
   # `[[time, symbol], ...]` oldest first: the buys the chart marks under the plot.
   #
   # The SAME rows `metrics` counts, and for the same reason — a mark is a claim that the bot
@@ -32,9 +41,9 @@ module Bot::ChartSeries
   # allowed to have its execution missing and is read back from amount * price — one branch, in
   # one place, rather than the same rule spelled twice in two languages.
   def chart_buy_marks
-    transactions.submitted.buy.order(:created_at)
-                .pluck(:created_at, :base, :price, :amount, :amount_exec, :quote_amount_exec, :external_status)
-                .filter_map do |at, base, price, amount, amount_exec, quote_amount_exec, external_status|
+    marks = transactions.submitted.buy.order(:created_at)
+                        .pluck(:created_at, :base, :price, :amount, :amount_exec, :quote_amount_exec, :external_status)
+                        .filter_map do |at, base, price, amount, amount_exec, quote_amount_exec, external_status|
       amount_exec, quote_amount_exec =
         Transaction.confirmed_exec_amounts(external_status, price, amount, amount_exec, quote_amount_exec)
       next if price.blank? || amount_exec.blank? || quote_amount_exec.blank?
@@ -42,6 +51,21 @@ module Bot::ChartSeries
 
       [at, base]
     end
+    chart_thinned_marks(marks)
+  end
+
+  # One mark per symbol per bucket, keeping the FIRST in each — so the first and last buys of the
+  # history both survive, and a symbol that only ever traded once is never thinned away. Applied
+  # only when there are more marks than buckets: the ordinary bot pays nothing for this.
+  def chart_thinned_marks(marks)
+    return marks if marks.size <= MARK_BUCKETS
+
+    first = marks.first[0]
+    span = marks.last[0] - first
+    return marks if span.zero?
+
+    seen = Set.new
+    marks.select { |at, base| seen.add?([((at - first) / span * MARK_BUCKETS).floor, base]) }
   end
 
   # The seam every candle fetch goes through. Overridable in tests, and the reason the index's

--- a/app/models/bot/rebalance_accounting.rb
+++ b/app/models/bot/rebalance_accounting.rb
@@ -165,16 +165,10 @@ module Bot::RebalanceAccounting
     { basis: 0, cash: 0, contributed: 0, realised_cash: 0, realised_pnl: 0 }
   end
 
-  # The "null exec means it filled for the requested amount" fallback covers legacy rows that were
-  # never backfilled, and is only sound for CONFIRMED ones. An accepted-but-unfilled order
-  # (open/unknown) or a cancelled one must not be assumed filled, or its requested amount becomes
-  # phantom holdings the rebalance leg would then trade against.
-  def confirmed_exec_amounts(external_status, price, amount, amount_exec, quote_amount_exec)
-    if external_status == 'closed'
-      quote_amount_exec ||= price * amount if price.present? && amount.present?
-      amount_exec ||= amount
-    end
-    [amount_exec, quote_amount_exec]
+  # Lives on Transaction — the rule is about how to read one row, and the chart marks need it on
+  # bots that do no rebalancing at all.
+  def confirmed_exec_amounts(...)
+    Transaction.confirmed_exec_amounts(...)
   end
 
   private

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -73,6 +73,21 @@ class Transaction < ApplicationRecord
 
   BTC = %w[XXBT XBT BTC].freeze
 
+  # The "null exec means it filled for the requested amount" fallback covers legacy rows that were
+  # never backfilled, and is only sound for CONFIRMED ones. An accepted-but-unfilled order
+  # (open/unknown) or a cancelled one must not be assumed filled, or its requested amount becomes
+  # phantom holdings the rebalance leg would then trade against.
+  #
+  # A class method taking loose columns, because every caller reads these rows by `pluck` — the
+  # metrics walk over tens of thousands of them and never instantiate one.
+  def self.confirmed_exec_amounts(external_status, price, amount, amount_exec, quote_amount_exec)
+    if external_status == 'closed'
+      quote_amount_exec ||= price * amount if price.present? && amount.present?
+      amount_exec ||= amount
+    end
+    [amount_exec, quote_amount_exec]
+  end
+
   # TODO: Migrate Transaction to directly reference assets instead of symbols
   def base_asset
     @base_asset ||= exchange.assets.find_by(symbol: base) ||

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -36,14 +36,17 @@
            { value: serie[:value].map { |amount| amount&.round(decimals)&.to_f },
              invested: serie[:invested].map { |amount| amount.to_d.round(decimals).to_f } }
          end %>
-      <%# Every executed buy, as a mark under the plot: when, and in what. Logos resolved through
-          the exchange's tickers the same way the holdings tables do it. %>
-      <% fills = bot.transactions.submitted.buy.where.not(price: nil).order(:created_at).pluck(:created_at, :base) %>
-      <% logo_assets = bot.exchange.tickers.where(base: fills.map(&:last).uniq).includes(:base_asset).index_by(&:base) %>
-      <% buys = fills.map do |at, base|
-           asset = logo_assets[base]&.base_asset
-           { x: at.in_time_zone(current_user.time_zone), symbol: base,
-             image: asset&.image_url, color: ensure_contrast(asset&.color || '#8A9BA8') }
+      <%# Every executed buy, as a mark under the plot: when, and in what.
+          `[time, symbol]` pairs and a symbol => logo map, NOT a logo per fill: an hourly bot
+          running for a year is ~9,000 marks, and repeating a CDN image URL on each of them would
+          put megabytes into one data attribute for the browser to parse on every broadcast.
+          Logos resolved through the exchange's tickers the same way the holdings tables do it. %>
+      <% marks = bot.chart_buy_marks %>
+      <% logo_assets = bot.exchange.tickers.where(base: marks.map(&:last).uniq).includes(:base_asset).index_by(&:base) %>
+      <% buys = marks.map { |at, base| [at.in_time_zone(current_user.time_zone), base] } %>
+      <% buy_logos = logo_assets.transform_values do |ticker|
+           { image: ticker.base_asset&.image_url,
+             color: ensure_contrast(ticker.base_asset&.color || '#8A9BA8') }
          end %>
       <%= tag.div data: {
         controller: "bot--chart",
@@ -58,7 +61,8 @@
         bot__chart_pnl_value: pnl_series,
         bot__chart_assets_value: assets,
         bot__chart_pnl_only_value: hide_money,
-        bot__chart_buys_value: buys
+        bot__chart_buys_value: buys,
+        bot__chart_buy_logos_value: buy_logos
       } do %>
         <%# The switch sits on the date line, opposite it: one row across the top of the plot.
             PnL FIRST and on by default: VALUE always climbs for a DCA bot because the money going

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -36,14 +36,19 @@
            { value: serie[:value].map { |amount| amount&.round(decimals)&.to_f },
              invested: serie[:invested].map { |amount| amount.to_d.round(decimals).to_f } }
          end %>
-      <%# Every executed buy, as a mark under the plot: when, and in what.
-          `[time, symbol]` pairs and a symbol => logo map, NOT a logo per fill: an hourly bot
-          running for a year is ~9,000 marks, and repeating a CDN image URL on each of them would
-          put megabytes into one data attribute for the browser to parse on every broadcast.
+      <%# Every executed buy, as a mark under the plot: when, in what, and how much of it.
+          Tuples plus one symbol => logo map, NOT a logo per mark: an hourly bot running for a
+          year is ~9,000 of them, and repeating a CDN image URL on each would put megabytes into
+          one data attribute for the browser to parse on every broadcast.
           Logos resolved through the exchange's tickers the same way the holdings tables do it. %>
       <% marks = bot.chart_buy_marks %>
-      <% logo_assets = bot.exchange.tickers.where(base: marks.map(&:last).uniq).includes(:base_asset).index_by(&:base) %>
-      <% buys = marks.map { |at, base| [at.in_time_zone(current_user.time_zone), base] } %>
+      <% symbols = marks.map { |mark| mark[1] }.uniq %>
+      <% logo_assets = bot.exchange.tickers.where(base: symbols).includes(:base_asset).index_by(&:base) %>
+      <%# `to_f` on the amounts, not `to_s`: a BigDecimal serializes into a data attribute as a
+          JSON STRING, and the stack would then sort its logos alphabetically by a number. %>
+      <% buys = marks.map do |at, base, amount, quote, fills|
+           [at.in_time_zone(current_user.time_zone), base, amount.to_f, quote.to_f, fills]
+         end %>
       <% buy_logos = logo_assets.transform_values do |ticker|
            { image: ticker.base_asset&.image_url,
              color: ensure_contrast(ticker.base_asset&.color || '#8A9BA8') }

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -36,6 +36,15 @@
            { value: serie[:value].map { |amount| amount&.round(decimals)&.to_f },
              invested: serie[:invested].map { |amount| amount.to_d.round(decimals).to_f } }
          end %>
+      <%# Every executed buy, as a mark under the plot: when, and in what. Logos resolved through
+          the exchange's tickers the same way the holdings tables do it. %>
+      <% fills = bot.transactions.submitted.buy.where.not(price: nil).order(:created_at).pluck(:created_at, :base) %>
+      <% logo_assets = bot.exchange.tickers.where(base: fills.map(&:last).uniq).includes(:base_asset).index_by(&:base) %>
+      <% buys = fills.map do |at, base|
+           asset = logo_assets[base]&.base_asset
+           { x: at.in_time_zone(current_user.time_zone), symbol: base,
+             image: asset&.image_url, color: ensure_contrast(asset&.color || '#8A9BA8') }
+         end %>
       <%= tag.div data: {
         controller: "bot--chart",
         action: "mouseover@document->bot--chart#focus mouseleave@document->bot--chart#blur " \
@@ -48,7 +57,8 @@
         bot__chart_series_value: series,
         bot__chart_pnl_value: pnl_series,
         bot__chart_assets_value: assets,
-        bot__chart_pnl_only_value: hide_money
+        bot__chart_pnl_only_value: hide_money,
+        bot__chart_buys_value: buys
       } do %>
         <%# The switch sits on the date line, opposite it: one row across the top of the plot.
             PnL FIRST and on by default: VALUE always climbs for a DCA bot because the money going
@@ -88,6 +98,9 @@
         <div class="widget--chart__plot">
           <canvas data-bot--chart-target="analyzerChart" width="10" height="2"></canvas>
         </div>
+        <%# Positioned from the chart's own x scale, so it shares the plot's width and nothing else.
+            Populated by the controller after every build. %>
+        <div class="widget--chart__buys" data-bot--chart-target="buys"></div>
 
       <% end %>
     <% end %>

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -104,12 +104,26 @@
                  data-bot--chart-target="percent">&nbsp;</div>
           </div>
         </div>
+        <%# The marks live INSIDE the plot, hanging off its floor: they are a reading of the same
+            curve, at the same x scale, and a strip below the chart made them a second thing to
+            look at. The row itself has no height at all — the stacks hang upward over the plot,
+            so showing them never moves the chart or the page. %>
         <div class="widget--chart__plot">
           <canvas data-bot--chart-target="analyzerChart" width="10" height="2"></canvas>
+          <div class="widget--chart__buys" data-bot--chart-target="buys"></div>
         </div>
-        <%# Positioned from the chart's own x scale, so it shares the plot's width and nothing else.
-            Populated by the controller after every build. %>
-        <div class="widget--chart__buys" data-bot--chart-target="buys"></div>
+        <%# Off by choice, not by default: the marks sit over the curve, and a reader who came for
+            the shape of the line should get the line. The choice is remembered per browser. %>
+        <div class="widget--chart__orders">
+          <label class="toggle-group">
+            <div class="toggle">
+              <input type="checkbox" data-bot--chart-target="orders"
+                     data-action="change->bot--chart#toggleOrders">
+              <div class="toggle__style"></div>
+            </div>
+            <span class="toggle-group__info__label"><%= t('bot.details.stats.chart.orders') %></span>
+          </label>
+        </div>
 
       <% end %>
     <% end %>

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -114,14 +114,17 @@
         </div>
         <%# Off by choice, not by default: the marks sit over the curve, and a reader who came for
             the shape of the line should get the line. The choice is remembered per browser. %>
+        <%# The tracker's Show cash switch, in the same shape: small toggle, label as the hit area.
+            No form behind it — this one is a way of reading the chart in front of you, so it is
+            remembered in the browser rather than posted and stored against the account. %>
         <div class="widget--chart__orders">
-          <label class="toggle-group">
-            <div class="toggle">
+          <label>
+            <div class="toggle toggle--small">
               <input type="checkbox" data-bot--chart-target="orders"
                      data-action="change->bot--chart#toggleOrders">
               <div class="toggle__style"></div>
             </div>
-            <span class="toggle-group__info__label"><%= t('bot.details.stats.chart.orders') %></span>
+            <span class="label"><%= t('bot.details.stats.chart.orders') %></span>
           </label>
         </div>
 

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -118,7 +118,7 @@
             No form behind it — this one is a way of reading the chart in front of you, so it is
             remembered in the browser rather than posted and stored against the account. %>
         <div class="widget--chart__orders">
-          <label>
+          <label class="toggle-inline">
             <div class="toggle toggle--small">
               <input type="checkbox" data-bot--chart-target="orders"
                      data-action="change->bot--chart#toggleOrders">

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -136,6 +136,7 @@ bg:
                 average_price: 'Средна цена'
                 bought: Купено
                 chart:
+                    orders: 'Показване на поръчките'
                     modes: 'Режим на графиката'
                     pnl: 'P/L'
                     total_invested: 'Общо инвестирано'

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -136,6 +136,7 @@ cs:
                 average_price: 'Průměrná cena'
                 bought: Nakoupeno
                 chart:
+                    orders: 'Zobrazit příkazy'
                     modes: 'Režim grafu'
                     pnl: 'P/L'
                     total_invested: 'Celkem investováno'

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -136,6 +136,7 @@ da:
                 average_price: 'Gennemsnitspris'
                 bought: Købt
                 chart:
+                    orders: 'Vis ordrer'
                     modes: 'Diagramtilstand'
                     pnl: 'P/L'
                     total_invested: 'Samlet investeret'

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -134,6 +134,7 @@ de:
                 average_price: Durchschnittspreis
                 bought: Gekauft
                 chart:
+                    orders: 'Orders anzeigen'
                     modes: 'Diagrammmodus'
                     pnl: 'P/L'
                     total_invested: 'Insgesamt investiert'

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -136,6 +136,7 @@ el:
                 average_price: 'Μέση τιμή'
                 bought: Αγοράστηκε
                 chart:
+                    orders: 'Εμφάνιση εντολών'
                     modes: 'Λειτουργία γραφήματος'
                     pnl: 'P/L'
                     total_invested: 'Σύνολο επένδυσης'

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -136,6 +136,7 @@ en:
                 average_price: 'Average price'
                 bought: Bought
                 chart:
+                    orders: 'Show orders'
                     modes: 'Chart mode'
                     pnl: 'P/L'
                     total_invested: 'Total invested'

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -138,6 +138,7 @@ es:
                 average_price: 'Precio medio'
                 bought: Comprado
                 chart:
+                    orders: 'Mostrar órdenes'
                     modes: 'Modo del gráfico'
                     pnl: 'P/L'
                     total_invested: 'Total invertido'

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -138,6 +138,7 @@ fr:
                 average_price: 'Prix moyen'
                 bought: 'Acheté'
                 chart:
+                    orders: 'Afficher les commandes'
                     modes: 'Mode du graphique'
                     pnl: 'P/L'
                     total_invested: 'Total investi'

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -136,6 +136,7 @@ it:
                 average_price: 'Prezzo medio'
                 bought: Acquistato
                 chart:
+                    orders: 'Mostra ordini'
                     modes: 'Modalità grafico'
                     pnl: 'P/L'
                     total_invested: 'Totale investito'

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -138,6 +138,7 @@ nl:
                 average_price: 'Gemiddelde prijs'
                 bought: Gekocht
                 chart:
+                    orders: 'Orders tonen'
                     modes: 'Grafiekmodus'
                     pnl: 'P/L'
                     total_invested: 'Totaal geïnvesteerd'

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -138,6 +138,7 @@ pl:
                 average_price: 'Średnia cena'
                 bought: Zakupione
                 chart:
+                    orders: 'Pokaż zlecenia'
                     modes: 'Tryb wykresu'
                     pnl: 'P/L'
                     total_invested: 'Zainwestowana suma'

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -136,6 +136,7 @@ pt:
                 average_price: 'Preço médio'
                 bought: Comprado
                 chart:
+                    orders: 'Mostrar ordens'
                     modes: 'Modo do gráfico'
                     pnl: 'P/L'
                     total_invested: 'Total investido'

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -136,6 +136,7 @@ ru:
                 average_price: 'Средняя цена'
                 bought: Куплено
                 chart:
+                    orders: 'Показать ордера'
                     modes: 'Режим графика'
                     pnl: 'P/L'
                     total_invested: 'Всего инвестировано'

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -136,6 +136,7 @@ sk:
                 average_price: 'Priemerná cena'
                 bought: Nakúpené
                 chart:
+                    orders: 'Zobraziť príkazy'
                     modes: 'Režim grafu'
                     pnl: 'P/L'
                     total_invested: 'Celkom investované'

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -136,6 +136,7 @@ sv:
                 average_price: 'Snittpris'
                 bought: Köpt
                 chart:
+                    orders: 'Visa ordrar'
                     modes: 'Diagramläge'
                     pnl: 'P/L'
                     total_invested: 'Totalt investerat'

--- a/test/models/bot/chart_buy_marks_test.rb
+++ b/test/models/bot/chart_buy_marks_test.rb
@@ -13,7 +13,7 @@ class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
   end
 
   def mark_symbols
-    bot.chart_buy_marks.map(&:last)
+    bot.chart_buy_marks.map { |mark| mark[1] }
   end
 
   test 'an executed buy is marked' do
@@ -83,7 +83,7 @@ class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
     create(:transaction, bot: bot, base: 'BTC', created_at: 2.days.ago)
     create(:transaction, bot: bot, base: 'ETH', created_at: 1.day.ago)
 
-    times, symbols = bot.chart_buy_marks.transpose
+    times, symbols, = bot.chart_buy_marks.transpose
 
     assert_equal %w[BTC ETH], symbols
     assert times[0] < times[1]
@@ -117,7 +117,7 @@ class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
     marks = bot.chart_buy_marks
 
     assert_operator marks.size, :<=, (Bot::ChartSeries::MARK_BUCKETS + 1) * 2
-    assert_equal %w[BTC ETH].to_set, marks.to_set(&:last)
+    assert_equal(%w[BTC ETH].to_set, marks.to_set { |mark| mark[1] })
   end
 
   test 'thinning keeps both ends of the history' do
@@ -134,5 +134,31 @@ class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
     3.times { |i| create(:transaction, bot: bot, base: 'BTC', created_at: i.days.ago) }
 
     assert_equal 3, bot.chart_buy_marks.size
+  end
+
+  # The mark says what it bought, so collapsing fills has to add them up. Sampling one and
+  # dropping the rest would understate a purchase in the tooltip.
+  test 'thinning sums the fills it collapses rather than dropping them' do
+    seed_dense_history(4000)
+
+    marks = bot.chart_buy_marks
+
+    assert_operator marks.size, :<, 4000, 'expected this history to be thinned at all'
+    assert_equal(4000, marks.sum { |mark| mark[4] })
+    assert_in_delta 4000 * 0.001, marks.sum { |mark| mark[2] }, 1e-6
+    assert_in_delta 4000 * 50, marks.sum { |mark| mark[3] }, 1e-6
+  end
+
+  test 'a mark carries the amount and the value that actually executed' do
+    create(:transaction, bot: bot, base: 'BTC', amount: 0.002, price: 50_000,
+                         amount_exec: 0.001, quote_amount_exec: 47)
+
+    at, symbol, amount, quote, fills = bot.chart_buy_marks.sole
+
+    assert at
+    assert_equal 'BTC', symbol
+    assert_equal 0.001.to_d, amount
+    assert_equal 47.to_d, quote
+    assert_equal 1, fills
   end
 end

--- a/test/models/bot/chart_buy_marks_test.rb
+++ b/test/models/bot/chart_buy_marks_test.rb
@@ -88,4 +88,51 @@ class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
     assert_equal %w[BTC ETH], symbols
     assert times[0] < times[1]
   end
+
+  # A five-minute bot buying twenty assets for a year is millions of rows, and every one of them
+  # would be serialized into a data attribute on every render and every metrics broadcast. Two
+  # marks closer together than a pixel cannot be told apart on any plot this app draws, so only
+  # one of them is worth shipping.
+  #
+  # Rows go in with `insert_all` — the factory's per-row broadcasts and jobs turn a few thousand
+  # of them into a minute of test time, and none of that is what this is checking.
+  def seed_dense_history(rows, symbols: ['BTC'])
+    start = 1.year.ago.change(usec: 0)
+    now = Time.current
+    Transaction.insert_all(
+      Array.new(rows) do |i|
+        { bot_id: bot.id, exchange_id: bot.exchange_id, base: symbols[i % symbols.size],
+          quote: 'USD', price: 50_000, amount: 0.001, amount_exec: 0.001, quote_amount: 50,
+          quote_amount_exec: 50, status: 0, side: 0, external_status: 2,
+          transaction_type: 'REGULAR', bot_interval: '', bot_quote_amount: 0,
+          error_messages: '[]', created_at: start + (i * 2).hours, updated_at: now }
+      end
+    )
+    start
+  end
+
+  test 'a history too dense to draw is thinned, keeping each symbol once per bucket' do
+    seed_dense_history(4000, symbols: %w[BTC ETH])
+
+    marks = bot.chart_buy_marks
+
+    assert_operator marks.size, :<=, (Bot::ChartSeries::MARK_BUCKETS + 1) * 2
+    assert_equal %w[BTC ETH].to_set, marks.to_set(&:last)
+  end
+
+  test 'thinning keeps both ends of the history' do
+    start = seed_dense_history(4000)
+    last = bot.transactions.maximum(:created_at)
+
+    marks = bot.chart_buy_marks
+
+    assert_in_delta start.to_f, marks.first.first.to_f, 1
+    assert_operator marks.last.first, :>, last - 2.days
+  end
+
+  test 'a history small enough to draw is not thinned' do
+    3.times { |i| create(:transaction, bot: bot, base: 'BTC', created_at: i.days.ago) }
+
+    assert_equal 3, bot.chart_buy_marks.size
+  end
 end

--- a/test/models/bot/chart_buy_marks_test.rb
+++ b/test/models/bot/chart_buy_marks_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The marks under the chart have to name the same fills the curve above them is drawn from.
+# A row that carries a price but never executed — an order still open, or cancelled before it
+# filled — would otherwise put a logo under a purchase that never happened.
+class Bot::ChartBuyMarksTest < ActiveSupport::TestCase
+  # Lazy, not a `setup`: the two-asset test below builds its own bot, and a bitcoin asset created
+  # eagerly here would collide with the one that factory creates.
+  def bot
+    @bot ||= create(:dca_single_asset, :started)
+  end
+
+  def mark_symbols
+    bot.chart_buy_marks.map(&:last)
+  end
+
+  test 'an executed buy is marked' do
+    create(:transaction, bot: bot, base: 'BTC')
+
+    assert_equal ['BTC'], mark_symbols
+  end
+
+  test 'a sell is not a buy' do
+    create(:transaction, bot: bot, base: 'BTC', side: :sell)
+
+    assert_empty mark_symbols
+  end
+
+  test 'an order still open with nothing executed is not marked' do
+    create(:transaction, bot: bot, base: 'BTC', external_status: :open,
+                         amount_exec: nil, quote_amount_exec: nil)
+
+    assert_empty mark_symbols
+  end
+
+  test 'an order cancelled before it filled is not marked' do
+    create(:transaction, bot: bot, base: 'BTC', external_status: :cancelled,
+                         amount_exec: nil, quote_amount_exec: nil)
+
+    assert_empty mark_symbols
+  end
+
+  test 'an order cancelled after a partial fill is marked' do
+    create(:transaction, bot: bot, base: 'BTC', external_status: :cancelled,
+                         amount_exec: 0.0004, quote_amount_exec: 20)
+
+    assert_equal ['BTC'], mark_symbols
+  end
+
+  # `confirmed_exec_amounts` fills a closed row's execution in from amount * price, and the
+  # metrics count it — so the mark has to count it too.
+  test 'a closed order whose execution was never written back is marked' do
+    create(:transaction, bot: bot, base: 'BTC', external_status: :closed,
+                         amount_exec: nil, quote_amount_exec: nil)
+
+    assert_equal ['BTC'], mark_symbols
+  end
+
+  test 'a zero fill is not a fill' do
+    create(:transaction, bot: bot, base: 'BTC', amount_exec: 0, quote_amount_exec: 0)
+
+    assert_empty mark_symbols
+  end
+
+  test 'a row with no price at all is not marked' do
+    create(:transaction, bot: bot, base: 'BTC', price: nil,
+                         amount_exec: nil, quote_amount_exec: nil)
+
+    assert_empty mark_symbols
+  end
+
+  test 'a failed attempt is not marked' do
+    create(:transaction, bot: bot, base: 'BTC', status: :failed)
+
+    assert_empty mark_symbols
+  end
+
+  # A two-asset bot, so the pairing of a time with its own symbol is actually visible.
+  test 'marks arrive oldest first, each with its own time' do
+    bot = create(:dca_dual_asset, :started)
+    create(:transaction, bot: bot, base: 'BTC', created_at: 2.days.ago)
+    create(:transaction, bot: bot, base: 'ETH', created_at: 1.day.ago)
+
+    times, symbols = bot.chart_buy_marks.transpose
+
+    assert_equal %w[BTC ETH], symbols
+    assert times[0] < times[1]
+  end
+end


### PR DESCRIPTION
Asset logos hanging off the floor of the bot chart, one mark per executed buy, placed on the chart's own x scale so a mark sits under the point it moved.

The marks live inside the plot rather than in a strip below it, and the row they sit in has no height of its own: the stacks are anchored to its baseline and grow upward over the curve, so turning them on — or opening one — never moves the chart or the page. They are off by default, behind a **Show orders** toggle under the chart that remembers the choice per browser. While off nothing is built at all rather than built and hidden, which on a twenty-asset index is hundreds of elements per redraw.

## Collapsing

Marks whose logos would overlap horizontally by more than half a logo width collapse into a single vertical stack, chained left to right so a run of buys a few pixels apart stays one crowd rather than drifting apart again. A stack carries each asset once, so a bot that buys eleven coins in one second reads as eleven assets rather than as however many fills the venue split them into.

Within a stack the marks are ranked smallest buy first, so the one painted last — the one on top — is the biggest of that crowd, and it is the only one wearing its logo while the stack is closed. The rest show their asset's colour, each sticking out half a logo. On a 20-asset index that is the difference between a row taller than the chart and one about a fifth of its height.

Hovering a stack unfolds it upward to a full logo of each, fading the logos in. The stack is anchored at its bottom, so the biggest buy never moves.

## The card

One hover does all of it — unfold, logos, and the card that reads the stack out.

The card is one per stack, not one per mark. It sits beside the stack, since the stack unfolds upward over the plot and a card below would cover the very curve being read, and it is held open by the stack's own hover: moving from one mark to the next rewrites it rather than dismissing it and building another one a few pixels over. It wears the dropdown's surface, so a box floating over the page reads as the same kind of object as every other one here.

Each mark names the purchase behind it: date, ticker, amount, and the price the money went through at. The price is derived from the totals rather than read off a row, so a mark standing for several fills states the price of the whole crowd rather than one arbitrary member of it, and a mark covering more than one buy says how many.

## Following the chart

The row is rebuilt on every chart build, so the P/L–Value switch, the range window, a resize and a focused holding all keep it aligned. Buys outside the window in view are not marked, and while a holdings row is focused only that asset's buys are.

## What a mark is allowed to claim

A mark says the bot bought something at that time, so it has to be true in both coordinates.

A transaction row carrying a price has not necessarily bought anything — an order still open, or cancelled before it filled, carries a price and no execution. The marks come from the same rows the metrics count, run through the same execution rule. That rule moves from `Bot::RebalanceAccounting` to `Transaction`, since it describes how to read one row and is needed on bots that do no rebalancing at all; the concern keeps the method name for its own callers.

The chart's metrics are cached for minutes while transactions are read live, so a buy can be newer than the last chart label. Marks are bounded at both ends of the series in view — otherwise such a buy is clamped onto the final point and dated to a day it did not happen on.

## Payload

The marks ship as `[time, symbol]` pairs plus one symbol-to-logo map, rather than a logo hash per fill repeating the same image URL thousands of times. A 20-asset index with 560 fills went from roughly 85KB to 23KB.

Beyond that, a history longer than the plot can draw is thinned to one mark per symbol per 1/500th of its span. The browser collapses marks by pixel proximity regardless, so two in the same bucket land in the same stack at any width this app renders; shipping both only costs bytes, and one tuple per fill for the life of a frequently-trading bot is unbounded. Bucketed marks are timed at their first fill, so both ends of the history survive and a symbol that traded once is never thinned away — and they SUM what they collapse rather than sampling one of it, since a mark that states an amount must not understate it. A history short enough to draw is untouched.

## Tests

`test/models/bot/chart_buy_marks_test.rb` covers which rows earn a mark — executed buys, partial fills, and closed rows whose execution was never written back are marked; sells, unfilled open orders, orders cancelled before filling, zero fills, priceless rows and failed attempts are not — what a mark carries, and that thinning conserves the fills, amounts and values it collapses. The positioning, ordering, unfolding, card and toggle are browser-side and checked by hand; this repo has no JS test harness.
