### PR TITLE
Draw the account's P/L behind the dashboard headline

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -173,16 +173,46 @@ ol, ul
                 line-height: calc(3rem * 0.6)
                 letter-spacing: calc(0.25rem * 0.6)
 
+// The dashboard headline, and the P/L curve that runs into it.
+//
+// The rule under the number is the chart's ZERO line, which is why it is drawn as an absolute rule
+// at --dash-height rather than as the section's own border: a curve dipping into loss hangs below
+// it, and a border would follow the box down. The section grows by exactly that much instead, so
+// the space under the line is reserved rather than borrowed from the row beneath.
 .dash-intro
-    border-bottom: 0.1rem solid var(--steel)
+    --dash-height: 7rem
+    position: relative
     display: flex
-    flex-direction: column
-    justify-content: flex-end
-    align-items: flex-end
-    overflow: hidden
-    height: 7rem
+    min-height: var(--dash-height)
     @media only screen and (min-width: 768px)
         display: flex
+    &::after
+        content: ''
+        position: absolute
+        left: 0
+        right: 0
+        top: var(--dash-height)
+        border-bottom: 0.1rem solid var(--steel)
+    #global-pnl
+        display: flex
+        flex: 1
+        min-width: 0
+        min-height: var(--dash-height)
+        align-items: flex-start
+        justify-content: flex-end
+        // The one thing here that still belongs at the bottom of the box.
+        > .loader--small
+            align-self: flex-end
+    // The number is set at 8.2rem in a 7rem line box and pulled a further 1rem down: it is MEANT
+    // to sit on the line and be cropped by it, which is what this box keeps doing now that the
+    // section itself has to let the curve out.
+    &__figure
+        display: flex
+        flex-direction: column
+        justify-content: flex-end
+        height: var(--dash-height)
+        overflow: hidden
+        text-align: right
     h1
         color: var(--steel)
         display: block
@@ -191,3 +221,68 @@ ol, ul
         max-height: 7rem
         margin-bottom: -1rem
         font-weight: 600 !important
+    // Whatever width the number leaves, and twice the height of the headline: the box above the
+    // zero line, mirrored below it. Fixed rather than cut to each account's worst day — the rest
+    // of the page would otherwise sit at a height that means something only to this curve.
+    &__spark
+        display: flex
+        flex: 1
+        min-width: 0
+        height: calc(var(--dash-height) * 2)
+        // The curve is a desktop reading. On a phone the headline already fills the row, and the
+        // space a loss reserves below the line comes out of a layout that has none to give — so
+        // the plot goes entirely, and the section is the 7rem box it always was.
+        @media only screen and (max-width: 767.9px)
+            display: none
+        // Held back until the headline's box has been measured (see pnl_spark_controller.js). The
+        // figure has no reserved width on the first paint, so the curve would be drawn to the
+        // wrong edge and then snap across to the right one.
+        visibility: hidden
+        .is-measured &
+            visibility: visible
+        // Pushed right so the curve always ENDS at the figure it explains; its width is how much
+        // history there is to draw, full at thirty days.
+        &__curve
+            position: relative
+            margin-left: auto
+            height: 100%
+            svg
+                display: block
+                width: 100%
+                height: 100%
+                // A point that reaches an edge is drawn ON it, so half its stroke falls outside
+                // the box. There is nothing to protect there — the section reserved the room.
+                overflow: visible
+        // Green above the zero line, red below it, as on every other chart here. Each half is the
+        // same shape under its own clip, so the colour changes where the curve crosses rather than
+        // at the nearest point to it.
+        .is-gain
+            color: var(--grass)
+        .is-loss
+            color: var(--berry)
+        &__area
+            fill: currentColor
+            opacity: 0.12
+        &__line
+            fill: none
+            stroke: currentColor
+            stroke-width: 0.25rem
+            stroke-linejoin: round
+            stroke-linecap: round
+        &__end,
+        &__dot
+            position: absolute
+            width: 0.75rem
+            height: 0.75rem
+            margin: -0.375rem 0 0 -0.375rem
+            border-radius: 50%
+            pointer-events: none
+        // The last point, always marked; it hangs half off the right edge the way the charts let
+        // theirs hang off the plot.
+        &__end
+            left: 100%
+            background: currentColor
+        // And the hovered one, a ring instead of a disc so the two never read as one figure.
+        &__dot
+            background: var(--washed)
+            border: 0.25rem solid currentColor

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -64,6 +64,14 @@ class BotsController < ApplicationController
     global_pnl_snapshot = current_user.global_pnl_snapshot(cache_only: true)
     @global_pnl = global_pnl_snapshot[:result]
     @global_pnl_loading = global_pnl_snapshot[:loading]
+    # The same figure over time. Its source is the candle-marked metrics the bot charts use, which
+    # nothing warms in the background — so like the headline it has a waiting state, and the view
+    # asks for the live pass that fills it.
+    if @global_pnl
+      history = User::PnlHistory.snapshot(current_user)
+      @global_pnl_history = history[:result]
+      @global_pnl_history_loading = history[:loading]
+    end
     # Figures stay in USD all the way here; this is the one rate that turns the whole page
     # into the account's chosen fiat.
     @denomination = current_user.denomination

--- a/app/helpers/bot_helper.rb
+++ b/app/helpers/bot_helper.rb
@@ -25,6 +25,105 @@ module BotHelper
     values.each_with_index.map { |value, i| value.to_d - (invested[i] || 0).to_d }
   end
 
+  # == the dashboard's mini P/L curve ==
+  #
+  # The zero line is the bottom rule of `.dash-intro`, which is why the geometry is written in a
+  # 100-unit box ABOVE it: y=100 is that rule, y=0 is the top of the headline. Below the rule is
+  # the same box mirrored — a fixed 100 units, not however deep this account's worst day happens
+  # to be, so the page under the chart sits where it sits whatever the curve does.
+  #
+  # The plot itself is drawn the way the bot and tracker charts draw theirs: one smoothed curve,
+  # green above the line and red below it, filled to the line, with a dot on the last point.
+  # Splitting the colours is left to two clip paths in the view, so the crossing is exact rather
+  # than resolved per segment.
+
+  # Ten percent to reach an edge. Without a floor the scale is whatever the account happened to do,
+  # so a flat fortnight would be redrawn as a mountain range and touching the top would mean
+  # nothing at all.
+  SPARK_MIN_SCALE = 0.10
+  # And thirty days to earn the full width. A week-old account gets a short curve rather than one
+  # stretched out of nothing.
+  SPARK_FULL_DAYS = 30
+
+  # The headline's two formats, in one place: the view writes them and pnl_spark_controller.js
+  # rebuilds them under the pointer. Two readings of one figure that have to agree character for
+  # character, or the number changes shape as it is hovered.
+  def pnl_headline_percent(value)
+    "#{'+' if value.positive?}#{format_percent(value, precision: 2)}"
+  end
+
+  def pnl_headline_amount(usd, denomination)
+    safe_join([('+' if usd.positive?), denomination.format(usd, precision: 0)].compact)
+  end
+
+  def pnl_spark(history)
+    percent = history[:percent]
+    scale = [percent.map(&:abs).max, SPARK_MIN_SCALE].max
+    points = percent.each_with_index.map do |value, i|
+      [i * (100.0 / (percent.size - 1)), (1 - (value / scale)) * 100]
+    end
+    curve = spark_curve(points)
+
+    {
+      path: curve,
+      # Closed along the zero line, so the ribbon is the distance from it — the same thing the
+      # curve is. One shape for both colours; the view clips it into halves.
+      area: "#{curve} L100,100 L0,100 Z",
+      scale: scale,
+      # Where the last point sits in the whole 200-unit box, for the dot that marks it — a
+      # percentage, because that box is only ever measured in rems by the CSS.
+      end_y: (points.last[1] / 2).round(3),
+      width: ([history[:days] / SPARK_FULL_DAYS.to_f, 1].min * 100).round(2),
+      gain: !percent.last.negative?
+    }
+  end
+
+  private
+
+  # Monotone cubic interpolation (Fritsch–Carlson), which is what `cubicInterpolationMode:
+  # "monotone"` gives the charts this curve is meant to match. Monotone and not a plain spline
+  # because it cannot overshoot the data: the box is sized to the extremes, so a curve that
+  # bulged past them would be drawn straight into the clip.
+  def spark_curve(points)
+    slopes = spark_slopes(points)
+    segments = points.each_cons(2).with_index.map do |(from, to), i|
+      third = (to[0] - from[0]) / 3.0
+      format('C%g,%g %g,%g %g,%g',
+             (from[0] + third).round(2), (from[1] + (slopes[i] * third)).round(2),
+             (to[0] - third).round(2), (to[1] - (slopes[i + 1] * third)).round(2),
+             to[0].round(2), to[1].round(2))
+    end
+
+    "M#{format('%g,%g', points[0][0].round(2), points[0][1].round(2))} #{segments.join(' ')}"
+  end
+
+  # The tangent at each point: the average of its neighbours' secants, then pulled back wherever
+  # that would turn a rise into a dip.
+  def spark_slopes(points)
+    secants = points.each_cons(2).map { |from, to| (to[1] - from[1]) / (to[0] - from[0]) }
+    slopes = [secants.first] + secants.each_cons(2).map { |before, after| (before + after) / 2.0 } + [secants.last]
+
+    secants.each_with_index do |secant, i|
+      if secant.zero?
+        slopes[i] = slopes[i + 1] = 0.0
+        next
+      end
+
+      alpha = slopes[i] / secant
+      beta = slopes[i + 1] / secant
+      slopes[i] = 0.0 if alpha.negative?
+      slopes[i + 1] = 0.0 if beta.negative?
+      next unless (alpha**2) + (beta**2) > 9
+
+      tau = 3.0 / Math.sqrt((alpha**2) + (beta**2))
+      slopes[i] = tau * alpha * secant
+      slopes[i + 1] = tau * beta * secant
+    end
+    slopes
+  end
+
+  public
+
   # Per-exchange label for the API key field, with a generic translated fallback.
   # Each exchange MAY define its own `bot.api.<exchange>.public_key` /
   # `private_key`; when it doesn't, we use the localized generic label under

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -136,6 +136,9 @@ application.register("pie-chart", PieChartController)
 import PnlFormatController from "./pnl_format_controller"
 application.register("pnl-format", PnlFormatController)
 
+import PnlSparkController from "./pnl_spark_controller"
+application.register("pnl-spark", PnlSparkController)
+
 import ProgressBarController from "./progress_bar_controller"
 application.register("progress-bar", ProgressBarController)
 

--- a/app/javascript/controllers/pnl_spark_controller.js
+++ b/app/javascript/controllers/pnl_spark_controller.js
@@ -1,0 +1,135 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="pnl-spark"
+//
+// The dashboard headline, read at a day the pointer picks. Same idea as the tracker's chart —
+// hover the curve, the figure above it says what it was worth then — but with no library and no
+// canvas: the plot is an SVG the server drew, and this only has to map a pointer to a point.
+//
+// Both formats are rewritten on every move, never just the visible one: which of them is on
+// screen is a class on <html> (see pnl_format_controller.js), and the reader can flip it while
+// the pointer is still on the curve.
+export default class extends Controller {
+  static targets = ["curve", "dot", "figure", "percent", "amount"]
+  static values = {
+    percent: Array,
+    profit: Array,
+    // The ratio the top of the box is worth — the server's, not re-derived here, or the dot would
+    // sit off the curve whenever the ten-percent floor is what set the scale.
+    scale: Number,
+    // USD is what everything behind the page is computed in; this is the last step to the fiat the
+    // account is shown in, exactly as Denomination does it server-side.
+    rate: Number,
+    unit: String,
+    suffixed: Boolean,
+    delimiter: String,
+  }
+
+  connect() {
+    // Read on every connect, not once: the P/L broadcast replaces this whole element every few
+    // minutes, and what it rendered is the live figure the pointer returns to.
+    this.live = [
+      this.percentTarget.innerHTML,
+      this.hasAmountTarget ? this.amountTarget.innerHTML : null,
+    ]
+    this.#reserve()
+    // Again once the face is in: a headline measured in the fallback font is measured in the
+    // wrong one, and this figure is set at 8.2rem, where the difference is not subtle.
+    document.fonts?.ready?.then(() => this.#reserve())
+  }
+
+  move(event) {
+    const box = this.curveTarget.getBoundingClientRect()
+    if (!box.width) return
+
+    // A window dragged across the layout's breakpoint brings the plot back with nothing reserved.
+    // Measuring here costs one layout on the first move and cannot be seen: the number has not
+    // changed yet.
+    if (!this.figureTarget.style.minWidth) this.#reserve()
+
+    const last = this.percentValue.length - 1
+    const at = Math.round(((event.clientX - box.left) / box.width) * last)
+    this.#show(Math.min(last, Math.max(0, at)), last)
+  }
+
+  leave() {
+    this.percentTarget.innerHTML = this.live[0]
+    if (this.hasAmountTarget) this.amountTarget.innerHTML = this.live[1]
+    this.dotTarget.hidden = true
+  }
+
+  #show(index, last) {
+    const percent = this.percentValue[index]
+    this.percentTarget.textContent = this.#percent(percent)
+    if (this.hasAmountTarget) this.amountTarget.replaceChildren(...this.#money(this.profitValue[index]))
+
+    // In the box's own percentages, so the dot rides the curve at any size: the viewBox is 100
+    // units above the zero line and the same 100 below it.
+    this.dotTarget.hidden = false
+    this.dotTarget.style.left = `${(index / last) * 100}%`
+    this.dotTarget.style.top = `${((1 - percent / this.scaleValue) / 2) * 100}%`
+    // The ring takes the side of the day under it, not the side the curve ends on: hovering a loss
+    // on a curve that ends in profit would otherwise ring a red stretch in green.
+    this.dotTarget.classList.toggle("is-gain", percent >= 0)
+    this.dotTarget.classList.toggle("is-loss", percent < 0)
+  }
+
+  // Hold the headline's box open at the widest reading the pointer can put in it, so the number
+  // cannot resize under the pointer and drag the curve out from under it.
+  //
+  // MEASURED, not counted: the figures here are not tabular — "+11.72%" is three pixels narrower
+  // than "+20.99%" of the same length — so no count of characters predicts the width, and CSS has
+  // no way to ask. Every reading is laid out once, out of flow and invisible, in the markup that
+  // will hold it; the widest wins and the ruler is thrown away.
+  #reserve() {
+    if (!this.hasFigureTarget) return
+    // Nothing to hold open where the curve is not drawn: below the breakpoint the plot is gone,
+    // and a width measured for it would be a headline wider than the phone.
+    if (!this.curveTarget.getBoundingClientRect().width) {
+      this.figureTarget.style.minWidth = ""
+      return
+    }
+
+    const ruler = document.createElement("div")
+    ruler.style.cssText = "position:absolute;visibility:hidden;white-space:nowrap"
+    for (const label of new Set(this.percentValue.map((value) => this.#percent(value)))) {
+      ruler.append(this.#rulerRow(label))
+    }
+    if (this.hasAmountTarget) {
+      for (const usd of this.profitValue) ruler.append(this.#rulerRow(...this.#money(usd)))
+    }
+
+    // Inside the headline, so it is measured in the headline's own type.
+    this.percentTarget.parentElement.append(ruler)
+    this.figureTarget.style.minWidth = `${ruler.getBoundingClientRect().width}px`
+    ruler.remove()
+    // Only now is the curve drawn to the edge it will keep.
+    this.element.classList.add("is-measured")
+  }
+
+  #rulerRow(...content) {
+    const row = document.createElement("div")
+    row.append(...content)
+    return row
+  }
+
+  #percent(value) {
+    return `${value > 0 ? "+" : ""}${(value * 100).toFixed(2)}%`
+  }
+
+  // The headline's amount, rebuilt the way the server writes it: sign, then the unit in <small>
+  // — before the figure, or after it where the currency is written that way.
+  #money(usd) {
+    const value = usd * this.rateValue
+    const sign = value > 0 ? "+" : value < 0 ? "-" : ""
+    // Grouped by hand with the server's own mark rather than by the browser's locale, which groups
+    // a Polish page with spaces where Rails wrote commas — the number would change shape the
+    // moment it was hovered.
+    const digits = Math.round(Math.abs(value)).toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, this.delimiterValue)
+    const unit = document.createElement("small")
+    unit.textContent = this.unitValue
+
+    return this.suffixedValue ? [`${sign}${digits} `, unit] : [sign, unit, digits]
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,7 +186,8 @@ class User < ApplicationRecord
       target: 'global-pnl',
       partial: 'bots/global_pnl',
       locals: { global_pnl: global_pnl, denomination: denomination, loading: false,
-                hide_balances: hide_balances? }
+                hide_balances: hide_balances?,
+                history: User::PnlHistory.snapshot(self, live: true)[:result] }
     )
   end
 

--- a/app/models/user/pnl_history.rb
+++ b/app/models/user/pnl_history.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# What the account's BOTS have been worth over time — the curve behind the dashboard headline.
+#
+# The headline is a point: value minus what went in, right now. This is the same subtraction at
+# every moment it can be made for, off the same source the bot's OWN chart is drawn from: the
+# candle-marked metrics, where the value between two purchases is the holding priced at market
+# rather than a flat step from one fill to the next.
+#
+# That reading is the heavier of the two metrics caches and the warm job does not fill it, so a
+# cold one is a WAIT, not a reason to draw the cheap shape: the snapshot says `loading`, the page
+# asks for a live pass exactly as it does for a cold headline, and the broadcast brings both.
+#
+# NOT the tracker's history. That one is the whole account (every connected venue, every manual
+# holding, every deposit) and is stored per day in `portfolio_snapshots`. This is the bots alone,
+# so the two curves are allowed to disagree — and the last point here IS the headline, because the
+# metrics' final label is the live reading the headline is computed from.
+class User::PnlHistory
+  # The bot types that have a P/L to speak of, as `User#global_pnl_snapshot` counts them.
+  MEASURABLE = %i[dca_single_asset? dca_dual_asset? dca_index? dca_multi_asset? signal?].freeze
+
+  # Columns the curve is resampled onto. A sparkline a few hundred pixels wide has nothing to say
+  # past this, and every column is two floats in a data attribute.
+  MAX_POINTS = 180
+
+  # { result: { percent:, profit_usd:, days: } | nil, loading: Boolean }, on the same three terms
+  # as `User#global_pnl_snapshot`: ready, waiting on a cold cache, or nothing to draw.
+  # `live:` lets a background job compute what a request may only read.
+  def self.snapshot(user, live: false) = new(user, live: live).call
+
+  def initialize(user, live: false)
+    @user = user
+    @live = live
+    @rates = {}
+  end
+
+  def call
+    tracks = []
+    @user.bots.not_deleted.each do |bot|
+      next unless MEASURABLE.any? { |type| bot.public_send(type) }
+
+      track = readings(bot)
+      # One bot short is the whole account short: a partial curve under a total headline would be
+      # a different account's history.
+      return { result: nil, loading: true } if track == :cold
+
+      tracks << track if track
+    end
+
+    { result: merge(tracks), loading: false }
+  end
+
+  private
+
+  # [[time, value_usd, invested_usd], ...] ascending, or :cold while the reading it needs is
+  # still being computed.
+  def readings(bot)
+    metrics = marked_metrics(bot)
+    return :cold if metrics == :cold
+
+    labels = metrics&.dig(:chart, :labels)
+    return if labels.blank?
+
+    currency = bot.quote_asset&.symbol
+    return if currency.blank?
+
+    rate = rate_for(currency)
+    return :cold if rate.nil?
+
+    values, invested = metrics.dig(:chart, :series)
+    labels.each_with_index.map do |at, i|
+      [at, (values[i] || 0).to_d * rate, (invested[i] || 0).to_d * rate]
+    end
+  end
+
+  # The candle-marked metrics — the bot chart's own ruler. A request may only read them; a cold
+  # one there means the curve is not ready yet, which is worth saying only for a bot that has
+  # something to draw at all, and the cheap hash is what knows that.
+  def marked_metrics(bot)
+    return bot.metrics_with_current_prices_and_candles if @live
+
+    cached = bot.metrics_with_current_prices_and_candles_from_cache
+    return cached if cached
+
+    bot.metrics_with_current_prices_from_cache&.dig(:chart, :labels).present? ? :cold : nil
+  end
+
+  # Every bot holds its last reading until the next one — the marked series already carries the
+  # market moves between them — so the account's curve is a sum of step functions, read down a
+  # column at a time. Uniform columns, because the plot spaces its points evenly: the axis is
+  # time, and a curve drawn from unevenly-spaced readings would stretch quiet weeks and squeeze
+  # busy ones.
+  def merge(tracks)
+    return if tracks.empty?
+
+    first = tracks.map { |track| track.first[0] }.min
+    last = tracks.map { |track| track.last[0] }.max
+    span = last - first
+    return if span <= 0
+
+    # One column MORE than there are readings, and it goes in front of them: the account had made
+    # nothing before its first purchase, and the curve has to start there. Without it the curve
+    # opens on whatever that first fill marks — a just-bought position priced against a candle
+    # grid, which is the spread plus a slice of interpolation below what was paid for it — and an
+    # account appears to begin under water before it has done anything.
+    columns = (tracks.sum(&:size) + 1).clamp(3, MAX_POINTS)
+    step = span / (columns - 2.0)
+    cursors = Array.new(tracks.size, 0)
+    percent = []
+    profit = []
+
+    columns.times do |i|
+      # The last column is the last reading itself, not a fraction that lands a float's breadth
+      # short of it: that point is the headline, and it has to be exact.
+      at = case i
+           when 0 then first - step
+           when columns - 1 then last
+           else first + (step * (i - 1))
+           end
+      value = invested = 0.to_d
+      tracks.each_with_index do |track, index|
+        cursors[index] += 1 while cursors[index] + 1 < track.size && track[cursors[index] + 1][0] <= at
+        reading = track[cursors[index]]
+        next if reading[0] > at # this bot had not started yet
+
+        value += reading[1]
+        invested += reading[2]
+      end
+
+      pnl = value - invested
+      profit << pnl.to_f
+      # A percentage of nothing is not zero percent, but a moment before any money went in has no
+      # shape to draw either — it sits on the zero line.
+      percent << (invested.positive? ? (pnl / invested).to_f : 0.0)
+    end
+
+    { percent: percent, profit_usd: profit, days: span / 1.day }
+  end
+
+  # One lookup per currency for the whole account, on the same terms as everything else here: a
+  # request reads what is cached, a live pass may go and get it.
+  def rate_for(currency)
+    @rates.fetch(currency.upcase) do
+      result = Utilities::Currency.exchange_rate(from: currency, to: 'USD', cache_only: !@live)
+      @rates[currency.upcase] = result.success? ? result.data.to_d : nil
+    end
+  end
+end

--- a/app/views/bots/_global_pnl.html.erb
+++ b/app/views/bots/_global_pnl.html.erb
@@ -1,23 +1,46 @@
-<div id="global-pnl">
+<%# The headline and the curve behind it are ONE element: this is what the P/L broadcast replaces,
+    and a curve left outside it would go on drawing the account's history under a number that had
+    already moved on. The controller is here rather than on the plot for the same reason — the
+    figures it writes into are its siblings. %>
+<% spark = global_pnl.present? && history.present? ? pnl_spark(history) : nil %>
+<%= tag.div id: 'global-pnl', data: spark ? {
+      controller: 'pnl-spark',
+      pnl_spark_percent_value: history[:percent].to_json,
+      # The money is left OUT while balances are hidden — the ratio is not a balance, the profit
+      # is, and shipping it in an attribute for CSS to cover is how it leaks.
+      pnl_spark_profit_value: (history[:profit_usd].to_json unless hide_balances),
+      pnl_spark_scale_value: spark[:scale],
+      pnl_spark_rate_value: denomination.rate.to_f,
+      pnl_spark_unit_value: denomination.unit,
+      # The thousands mark the SERVER writes, not the one the reader's browser would pick: the
+      # figure the pointer replaces was grouped by Rails, and "1 200 200" landing on top of
+      # "1,200,200" is one number written two ways.
+      pnl_spark_delimiter_value: I18n.t('number.currency.format.delimiter',
+                                        default: I18n.t('number.format.delimiter', default: ',')),
+      pnl_spark_suffixed_value: Denomination::SUFFIXED.include?(denomination.currency)
+    } : {} do %>
   <% if global_pnl.present? %>
-    <% pnl_percent = global_pnl[:percent] %>
-    <% profit_usd = global_pnl[:profit_usd] %>
+    <% if spark %>
+      <%= render partial: 'bots/pnl_spark', locals: { spark: spark } %>
+    <% end %>
     <%# Switches every PnL on the page — this one and each bot tile — see pnl_format_controller.js.
         With balances hidden there is no second format to switch to, so the headline is a headline
         again: no controller, no pointer, no amount. %>
-    <%= tag.h1 class: "header header--1",
-               data: (hide_balances ? {} : { controller: "pnl-format", action: "click->pnl-format#toggle" }),
-               style: ("cursor: pointer;" unless hide_balances) do %>
-      <span class="pnl-percent">
-        <%= pnl_percent.positive? ? '+' : '' %><%= format_percent(pnl_percent, precision: 2) %>
-      </span>
-      <% unless hide_balances %>
-        <span class="pnl-amount">
-          <%= profit_usd.positive? ? '+' : '' %><%= denomination.format(profit_usd, precision: 0) %>
-        </span>
+    <%# The box the number is read in. It is held open to the widest reading the pointer can put
+        in it — measured in the browser, because these figures are not tabular and no count of
+        characters predicts their width. Without it the number resizes as it is read, the box
+        resizes with it, and the curve moves out from under the pointer. %>
+    <div class="dash-intro__figure" data-pnl-spark-target="figure">
+      <%= tag.h1 class: "header header--1",
+                 data: (hide_balances ? {} : { controller: "pnl-format", action: "click->pnl-format#toggle" }),
+                 style: ("cursor: pointer;" unless hide_balances) do %>
+        <span class="pnl-percent" data-pnl-spark-target="percent"><%= pnl_headline_percent(global_pnl[:percent]) %></span>
+        <% unless hide_balances %>
+          <span class="pnl-amount" data-pnl-spark-target="amount"><%= pnl_headline_amount(global_pnl[:profit_usd], denomination) %></span>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   <% elsif loading %>
     <div class="loader--small"></div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/bots/_pnl_spark.html.erb
+++ b/app/views/bots/_pnl_spark.html.erb
@@ -1,0 +1,39 @@
+<%# The account's P/L, drawn on the headline's own line, in the language the bot and tracker charts
+    already speak: a smoothed curve, green above the zero line and red below it, a ribbon between
+    the curve and the line, and a dot on the last point.
+
+    Two boxes: the cell, which takes whatever width is left of the number, and the curve inside it,
+    which is only as wide as the history has earned (full width at thirty days) and hangs off the
+    cell's right so it always ENDS at the figure it explains.
+
+    ONE shape per role, clipped into halves rather than drawn twice with the points split: the
+    colour then changes exactly where the curve crosses zero, not at the nearest point to it.
+    preserveAspectRatio="none" because the geometry is written in a 100-unit box and stretched to
+    whatever that leaves — the stroke opts out of the stretch, or it would be a wedge. %>
+<div class="dash-intro__spark">
+  <div class="dash-intro__spark__curve"
+       style="width: <%= spark[:width] %>%"
+       data-pnl-spark-target="curve"
+       data-action="pointermove->pnl-spark#move pointerleave->pnl-spark#leave">
+    <svg viewBox="0 0 100 200" preserveAspectRatio="none" aria-hidden="true">
+      <defs>
+        <%# Deliberately taller than the box on both sides: a peak that reaches an edge would
+            otherwise have half its stroke shaved off by its own half's clip. %>
+        <clipPath id="dash-spark-above"><rect x="0" y="-100" width="100" height="200" /></clipPath>
+        <clipPath id="dash-spark-below"><rect x="0" y="100" width="100" height="200" /></clipPath>
+        <path id="dash-spark-area" d="<%= spark[:area] %>" />
+        <path id="dash-spark-curve" d="<%= spark[:path] %>" vector-effect="non-scaling-stroke" />
+      </defs>
+      <use href="#dash-spark-area" class="dash-intro__spark__area is-gain" clip-path="url(#dash-spark-above)" />
+      <use href="#dash-spark-area" class="dash-intro__spark__area is-loss" clip-path="url(#dash-spark-below)" />
+      <use href="#dash-spark-curve" class="dash-intro__spark__line is-gain" clip-path="url(#dash-spark-above)" />
+      <use href="#dash-spark-curve" class="dash-intro__spark__line is-loss" clip-path="url(#dash-spark-below)" />
+    </svg>
+    <%# The last point, marked where the number above it is read from. The hover dot is the same
+        point in the chart's other state: a ring rather than a disc, on whichever day is under the
+        pointer. %>
+    <span class="dash-intro__spark__end <%= spark[:gain] ? 'is-gain' : 'is-loss' %>"
+          style="top: <%= spark[:end_y] %>%"></span>
+    <span class="dash-intro__spark__dot is-gain" data-pnl-spark-target="dot" hidden></span>
+  </div>
+</div>

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -16,11 +16,18 @@
   <%# The total is asked for ONCE per page load, and asked again only while its spinner is still
       there — a lost request, a failed job or a broadcast that landed during a disconnect. The
       per-bot tile jobs no longer broadcast it as a side effect. %>
-  <%= tag.section class: 'dash-intro', data: @global_pnl_loading ? { controller: "broadcast--on-connect",
-                                                                     broadcast__on_connect_method_value: "global_pnl_update",
-                                                                     broadcast__on_connect_retry_while_value: "#global-pnl .loader--small" } : {} do %>
+  <%# The curve is asked for on the same trip as the total: one job renders both, so a cold
+      headline and a cold curve cost one pass between them. Only the headline's wait is RETRIED —
+      it is the one holding a spinner; a curve that never arrives leaves a page that reads
+      correctly and asks again on the next load. %>
+  <% pnl_pass = @global_pnl_loading || @global_pnl_history_loading %>
+  <%= tag.section class: 'dash-intro', data: pnl_pass ? { controller: "broadcast--on-connect",
+                                                          broadcast__on_connect_method_value: "global_pnl_update",
+                                                          broadcast__on_connect_retry_while_value:
+                                                            ("#global-pnl .loader--small" if @global_pnl_loading) }.compact : {} do %>
     <%= render partial: 'bots/global_pnl', locals: { global_pnl: @global_pnl, denomination: @denomination,
-                                                     loading: @global_pnl_loading, hide_balances: current_user.hide_balances? } %>
+                                                     loading: @global_pnl_loading, history: @global_pnl_history,
+                                                     hide_balances: current_user.hide_balances? } %>
   <% end %>
   
   <div class="page-head page-head--bots">

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The dashboard's P/L curve, on the page.
+#
+# It is drawn in the same element the headline lives in, because that element is what the P/L
+# broadcast replaces — a curve outside it would go on drawing an old history under a fresh number.
+# Everything it needs to answer a hover ships with it: the two series, the scale the server drew it
+# at, and the rate the amounts are shown in.
+class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true) # satisfies the onboarding gate (an admin must exist)
+    @user = create(:user)
+    exchange = create(:binance_exchange)
+    shared = { user: @user, exchange: exchange, base_asset: create(:asset, :bitcoin),
+               quote_asset: create(:asset, :usd) }
+    create(:dca_single_asset, **shared)
+    create(:dca_single_asset, **shared) # a second bot: a lone bot redirects to its own page
+
+    User.any_instance.stubs(:global_pnl_snapshot).returns(
+      { result: { percent: 0.25.to_d, profit_usd: 25.to_d }, loading: false }
+    )
+    sign_in @user
+  end
+
+  # The curve is drawn from the CANDLE-MARKED metrics — the bot chart's own ruler — so that is
+  # what a warm dashboard has cached.
+  def stub_history(points)
+    metrics = { pnl: 0.25.to_d, total_quote_amount_invested: 100.to_d, total_amount_value_in_quote: 125.to_d,
+                chart: { labels: points.map { |at, _, _| at },
+                         series: [points.map { |_, value, _| value }, points.map { |_, _, invested| invested }] } }
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache).returns(metrics)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache).returns(metrics)
+  end
+
+  test 'a month of history draws a full-width curve on the zero line' do
+    now = Time.current
+    stub_history(31.times.map { |day| [now - (30 - day).days, 100 + day, 100] })
+
+    get bots_path
+
+    assert_select '#global-pnl[data-controller=?]', 'pnl-spark'
+    assert_select '.dash-intro__spark__curve[style=?]', 'width: 100.0%'
+    assert_select '.dash-intro__spark__line'
+  end
+
+  test 'a fortnight of history draws half of it' do
+    now = Time.current
+    stub_history(16.times.map { |day| [now - (15 - day).days, 100 + day, 100] })
+
+    get bots_path
+
+    assert_select '.dash-intro__spark__curve[style=?]', 'width: 50.0%'
+  end
+
+  test 'the plot is the same box above and below the line, whatever the curve did' do
+    now = Time.current
+    stub_history([[now - 2.days, 100, 100], [now - 1.day, 90, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '.dash-intro__spark:not([style])'
+    assert_select '.dash-intro__spark svg[viewBox=?]', '0 0 100 200'
+  end
+
+  test 'the headline still reads as it did, and the figures are the hover targets' do
+    now = Time.current
+    stub_history([[now - 1.day, 100, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '#global-pnl .pnl-percent[data-pnl-spark-target=?]', 'percent', text: /\+25\.00%/
+    assert_select '#global-pnl .pnl-amount[data-pnl-spark-target=?]', 'amount', text: /\+\$25/
+  end
+
+  # The figure the pointer replaces was grouped by Rails. The browser groups a Polish page with
+  # spaces, so the mark travels with the data rather than being read off <html lang>.
+  test 'the hover carries the thousands mark the server wrote with' do
+    now = Time.current
+    stub_history([[now - 1.day, 100, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '#global-pnl[data-pnl-spark-delimiter-value=?]', ','
+  end
+
+  test 'no history, no curve — and the headline is untouched' do
+    metrics = { pnl: 0.25.to_d, total_quote_amount_invested: 100.to_d, total_amount_value_in_quote: 125.to_d }
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache).returns(metrics)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache).returns(metrics)
+
+    get bots_path
+
+    assert_select '.dash-intro__spark', false
+    assert_select '#global-pnl .pnl-percent', text: /\+25\.00%/
+    assert_select '.dash-intro[data-controller]', false, 'nothing to wait for, so nothing is asked for'
+  end
+
+  # The marked metrics are not warmed in the background, so a dashboard that finds them cold asks
+  # for the live pass — the same one a cold headline asks for, rendering both.
+  test 'a cold curve asks for the pass that fills it, without claiming the headline is loading' do
+    now = Time.current
+    metrics = { pnl: 0.25.to_d, total_quote_amount_invested: 100.to_d, total_amount_value_in_quote: 125.to_d,
+                chart: { labels: [now - 1.day, now], series: [[100, 125], [100, 100]] } }
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache).returns(metrics)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache).returns(nil)
+
+    get bots_path
+
+    assert_select '.dash-intro[data-broadcast--on-connect-method-value=?]', 'global_pnl_update'
+    assert_select '.dash-intro[data-broadcast--on-connect-retry-while-value]', false
+    assert_select '.dash-intro__spark', false
+    assert_select '#global-pnl .pnl-percent', text: /\+25\.00%/
+  end
+
+  test 'hiding balances keeps the curve and takes the amount' do
+    @user.update!(hide_balances: true)
+    now = Time.current
+    stub_history([[now - 1.day, 100, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '.dash-intro__spark__line'
+    assert_select '#global-pnl .pnl-amount', false
+    # The ratio is not a balance; the profit behind it is, and an attribute is not a hiding place.
+    assert_select '#global-pnl[data-pnl-spark-percent-value]'
+    assert_select '#global-pnl[data-pnl-spark-profit-value]', false
+  end
+end

--- a/test/helpers/bot_helper_test.rb
+++ b/test/helpers/bot_helper_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class BotHelperTest < ActionView::TestCase
+  # The headline labels below are written with it, exactly as the view has it.
+  include NumbersHelper
+
   test 'whitelist ip comes from the claimed exchange proxy' do
     AppConfig.set('proxy_binance', 'http://user:secret@claimed-proxy.test:9000')
 
@@ -227,5 +230,97 @@ class BotHelperTest < ActionView::TestCase
   test 'a figure that rounds to something is left alone' do
     assert_equal '1,234.50', money_figure(1234.5)
     assert_equal '0.01', money_figure(0.005), 'rounds up to a real cent'
+  end
+  # == the dashboard's mini P/L curve ==
+  #
+  # The zero line is the bottom rule of `.dash-intro`, so y=100 in the viewBox IS that rule and the
+  # box above it is the headline's own 7rem. Below the rule is the same box mirrored: a fixed 100
+  # units, so nothing about the page's height depends on how bad this account's worst day was.
+  #
+  # The path is monotone cubic, the interpolation the bot and tracker charts use: a curve that
+  # cannot overshoot the points it joins, which matters here because the box is sized to the
+  # extremes and an overshoot would be drawn straight into the clip.
+
+  test 'a flat curve rides the zero line' do
+    spark = pnl_spark(percent: [0.0, 0.0, 0.0], days: 30)
+
+    assert_equal 'M0,100 C16.67,100 33.33,100 50,100 C66.67,100 83.33,100 100,100', spark[:path]
+    assert_equal 50.0, spark[:end_y], 'the line is the middle of the box'
+  end
+
+  # The floor exists so a quiet week is not redrawn as a mountain range: reaching the edge of the
+  # box has to MEAN something, and what it means is ten percent.
+  test 'a swing under ten percent falls short of the edge' do
+    spark = pnl_spark(percent: [0.0, 0.02], days: 30)
+
+    assert_equal 'M0,100 C33.33,93.33 66.67,86.67 100,80', spark[:path]
+    assert_equal 0.1, spark[:scale]
+  end
+
+  test 'ten percent reaches the top edge' do
+    assert_equal 'M0,100 C33.33,66.67 66.67,33.33 100,0', pnl_spark(percent: [0.0, 0.10], days: 30)[:path]
+  end
+
+  test 'past ten percent the whole curve rescales to the peak' do
+    spark = pnl_spark(percent: [0.0, 0.5, 0.25], days: 30)
+
+    assert_equal 0.5, spark[:scale]
+    assert spark[:path].start_with?('M0,100 '), 'starts on the zero line'
+    assert spark[:path].end_with?(' 100,50'), 'ends halfway up the box'
+  end
+
+  # A loss is drawn under the rule, in the half of the box that is always there for it.
+  test 'a loss is drawn below the line, on the same scale as a gain' do
+    spark = pnl_spark(percent: [0.0, 0.2, -0.1], days: 30)
+
+    assert_equal false, spark[:gain]
+    assert spark[:path].end_with?(' 100,150'), 'the last point is half a box under the line'
+    assert_equal 75.0, spark[:end_y]
+  end
+
+  test 'a curve that only ever falls reaches the bottom edge and none of the top' do
+    spark = pnl_spark(percent: [0.0, -0.15], days: 30)
+
+    assert_equal 'M0,100 C33.33,133.33 66.67,166.67 100,200', spark[:path]
+    assert_equal 100.0, spark[:end_y], 'the floor of the box'
+  end
+
+  # Monotone, not a plain spline: three points that rise and then flatten must not dip on the way,
+  # or the curve would draw a loss the account never had.
+  test 'a curve that levels off does not dip on the way' do
+    spark = pnl_spark(percent: [0.0, 0.1, 0.1], days: 30)
+    ys = spark[:path].scan(/[\d.]+,([\d.]+)/).flatten.map(&:to_f)
+
+    assert_equal 0.0, ys.min, 'never rises above the peak it is joining'
+    assert_operator ys.max, :<=, 100.0, 'and never falls below where it started'
+  end
+
+  # Width is history, not data density: a fortnight-old account gets a short curve rather than a
+  # full-width one drawn out of nothing.
+  test 'full width takes thirty days of history' do
+    assert_equal 50.0, pnl_spark(percent: [0.0, 0.1], days: 15)[:width]
+    assert_equal 100.0, pnl_spark(percent: [0.0, 0.1], days: 30)[:width]
+    assert_equal 100.0, pnl_spark(percent: [0.0, 0.1], days: 400)[:width]
+  end
+
+  test 'the area closes on the zero line at both ends' do
+    assert_equal 'M0,100 C33.33,66.67 66.67,33.33 100,0 L100,100 L0,100 Z',
+                 pnl_spark(percent: [0.0, 0.1], days: 30)[:area]
+  end
+
+  # The dot marking the last point is placed in the WHOLE box, both halves of it, because that is
+  # what the plot is drawn in.
+  test 'the end dot sits on the last point, in the whole box' do
+    assert_equal 0.0, pnl_spark(percent: [0.0, 0.1], days: 30)[:end_y], 'a peak at the very top'
+    assert_equal 50.0, pnl_spark(percent: [0.0, -0.1, 0.0], days: 30)[:end_y], 'back on the line, half way down'
+  end
+
+  # One figure, two writers: the view here, and the JS that rewrites it under the pointer. They
+  # have to agree character for character — a '+' the other one omits is a number that changes
+  # shape as it is read.
+  test 'the headline labels carry a sign only where one is due' do
+    assert_equal '+25.00%', pnl_headline_percent(0.25)
+    assert_equal '-10.00%', pnl_headline_percent(-0.1)
+    assert_equal '0.00%', pnl_headline_percent(0)
   end
 end

--- a/test/models/user/pnl_history_test.rb
+++ b/test/models/user/pnl_history_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Contract for the dashboard's mini P/L curve.
+#
+# The headline on /bots is a POINT — what the bots are up right now. This is the same figure over
+# time, read off the CANDLE-MARKED metrics: the source the bot's own chart uses, where the value
+# between two purchases is the holding priced at market rather than a flat step from fill to fill.
+# Nothing warms that cache in the background, so a cold one is a wait — `loading` — and the page
+# asks for the live pass exactly as it does for a cold headline.
+#
+# The tracker's curve is the whole account (every connected venue, every manual holding); this one
+# is the BOTS alone, so the two are allowed to disagree.
+class User::PnlHistoryTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @now = Time.current
+  end
+
+  # The metrics cache, in the shape every measurable bot stores it: labels, then value and
+  # invested as two parallel rows.
+  def metrics(points)
+    { chart: { labels: points.map { |at, _, _| at },
+               series: [points.map { |_, value, _| value }, points.map { |_, _, invested| invested }] } }
+  end
+
+  # Stubbed per CLASS, which is why the two-bot case uses two different bot types: the bots come
+  # off an association, so there is no instance here to stub.
+  def marked(type, points)
+    type.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache)
+        .returns(points && metrics(points))
+  end
+
+  # A column per reading, plus one in FRONT of them all: an account has made nothing before its
+  # first purchase, and the curve starts there rather than on whatever that first fill marks — a
+  # just-bought position priced against a candle grid opens a spread below what was paid for it.
+  test 'a column per reading, opening on the zero line' do
+    marked(Bots::DcaSingleAsset, [[@now - 2.days, 100, 100], [@now - 1.day, 110, 100], [@now, 90, 100]])
+    create(:dca_single_asset, user: @user)
+
+    history = User::PnlHistory.snapshot(@user)[:result]
+
+    assert_in_delta 2.0, history[:days], 1e-6, 'the span is the history, not the run-up to it'
+    assert_equal([0.0, 0.0, 0.1, -0.1], history[:percent].map { |value| value.round(6) })
+    assert_equal([0.0, 0.0, 10.0, -10.0], history[:profit_usd].map { |value| value.round(6) })
+  end
+
+  # The marked series carries the market between purchases, so a bot with no reading in a column
+  # is not flat by accident — it is flat because that is what it was last worth.
+  test 'a bot with no reading in a column keeps its last one, and the bots are summed' do
+    btc = create(:asset, :bitcoin)
+    usd = create(:asset, :usd)
+    single = create(:dca_single_asset, user: @user, base_asset: btc, quote_asset: usd)
+    create(:dca_multi_asset, user: @user, exchange: single.exchange, quote_asset: usd,
+                             base_assets: [btc, create(:asset, :ethereum)])
+    marked(Bots::DcaSingleAsset, [[@now - 2.days, 100, 100], [@now, 120, 100]])
+    marked(Bots::DcaMultiAsset, [[@now - 1.day, 50, 50]])
+
+    history = User::PnlHistory.snapshot(@user)[:result]
+
+    # Three readings a day apart, behind the opening column. First: nothing yet. Second: the
+    # single-asset bot alone (100/100). Third: it holds while the other arrives (150/150).
+    # Fourth: it moves to 120 and the other holds (170/150).
+    assert_equal 4, history[:percent].size
+    assert_equal([0.0, 0.0, 0.0, 0.133333], history[:percent].map { |value| value.round(6) })
+    assert_equal([0.0, 0.0, 0.0, 20.0], history[:profit_usd].map { |value| value.round(6) })
+  end
+
+  test 'a non-USD quote is converted at the cached rate' do
+    eur = create(:asset, :eur)
+    create(:dca_single_asset, user: @user, quote_asset: eur)
+    marked(Bots::DcaSingleAsset, [[@now - 1.day, 100, 100], [@now, 120, 100]])
+    Utilities::Currency.stubs(:exchange_rate)
+                       .with(from: 'EUR', to: 'USD', cache_only: true)
+                       .returns(Result::Success.new(1.1))
+
+    history = User::PnlHistory.snapshot(@user)[:result]
+
+    # A ratio is rate-free; the money is not.
+    assert_equal([0.0, 0.0, 0.2], history[:percent].map { |value| value.round(6) })
+    assert_equal([0.0, 0.0, 22.0], history[:profit_usd].map { |value| value.round(6) })
+  end
+
+  test 'a cold FX rate draws nothing, and says so' do
+    eur = create(:asset, :eur)
+    create(:dca_single_asset, user: @user, quote_asset: eur)
+    marked(Bots::DcaSingleAsset, [[@now - 1.day, 100, 100], [@now, 120, 100]])
+
+    snapshot = User::PnlHistory.snapshot(@user)
+
+    assert_nil snapshot[:result]
+    assert_equal true, snapshot[:loading]
+  end
+
+  # The marked metrics are the heavy cache and nothing warms them in the background. A bot that
+  # HAS a history is worth waiting for; the cheap hash is what knows whether it has one.
+  test 'a bot with history but no marked reading yet is a wait, not an empty chart' do
+    create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, nil)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache)
+                        .returns(metrics([[@now - 1.day, 100, 100], [@now, 120, 100]]))
+
+    snapshot = User::PnlHistory.snapshot(@user)
+
+    assert_nil snapshot[:result]
+    assert_equal true, snapshot[:loading]
+  end
+
+  test 'a bot that has never traded is not something to wait for' do
+    create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, nil)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache).returns(nil)
+
+    snapshot = User::PnlHistory.snapshot(@user)
+
+    assert_nil snapshot[:result]
+    assert_equal false, snapshot[:loading]
+  end
+
+  # A live pass may compute what a request may only read — this is what the broadcast job does.
+  test 'a live pass computes the marked metrics instead of waiting for them' do
+    create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, nil)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles)
+                        .returns(metrics([[@now - 1.day, 100, 100], [@now, 120, 100]]))
+
+    history = User::PnlHistory.snapshot(@user, live: true)[:result]
+
+    assert_equal([0.0, 0.0, 0.2], history[:percent].map { |value| value.round(6) })
+  end
+
+  test 'a single moment is not a curve' do
+    create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, [[@now, 120, 100]])
+
+    assert_nil User::PnlHistory.snapshot(@user)[:result]
+  end
+
+  # The plot spaces its points evenly, so the readings are resampled onto an even axis: a curve
+  # built from raw readings would stretch a quiet week and squeeze a busy one.
+  test 'a long history is resampled onto an even axis, ending on the live reading' do
+    points = 400.times.map { |i| [@now - (399 - i).days, 100 + i, 100] }
+    create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, points)
+
+    history = User::PnlHistory.snapshot(@user)[:result]
+
+    assert_in_delta 399.0, history[:days], 1e-6
+    assert_equal User::PnlHistory::MAX_POINTS, history[:percent].size
+    assert_equal 0.0, history[:percent].first.round(6)
+    assert_equal 3.99, history[:percent].last.round(6), 'the last column is the last reading'
+    assert_equal history[:percent].size, history[:profit_usd].size
+  end
+
+  test 'a deleted bot is not part of the account curve' do
+    bot = create(:dca_single_asset, user: @user)
+    marked(Bots::DcaSingleAsset, [[@now - 1.day, 100, 100], [@now, 120, 100]])
+    bot.update!(status: :deleted)
+
+    assert_nil User::PnlHistory.snapshot(@user)[:result]
+  end
+end


### PR DESCRIPTION
The /bots headline states what the account's bots are up **right now**. This puts the same figure over time behind it, running from the left edge into the number itself.

## The curve

`User::PnlHistory` sums every measurable bot's candle-marked metrics — the same reading each bot's own chart is drawn from, where the value between two purchases is the holding priced at market rather than a flat step from one fill to the next — into one series in USD, resampled onto a uniform time axis of at most 180 columns.

It is the bots alone. The tracker's curve is the whole account: every connected venue, every manual holding, every deposit. The two are allowed to disagree, and the last point here **is** the headline, because the metrics' final label is the live reading the headline is computed from.

One column sits in front of every reading, on the zero line. An account has made nothing before its first purchase, and without it the curve opens on whatever that first fill marks — a just-bought position priced against a candle grid, which is the spread plus a slice of interpolation below what was paid for it.

The marked metrics are the heavier of the two caches and nothing warms them in the background, so a cold one is a wait rather than a reason to draw the coarser shape. The snapshot reports `loading` on the same three terms as the global-PnL snapshot, and the page asks for the live pass through the broadcast that already exists for a cold total — one job renders both. Only the headline's wait is retried; it is the one holding a spinner.

## The plot

The bottom rule of `.dash-intro` is the chart's zero line, so it moved from the section's border onto an absolute rule at the headline's height: the plot hangs below it, and a border would follow the box down. Above the line is the headline's own height and below it the same again — fixed, not cut to each account's worst day, so the page under the chart does not move with the data.

- Normalised to reach an edge at ten percent, so a quiet fortnight is not redrawn as a mountain range.
- From the left edge to where the number begins, at full width from thirty days of history.
- Drawn the way the bot and tracker charts draw theirs: a monotone-cubic path, green above the line and red below it — one shape under two clip paths, so the colour changes where the curve crosses rather than at the nearest point to it — a ribbon to the line, and a dot on the last point.

## Hovering

Hovering reads the headline back at that day, in both formats, with a ring on the day under the pointer.

The box the number is read in is held open at the widest reading the pointer can put in it, measured once in the browser. These figures are not tabular — `+11.72%` is narrower than `+20.99%` of the same length — so no count of characters predicts the width, and without it the number resizes as it is read and drags the curve out from under the pointer. The curve is not drawn until that measurement is in. Amounts are grouped with the mark the server formatted with rather than the browser's locale, or a page whose locale groups with spaces lands one number on top of the same number written another way.

Hiding balances takes the profit series out of the markup entirely — the ratio is not a balance, the profit is. Below 768px the plot is not drawn at all.

## Tests

`test/models/user/pnl_history_test.rb` for the series, the geometry cases in `test/helpers/bot_helper_test.rb`, and `test/controllers/bots/index_pnl_spark_test.rb` for what reaches the page.
