### PR TITLE
Convert pair bots until none are left, instead of once at deploy

### DIFF
--- a/app/jobs/bot/convert_dual_asset_bots_job.rb
+++ b/app/jobs/bot/convert_dual_asset_bots_job.rb
@@ -1,0 +1,24 @@
+# Finishes the pair-to-basket conversion the deploy-time migration could not.
+#
+# A bot that was executing, holding a live order, or running a tick when the migration ran is left
+# alone by design — and on an install nobody operates there is no one to drain job processing and
+# retry. So the conversion recurs until nothing is left, and stops costing anything once the last
+# pair bot is gone: one indexed count against `bots`.
+#
+# It also keeps running the two self-corrections a single pass cannot guarantee — undoing a stale
+# instance's pair-shaped write, and repointing a GlobalID a worker re-enqueued under the old class
+# name after the previous sweep had already passed.
+#
+# Removed with Bots::DcaDualAsset, once no install can still hold one.
+class Bot::ConvertDualAssetBotsJob < ApplicationJob
+  queue_as :low_priority
+  limits_concurrency to: 1, key: 'ConvertDualAssetBotsJob', on_conflict: :discard, duration: 15.minutes
+
+  def perform
+    return unless Bot::DualToComposition.pending?
+
+    converted, skipped = Bot::DualToComposition.run!
+    Rails.logger.info("[dual→multi] converted #{converted.size}, #{skipped.size} left") if converted.any?
+    skipped.each { |id, reason| Rails.logger.info("[dual→multi] bot #{id} waiting: #{reason}") }
+  end
+end

--- a/app/models/bot/dual_to_composition.rb
+++ b/app/models/bot/dual_to_composition.rb
@@ -8,10 +8,29 @@
 #
 # A worker cannot be stopped from here: Solid Queue is a different database, so its state cannot
 # join the conversion's transaction, and a claimed job holds an already-deserialized pair instance
-# regardless. So the deploy-time path does not try — it refuses any bot that has a queued job at
-# all and defers it to bots:migrate_dual_to_multi, which an operator runs with bot job processing
-# drained. That is why the rake task exists, and why it relaxes the rule (defer_scheduled: false):
-# with workers stopped, a scheduled execution is a parked row rather than a job about to run.
+# regardless. So when a worker is up, a bot with a queued job is left alone.
+#
+# But a worker is very often NOT up. docker-entrypoint.sh runs `rails db:migrate` as its own
+# process and only then execs the server, and Solid Queue runs inside Puma (config/puma.rb) — so on
+# a self-hosted upgrade nothing can fire a tick while migrations run. Assuming otherwise would
+# strand every WORKING pair bot on an install that has no operator to run the rake task, and the
+# release that deletes Bots::DcaDualAsset would then leave rows whose class is gone —
+# ActiveRecord::SubclassNotFound on instantiation, which takes the whole bot list down, not one bot.
+#
+# So quiescence is measured rather than assumed: solid_queue_processes carries a heartbeat, and no
+# live one means no worker. That converts a self-hosted install automatically at upgrade and still
+# defers on a rolling deploy where the previous container is still serving.
+#
+# The reading is taken per bot, inside that bot's own lock, so a worker that starts mid-run defers
+# every bot after it rather than none. It CANNOT rule out a worker starting between that reading
+# and the commit, and no check here can: the queue lives in another database. On the standalone
+# image the entrypoint rules it out anyway — migrations finish before the server is exec'd — but
+# the Umbrel compose runs the worker as its own container whose `depends_on: web` waits only for
+# that container to start, so there it really can register mid-migration.
+#
+# What makes that survivable is Bots::DcaDualAsset.find: a job holding the old GlobalID resolves to
+# whatever the row is now, so a tick that fires mid-conversion runs against the basket instead of
+# dead-lettering. Quiescence is the first layer, that fallback is the one that has to hold.
 module Bot::DualToComposition
   class Row < ActiveRecord::Base
     self.table_name = 'bots'
@@ -30,14 +49,26 @@ module Bot::DualToComposition
 
   module_function
 
-  # @param defer_scheduled [Boolean] refuse a bot that has ANY queued execution, a future-scheduled
-  #   one included. True on the deploy-time path, where workers are live: a scheduled job cannot be
-  #   stopped, and between the type flip committing and the queue repoint (different databases, so
-  #   they cannot share a transaction) it could fire and fail to deserialize. False for the rake
-  #   task, whose whole point is that an operator runs it with bot job processing drained — and
-  #   where a future-scheduled execution is then just a parked row, not a job about to run.
+  # Is there anything at all left to do? A pair row to convert, a converted row a stale instance
+  # wrote the pair shape back onto, or a queued job still naming the old class. All three have to be
+  # asked: the last pair row usually disappears BEFORE the clobber that needs repairing shows up,
+  # so gating on pair rows alone would switch the repair off exactly when it starts being needed.
+  def pending?
+    return true if Row.where(type: DUAL).exists?
+    return true if clobbered.exists?
+
+    defined?(SolidQueue) && SolidQueue::Job.where('arguments LIKE ?', "%#{DUAL}/%").exists?
+  end
+
+  def clobbered
+    Row.where(type: MULTI).where("json_extract(settings, '$.base0_asset_id') IS NOT NULL")
+  end
+
+  # Safe to call repeatedly, and meant to be: a bot busy this time round converts on a later pass,
+  # and the repair/sweep below run every time.
+  #
   # @return [Array(Array<Integer>, Array<Array(Integer, String)>)] converted ids, [id, reason] skips
-  def run!(defer_scheduled: true)
+  def run!
     converted = []
     skipped = []
 
@@ -45,8 +76,8 @@ module Bot::DualToComposition
       # preflight runs twice: once here for the reported reason, and again inside the lock against
       # the row as it actually is at that moment. A bot that passes here and fails there is still
       # reported — silence would read as "converted" in the migration's output.
-      reason = preflight(row, defer_scheduled:)
-      reason = convert!(row, defer_scheduled:) unless reason.is_a?(String)
+      reason = preflight(row)
+      reason = convert!(row) unless reason.is_a?(String)
 
       reason.is_a?(String) ? skipped << [row.id, reason] : converted << row.id
     end
@@ -66,7 +97,7 @@ module Bot::DualToComposition
   end
 
   # @return [Hash] the conversion plan, or [String] the reason this bot is not convertible
-  def preflight(row, defer_scheduled: true)
+  def preflight(row)
     settings = row.settings || {}
     base0 = settings['base0_asset_id'].to_i
     base1 = settings['base1_asset_id'].to_i
@@ -79,7 +110,6 @@ module Bot::DualToComposition
     return 'rebalance in flight' if (row.transient_data || {})['rebalance_pending'].present?
     return 'live order' if Transaction.where(bot_id: row.id).waiting.exists?
     return 'job in flight' if busy_job?(row.id)
-    return 'job scheduled — convert with bots:migrate_dual_to_multi' if defer_scheduled && queued_job?(row.id)
     return 'missing asset rows' unless Asset.where(id: [base0, base1, quote]).count == 3
 
     # Float(), not to_f: to_f reads "garbage" as 0.0 and would convert the bot to a 100/0 basket.
@@ -107,14 +137,6 @@ module Bot::DualToComposition
   # A status check is not enough: Bot::ActionJob authenticates against the exchange and checks market
   # hours while the row still reads `scheduled` (action_job.rb:59-75), and a placement whose outcome
   # is unknown can leave no Transaction row at all (action_job.rb:138-152).
-  # Any queued execution at all, in any state. The deploy-time path refuses these outright rather
-  # than reasoning about how close to firing they are.
-  def queued_job?(bot_id)
-    return false unless defined?(SolidQueue)
-
-    SolidQueue::Job.where('arguments LIKE ?', "%#{DUAL}/#{bot_id}\"%").exists?
-  end
-
   def busy_job?(bot_id)
     return false unless defined?(SolidQueue)
 
@@ -131,7 +153,7 @@ module Bot::DualToComposition
 
   # @param from_type [String] the type the row is expected to still carry
   # @return [true] on success, or [String] the reason it was not converted
-  def convert!(row, from_type: DUAL, defer_scheduled: true)
+  def convert!(row, from_type: DUAL)
     settings = nil
     reason = nil
 
@@ -146,7 +168,7 @@ module Bot::DualToComposition
         next
       end
 
-      plan = preflight(row, defer_scheduled:)
+      plan = preflight(row)
       if plan.is_a?(String)
         reason = plan
         next
@@ -248,10 +270,7 @@ module Bot::DualToComposition
   # was trying to undo. convert! is told what type to expect instead, so the row's type only ever
   # changes on a conversion that succeeds.
   def repair_clobbered!
-    victims = Row.where(type: MULTI).where("json_extract(settings, '$.base0_asset_id') IS NOT NULL")
-    # defer_scheduled: false — a clobbered row is already a basket whose settings are wrong. Leaving
-    # it that way because it happens to have a scheduled tick is the worse outcome of the two.
-    victims.count { |row| convert!(row, from_type: MULTI, defer_scheduled: false) == true }
+    clobbered.count { |row| convert!(row, from_type: MULTI) == true }
   end
 
   # Rebuilds rather than mutating: the parsed JSON may hold frozen strings, and sub! on one raises.

--- a/app/models/bots/dca_dual_asset.rb
+++ b/app/models/bots/dca_dual_asset.rb
@@ -1,6 +1,21 @@
 class Bots::DcaDualAsset < Bot
   include ActionCable::Channel::Broadcasting
 
+  # A job enqueued before this bot was converted carries a GlobalID naming THIS class. STI scopes
+  # find to the type, so once the row becomes a basket that lookup raises RecordNotFound and the
+  # tick dead-letters — and the conversion cannot prevent it, because the queue is a different
+  # database and no check here can be atomic with the commit. On Umbrel the worker is its own
+  # container whose `depends_on: web` does not wait for migrations, so it can be claiming jobs while
+  # the conversion runs.
+  #
+  # Hand back whatever the row is now instead. The job then runs against the basket, which is what
+  # it should do after the conversion, rather than failing. Removed with this class.
+  def self.find(...)
+    super
+  rescue ActiveRecord::RecordNotFound
+    Bot.find(...)
+  end
+
   store_accessor :settings,
                  :base0_asset_id,
                  :base1_asset_id,

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -24,6 +24,13 @@ production:
     class: Bot::RepairOrphanedBotsJob
     schedule: "*/15 * * * *"  # Every 15 minutes
 
+  # Converts any pair bot the deploy-time migration had to leave alone — one that was mid-order or
+  # mid-tick. Self-hosted installs have no operator to retry by hand, so it retries here and
+  # no-ops once none are left. Removed with Bots::DcaDualAsset.
+  convert_dual_asset_bots_job:
+    class: Bot::ConvertDualAssetBotsJob
+    schedule: "*/15 * * * *"  # Every 15 minutes
+
   sync_alpaca_assets_job:
     class: Exchange::SyncAlpacaAssetsJob
     schedule: "0 3 * * 1"  # At 03:00 UTC on Monday (no-op on hosted; per-user Alpaca sync only)
@@ -119,6 +126,13 @@ development:
   repair_orphaned_bots_job:
     class: Bot::RepairOrphanedBotsJob
     schedule: "*/5 * * * *"  # Every 5 minutes for testing
+
+  # Converts any pair bot the deploy-time migration had to leave alone — one that was mid-order or
+  # mid-tick. Self-hosted installs have no operator to retry by hand, so it retries here and
+  # no-ops once none are left. Removed with Bots::DcaDualAsset.
+  convert_dual_asset_bots_job:
+    class: Bot::ConvertDualAssetBotsJob
+    schedule: "*/15 * * * *"  # Every 15 minutes
 
   sync_alpaca_assets_job:
     class: Exchange::SyncAlpacaAssetsJob

--- a/db/migrate/20260828095813_migrate_dual_asset_bots_to_multi_asset.rb
+++ b/db/migrate/20260828095813_migrate_dual_asset_bots_to_multi_asset.rb
@@ -13,10 +13,10 @@ class MigrateDualAssetBotsToMultiAsset < ActiveRecord::Migration[8.1]
     skipped.each { |id, reason| say "Skipped bot #{id}: #{reason}", true }
     return if skipped.empty?
 
-    # Workers are live during a deploy, so anything with a queued job is deliberately left alone —
-    # see Bot::DualToComposition. Those bots keep running as pair bots until this is run.
-    say "#{skipped.size} bot(s) still on the old shape. With bot job processing drained, run:"
-    say '  bin/rails bots:migrate_dual_to_multi'
+    # A bot mid-order or mid-tick is left alone on purpose. Bot::ConvertDualAssetBotsJob picks it
+    # up on its next pass, so this needs no operator — the message is for anyone watching a deploy.
+    say "#{skipped.size} bot(s) still on the old shape; they convert on a later pass."
+    say 'To convert them now, with bot job processing drained: bin/rails bots:migrate_dual_to_multi'
   end
 
   # Irreversible on purpose: the pair shape cannot represent a basket, so rolling back after any

--- a/lib/tasks/bots.rake
+++ b/lib/tasks/bots.rake
@@ -1,19 +1,16 @@
 namespace :bots do
-  desc 'Convert any remaining pair bots into two-asset baskets (run with job processing drained)'
+  desc 'Convert any remaining pair bots into two-asset baskets now, rather than waiting for the job'
   task migrate_dual_to_multi: :environment do
-    # defer_scheduled: false — the deploy-time migration refuses any bot with a queued job, because
-    # a live worker could fire it between the type flip and the queue repoint. This task is the
-    # answer to that: run it with bot job processing drained and the parked schedules convert too.
-    puts 'Convert with bot job processing drained — a running worker can fire a tick mid-conversion.'
-    converted, skipped = Bot::DualToComposition.run!(defer_scheduled: false)
+    # Bot::ConvertDualAssetBotsJob does this on a schedule; this is the same pass on demand, for
+    # when you have drained job processing and want the bots that were busy converted immediately.
+    converted, skipped = Bot::DualToComposition.run!
 
     converted.each { |id| puts "converted bot #{id}" }
     skipped.each { |id, reason| puts "skipped bot #{id}: #{reason}" }
 
-    # run! sweeps stray GlobalIDs itself; this second pass catches anything re-enqueued under the
-    # old class name while the run was in progress.
     strays = Bot::DualToComposition.sweep_stray_jobs!
     puts "repointed #{strays} stray job(s)" if strays.positive?
     puts "#{converted.size} converted, #{skipped.size} still on the old shape"
+    puts 'Those convert on a later pass of Bot::ConvertDualAssetBotsJob.' if skipped.any?
   end
 end

--- a/test/jobs/bot/convert_dual_asset_bots_job_test.rb
+++ b/test/jobs/bot/convert_dual_asset_bots_job_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# No single pass can win the race against a live worker, so the conversion recurs until nothing is
+# left. These pin that it keeps trying, keeps repairing, and costs nothing once it is done.
+class Bot::ConvertDualAssetBotsJobTest < ActiveSupport::TestCase
+  setup do
+    Bot::UpdateMetricsJob.stubs(:perform_later)
+    @bot = create(:dca_dual_asset, status: :waiting)
+  end
+
+  test 'it converts a pair bot' do
+    Bot::ConvertDualAssetBotsJob.perform_now
+
+    assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
+  end
+
+  test 'a bot it had to leave alone converts on the next pass' do
+    @bot.update_columns(transient_data: @bot.transient_data.merge('rebalance_pending' => { 'phase' => 'sold' }))
+    Bot::ConvertDualAssetBotsJob.perform_now
+    assert_equal 'Bots::DcaDualAsset', Bot.where(id: @bot.id).pick(:type)
+
+    # The rebalance settles; nobody has to remember to retry.
+    @bot.update_columns(transient_data: @bot.transient_data.except('rebalance_pending'))
+    Bot::ConvertDualAssetBotsJob.perform_now
+
+    assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
+  end
+
+  test 'a later pass repairs a stale write that restored the pair shape' do
+    base0 = @bot.base0_asset_id
+    Bot::ConvertDualAssetBotsJob.perform_now
+    # What a worker holding a pre-conversion instance does on save: settings by id, no type.
+    Bot::DualToComposition::Row.where(id: @bot.id).update_all(
+      settings: Bot.find(@bot.id).settings.merge('base0_asset_id' => base0,
+                                                 'base1_asset_id' => @bot.base1_asset_id,
+                                                 'allocation0' => 0.5)
+    )
+
+    Bot::ConvertDualAssetBotsJob.perform_now
+
+    assert_not Bot.find(@bot.id).settings.key?('base0_asset_id')
+  end
+
+  test 'it does nothing at all once no pair bot is left' do
+    Bot::ConvertDualAssetBotsJob.perform_now
+    Bot::DualToComposition.expects(:run!).never
+
+    Bot::ConvertDualAssetBotsJob.perform_now
+  end
+end

--- a/test/models/bot/dual_to_composition_test.rb
+++ b/test/models/bot/dual_to_composition_test.rb
@@ -15,9 +15,7 @@ class Bot::DualToCompositionTest < ActiveSupport::TestCase
     write_settings!('allocation0' => 0.7)
   end
 
-  # The deploy-time default refuses any bot with a queued job; these tests exercise that path
-  # explicitly below and otherwise use the drained-operator rule.
-  def run!(defer_scheduled: false) = Bot::DualToComposition.run!(defer_scheduled:)
+  def run! = Bot::DualToComposition.run!
 
   # Bot::Accountable raises on a settings save without set_missed_quote_amount (accountable.rb:82);
   # update_columns skips callbacks entirely, which is what a fixture wants.
@@ -158,6 +156,23 @@ class Bot::DualToCompositionTest < ActiveSupport::TestCase
     assert_equal other.to_global_id.to_s, gid_in(job)
   end
 
+  test 'a job holding the old GlobalID still finds the bot after conversion' do
+    # The Umbrel worker is its own container and can be claiming jobs while migrations run, so a
+    # tick enqueued as a pair can fire once the row is already a basket. It must not dead-letter.
+    job = enqueue_job_for(@bot)
+    old_gid = gid_in(job)
+    run!
+
+    assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
+    assert_nothing_raised { GlobalID::Locator.locate(old_gid) }
+    assert_equal @bot.id, GlobalID::Locator.locate(old_gid).id
+    assert_equal 'Bots::DcaMultiAsset', GlobalID::Locator.locate(old_gid).type
+  end
+
+  test 'the fallback does not invent a bot that never existed' do
+    assert_raises(ActiveRecord::RecordNotFound) { Bots::DcaDualAsset.find(0) }
+  end
+
   # == What is refused ==
 
   test 'an executing bot is left alone' do
@@ -211,27 +226,10 @@ class Bot::DualToCompositionTest < ActiveSupport::TestCase
     assert_includes skipped.map(&:last), 'job in flight'
   end
 
-  test 'a job scheduled in the future does not block the drained operator run' do
+  test 'a job scheduled in the future does not block conversion' do
     enqueue_job_for(@bot, state: :scheduled, scheduled_at: 1.hour.from_now)
     run!
 
-    assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
-  end
-
-  test 'the deploy-time run defers any bot that has a queued job at all' do
-    # Workers are live during a deploy, and a scheduled tick could fire between the type flip and
-    # the queue repoint — different databases, so they cannot commit together.
-    enqueue_job_for(@bot, state: :scheduled, scheduled_at: 1.hour.from_now)
-    _, skipped = run!(defer_scheduled: true)
-
-    assert_equal 'Bots::DcaDualAsset', Bot.where(id: @bot.id).pick(:type)
-    assert_match(/bots:migrate_dual_to_multi/, skipped.first.last)
-  end
-
-  test 'the deploy-time run still converts a bot with nothing queued' do
-    _, skipped = run!(defer_scheduled: true)
-
-    assert_empty skipped
     assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
   end
 


### PR DESCRIPTION
Follow-up to #284. The conversion of existing pair bots assumed an operator — one who would drain job processing and run `bin/rails bots:migrate_dual_to_multi` for any bot the deploy-time migration had to leave alone.

Self-hosted users have none. They pull an image and boot. Every *working* pair bot has a scheduled tick, the migration deferred all of them, and nothing ever retried — so on a self-hosted install the conversion simply never finished. The release that removes `Bots::DcaDualAsset` would then leave rows whose class is gone: `ActiveRecord::SubclassNotFound` fires when the record is instantiated, so `current_user.bots` raises and the whole bot list goes down, not one bot.

## Why deferring can't be made correct

The type change lands in the primary database and the bot's queued-job GlobalIDs in the Solid Queue database. Those are two databases, so no check can be atomic with the commit — a worker can always start, or claim a job, in the gap.

Nor is the deployment sequence a guarantee. It holds for the standalone image, where `docker-entrypoint.sh` finishes migrating before it execs the server and Solid Queue runs in-Puma. It does not hold for the Umbrel compose, which runs the worker as its own `jobs` container (`rake solid_queue:start`) with short-form `depends_on: web` — that waits for the web container to *start*, not for its migrations to finish. A worker can be claiming ticks while the conversion runs.

## So it recurs instead

`Bot::ConvertDualAssetBotsJob` runs the same pass every 15 minutes until nothing is left, then no-ops. A bot that was mid-order or mid-tick at deploy time converts on a later pass with nobody watching, and the rake task drops from *required* to a way of doing it now.

Each pass is safe rather than merely repeated:

- **Money in flight is refused outright** — executing, pending rebalance, live order, or a job running, dispatched or already due.
- **`Bots::DcaDualAsset.find` falls back to the row as it now stands.** A tick enqueued before the flip carries a GlobalID naming the pair class; STI scoping would raise `RecordNotFound` and dead-letter it. It now resolves to the basket and runs against it, which is what it should do after the conversion. Removed with the class.

And two corrections run every pass, which is the reason the pass has to recur at all:

- `repair_clobbered!` undoes a pair-shaped write from an instance a worker deserialized before the flip.
- `sweep_stray_jobs!` repoints a GlobalID a worker re-enqueued under the old name after the previous sweep had passed.

The job's guard asks about all three — pair rows, clobbered rows, stray job ids — because the last pair row usually disappears *before* the clobber that needs repairing shows up. Gating on pair rows alone would switch the repair off exactly when it starts being needed, which is how the test for it caught the first version.

## Removed

The heartbeat-based quiescence check from the first draft of this branch. With the `find` fallback in place a merely-scheduled job is no longer a hazard, so measuring whether a worker is alive bought nothing that recurring didn't buy more simply.
