### PR TITLE
Inset the dashboard plot, and wait on its own axis

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -173,6 +173,13 @@ ol, ul
                 line-height: calc(3rem * 0.6)
                 letter-spacing: calc(0.25rem * 0.6)
 
+// Left to right, the way the curve that replaces it is read.
+@keyframes dash-axis-sweep
+    from
+        background-position: 100% 0
+    to
+        background-position: 0 0
+
 // The dashboard headline, and the P/L curve that runs into it.
 //
 // The rule under the number is the chart's ZERO line, which is why it is drawn as an absolute rule
@@ -181,6 +188,9 @@ ol, ul
 // the space under the line is reserved rather than borrowed from the row beneath.
 .dash-intro
     --dash-height: 7rem
+    // How far the curve stops short of the section's top and bottom, so it never runs flush
+    // into the row above or the one below.
+    --dash-inset: 1rem
     position: relative
     display: flex
     min-height: var(--dash-height)
@@ -189,7 +199,7 @@ ol, ul
         // the curve is there yet: the plot arrives on a later trip, and a section that grew when
         // it landed would push the whole dashboard down under the reader's pointer.
         &--plotted
-            min-height: calc(var(--dash-height) * 2)
+            min-height: calc(var(--dash-height) * 2 - var(--dash-inset))
     &::after
         content: ''
         position: absolute
@@ -197,6 +207,21 @@ ol, ul
         right: 0
         top: var(--dash-height)
         border-bottom: 0.1rem solid var(--steel)
+    // The wait, drawn as the zero line itself: same place, same weight, with a light running
+    // along it. Above the rule (which is a later sibling in paint order) because it stands in
+    // for it rather than beside it.
+    &__loading
+        position: absolute
+        z-index: 1
+        left: 0
+        right: 0
+        top: var(--dash-height)
+        height: 0.1rem
+        background: linear-gradient(90deg, var(--steel) 40%, var(--ink) 50%, var(--steel) 60%)
+        background-size: 300% 100%
+        animation: dash-axis-sweep 1.6s linear infinite
+        @media (prefers-reduced-motion: reduce)
+            animation: none
     #global-pnl
         display: flex
         flex: 1
@@ -222,14 +247,15 @@ ol, ul
         max-height: 7rem
         margin-bottom: -1rem
         font-weight: 600 !important
-    // Whatever width the number leaves, and twice the height of the headline: the box above the
-    // zero line, mirrored below it. Fixed rather than cut to each account's worst day — the rest
-    // of the page would otherwise sit at a height that means something only to this curve.
+    // Whatever width the number leaves, and the headline's height less the inset, above the zero
+    // line and mirrored below it. Fixed rather than cut to each account's worst day — the rest of
+    // the page would otherwise sit at a height that means something only to this curve.
     &__spark
         display: flex
         flex: 1
         min-width: 0
-        height: calc(var(--dash-height) * 2)
+        height: calc(var(--dash-height) * 2 - var(--dash-inset) * 2)
+        margin-top: var(--dash-inset)
         // The curve is a desktop reading. On a phone the headline already fills the row, and the
         // space a loss reserves below the line comes out of a layout that has none to give — so
         // the plot goes entirely, and the section is the 7rem box it always was.

--- a/app/views/bots/_global_pnl.html.erb
+++ b/app/views/bots/_global_pnl.html.erb
@@ -41,6 +41,8 @@
       <% end %>
     </div>
   <% elsif loading %>
-    <div class="loader--small"></div>
+    <%# The wait is drawn on the chart's own zero line rather than as a spinner: the axis is
+        already there, and a light travelling along it says the curve is coming where it will be. %>
+    <div class="dash-intro__loading"></div>
   <% end %>
 <% end %>

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -29,7 +29,7 @@
                   data: pnl_pass ? { controller: "broadcast--on-connect",
                                      broadcast__on_connect_method_value: "global_pnl_update",
                                      broadcast__on_connect_retry_while_value:
-                                       ("#global-pnl .loader--small" if @global_pnl_loading) }.compact : {} do %>
+                                       ("#global-pnl .dash-intro__loading" if @global_pnl_loading) }.compact : {} do %>
     <%= render partial: 'bots/global_pnl', locals: { global_pnl: @global_pnl, denomination: @denomination,
                                                      loading: @global_pnl_loading, history: @global_pnl_history,
                                                      hide_balances: current_user.hide_balances? } %>

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -152,4 +152,17 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     assert_select '#global-pnl[data-pnl-spark-percent-value]'
     assert_select '#global-pnl[data-pnl-spark-profit-value]', false
   end
+  # The wait is the axis, not a spinner — and the poll that retries it has to be looking for the
+  # same element, or a cold headline never asks again.
+  test 'a cold headline waits on the zero line, and the retry watches that line' do
+    User.any_instance.stubs(:global_pnl_snapshot).returns({ result: nil, loading: true })
+
+    get bots_path
+
+    assert_select '#global-pnl .dash-intro__loading'
+    assert_select '#global-pnl .loader--small', false, 'no spinner in the headline any more'
+    assert_select '.dash-intro[data-broadcast--on-connect-retry-while-value=?]',
+                  '#global-pnl .dash-intro__loading'
+  end
+
 end


### PR DESCRIPTION
Two changes to the P/L plot behind the dashboard headline.

**The plot is inset 1rem top and bottom.** It spanned the full height of the headline above the
zero line and the same below it, so a good run or a bad one ran flush into the row above or the one
below. A `--dash-inset` on the section takes 1rem off each side (14rem → 12rem) and drops the
reserved height with it; the zero line stays where it was, and the curve's geometry is written in a
100-unit box that stretches to whatever the box is, so nothing else moved.

**The wait is drawn on the zero line instead of as a spinner.** The total arrives on a later trip
than the page, and until it did there was a spinner sitting where the number goes. The axis is
already drawn across that space, so the wait is now a light travelling along it, left to right, the
way the curve that replaces it is read. It holds still under `prefers-reduced-motion`.

The poll that retries a cold headline watches the DOM for whatever marks the wait, so its selector
moved to the new element. A test covers both halves of that pair — the marker in the view and the
selector that looks for it — since a drift between them leaves a headline that never asks again.
