### PR TITLE
Hold the plot's height before the plot arrives

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -185,7 +185,11 @@ ol, ul
     display: flex
     min-height: var(--dash-height)
     @media only screen and (min-width: 768px)
-        display: flex
+        // A section that will hold a plot holds its height from the first paint, whether or not
+        // the curve is there yet: the plot arrives on a later trip, and a section that grew when
+        // it landed would push the whole dashboard down under the reader's pointer.
+        &--plotted
+            min-height: calc(var(--dash-height) * 2)
     &::after
         content: ''
         position: absolute
@@ -200,9 +204,6 @@ ol, ul
         min-height: var(--dash-height)
         align-items: flex-start
         justify-content: flex-end
-        // The one thing here that still belongs at the bottom of the box.
-        > .loader--small
-            align-self: flex-end
     // The number is set at 8.2rem in a 7rem line box and pulled a further 1rem down: it is MEANT
     // to sit on the line and be cropped by it, which is what this box keeps doing now that the
     // section itself has to let the curve out.

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -21,10 +21,15 @@
       it is the one holding a spinner; a curve that never arrives leaves a page that reads
       correctly and asks again on the next load. %>
   <% pnl_pass = @global_pnl_loading || @global_pnl_history_loading %>
-  <%= tag.section class: 'dash-intro', data: pnl_pass ? { controller: "broadcast--on-connect",
-                                                          broadcast__on_connect_method_value: "global_pnl_update",
-                                                          broadcast__on_connect_retry_while_value:
-                                                            ("#global-pnl .loader--small" if @global_pnl_loading) }.compact : {} do %>
+  <%# The plot's space is held from the first paint — it is drawn on a later trip than the page,
+      and a section that grew when it landed would push the dashboard down under the reader. Held
+      for a curve that is on its way as much as for one already here; only an account with nothing
+      to plot at all keeps the plain headline strip. %>
+  <%= tag.section class: ['dash-intro', ('dash-intro--plotted' if pnl_pass || @global_pnl_history)],
+                  data: pnl_pass ? { controller: "broadcast--on-connect",
+                                     broadcast__on_connect_method_value: "global_pnl_update",
+                                     broadcast__on_connect_retry_while_value:
+                                       ("#global-pnl .loader--small" if @global_pnl_loading) }.compact : {} do %>
     <%= render partial: 'bots/global_pnl', locals: { global_pnl: @global_pnl, denomination: @denomination,
                                                      loading: @global_pnl_loading, history: @global_pnl_history,
                                                      hide_balances: current_user.hide_balances? } %>

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -34,6 +34,30 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache).returns(metrics)
   end
 
+  # The plot is drawn on a later trip than the page, so the section holds its height from the first
+  # paint — otherwise it grows when the curve lands and pushes the whole dashboard down.
+  test 'a section that will hold a plot reserves its height before the curve is there' do
+    now = Time.current
+    metrics = { pnl: 0.25.to_d, total_quote_amount_invested: 100.to_d, total_amount_value_in_quote: 125.to_d,
+                chart: { labels: [now - 1.day, now], series: [[100, 125], [100, 100]] } }
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_from_cache).returns(metrics)
+    Bots::DcaSingleAsset.any_instance.stubs(:metrics_with_current_prices_and_candles_from_cache).returns(nil)
+
+    get bots_path
+
+    assert_select '.dash-intro.dash-intro--plotted'
+    assert_select '.dash-intro__spark', false, 'the curve itself is still on its way'
+  end
+
+  test 'a section with the curve already in it keeps the same reserved height' do
+    now = Time.current
+    stub_history([[now - 1.day, 100, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '.dash-intro.dash-intro--plotted .dash-intro__spark'
+  end
+
   test 'a month of history draws a full-width curve on the zero line' do
     now = Time.current
     stub_history(31.times.map { |day| [now - (30 - day).days, 100 + day, 100] })
@@ -95,6 +119,7 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     assert_select '.dash-intro__spark', false
     assert_select '#global-pnl .pnl-percent', text: /\+25\.00%/
     assert_select '.dash-intro[data-controller]', false, 'nothing to wait for, so nothing is asked for'
+    assert_select '.dash-intro--plotted', false, 'and no space held for a plot that is not coming'
   end
 
   # The marked metrics are not warmed in the background, so a dashboard that finds them cold asks


### PR DESCRIPTION
The P/L curve behind the dashboard headline is drawn on a later trip than the page around it — its source is the one metrics cache nothing warms in the background — so the section grew when the curve landed and pushed the tiles down under whoever was already reading them.

`.dash-intro` now holds that height from the first paint. The modifier goes on for a curve that is on its way as much as for one already there; an account with nothing to plot at all keeps the plain headline strip. Desktop only: below 768px the plot is not drawn, so there is nothing to hold space for.

Measured on the rendered page at 1280px, both states:

| | section | tiles | curve |
|---|---|---|---|
| waiting | 112px | 168px | not there yet |
| drawn | 112px | 168px | drawn |

The rule that aligned the loading spinner to the bottom of that box goes with it — the spinner is positioned absolutely and never answered to it.
