### PR TITLE
Offer market-cap weighting as a rule, where it can do something

### DIFF
--- a/app/models/bots/dca_multi_asset.rb
+++ b/app/models/bots/dca_multi_asset.rb
@@ -177,6 +177,17 @@ class Bots::DcaMultiAsset < Bot
   def weighting = super.presence || 'manual'
   def market_cap_weighted? = weighting == 'market_cap'
 
+  # Whether the market-cap rule can do anything here. Stocks and ETFs carry no market cap at all —
+  # a QQQM/IBIT basket has nil on both members — and derive_composition keeps the stored weights
+  # when any member cannot be sized, so offering the rule there would be a switch that silently
+  # changes nothing. Zero counts as missing: an asset priced at no market cap is not a weight.
+  def market_cap_weightable?
+    ids = base_asset_ids.uniq
+    return false if ids.empty?
+
+    Asset.where(id: ids).where.not(market_cap: nil).where(market_cap: 1..).count == ids.size
+  end
+
   def composition_size = base_asset_ids.size
   def exited_title_key = 'bot.dca_multi_asset.removed_from_portfolio'
   def metrics_partial = 'bots/composition/metrics'

--- a/app/views/bots/dca_multi_assets/_settings.html.erb
+++ b/app/views/bots/dca_multi_assets/_settings.html.erb
@@ -3,6 +3,11 @@
 
 <div id="settings" class="column gap-1">
   <%= render partial: "bots/dca_multi_assets/settings/main", locals: { bot: bot, method: method, path: path } %>
+  <%# Only where every member has a market cap to be weighted by — or where the rule is already on,
+      so a basket whose data went away can still switch it off. %>
+  <% if bot.market_cap_weightable? || bot.market_cap_weighted? %>
+    <%= render partial: "bots/dca_multi_assets/settings/marketcap_allocation", locals: { bot: bot, method: method, path: path } %>
+  <% end %>
   <%= render partial: "bots/settings/smart_intervals", locals: { bot: bot, method: method, path: path } %>
   <%= render partial: "bots/settings/limit_orders", locals: { bot: bot, method: method, path: path } %>
   <%= render partial: "bots/settings/starting_time", locals: { bot: bot, method: method, path: path } %>

--- a/app/views/bots/dca_multi_assets/settings/_main.html.erb
+++ b/app/views/bots/dca_multi_assets/settings/_main.html.erb
@@ -29,17 +29,6 @@
     </div>
   </div>
 
-  <div class="conversational flex-justify-center">
-    <%= t('bot.dca_multi_asset.weighted') %>
-    <div class="sinput sinput--select <%= 'sinput--disabled' if composition_locked %>">
-      <%= t("bot.dca_multi_asset.weighting.#{bot.weighting}") %>
-      <%= f.select :weighting,
-                   Bots::DcaMultiAsset::WEIGHTINGS.map { |w| [t("bot.dca_multi_asset.weighting.#{w}"), w] },
-                   { selected: bot.weighting },
-                   data: { action: "change->form--submit#submit" }, disabled: composition_locked %>
-    </div>
-  </div>
-
   <div class="asset-allocations">
     <% base_assets.each do |asset| %>
       <% color = ensure_contrast(asset.color || '#8A9BA8') %>

--- a/app/views/bots/dca_multi_assets/settings/_marketcap_allocation.html.erb
+++ b/app/views/bots/dca_multi_assets/settings/_marketcap_allocation.html.erb
@@ -1,0 +1,37 @@
+<%# The same rule the pair bot offered, on a basket of any size. A checkbox rather than a picker:
+    the model stores a strategy name, but there are only two and the second is the switched-off one,
+    so weighting reads as the toggle it is. Rendered only where it can actually do something — see
+    the guard in _settings. %>
+<%= form_with model: bot,
+              url: path,
+              method: method,
+              class: "widget main-rule main-rule--multi-asset #{bot.market_cap_weighted? ? "rule--active" : "rule--inactive"}",
+              data: {
+                controller: "class-toggle form--submit",
+                class_toggle_target: "togglable",
+                class_toggle_toggle_classes_value: ["rule--active", "rule--inactive"],
+                turbo_stream: true
+              } do |f| %>
+  <div class="toggle-group">
+    <div class="toggle">
+      <%= f.check_box :weighting,
+                      { checked: bot.market_cap_weighted?,
+                        data: { action: "change->form--submit#submit change->class-toggle#toggle" },
+                        disabled: bot.composition_locked? },
+                      "market_cap", "manual" %>
+      <div class="toggle__style"></div>
+    </div>
+    <div class="toggle-group__info" data-controller="class-toggle" data-class-toggle-toggle-classes-value='["hidden"]'>
+      <div class="toggle-group__info__label">
+        <%= f.label :weighting, t('bot.utils.mkt_cap_adjusted_html').html_safe, class: "conversational conversational--small" %>
+        <div class="tooltip-info-icon" data-controller="tooltip" data-action="click->tooltip#toggle click->class-toggle#toggle">
+          <%= render 'svg/24x24_info' %>
+          <%= render 'svg/24x24_info-filled' %>
+        </div>
+      </div>
+      <div class="bot-option-info hidden" data-class-toggle-target="togglable">
+        <%= t('bot.utils.mkt_cap_adjusted_info_html').html_safe %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -8,10 +8,6 @@ bg:
             connect_alpaca_html: "За да инвестирате в акции, първо свържете Alpaca в %{settings_link}."
             settings_link: "Настройки"
         dca_multi_asset:
-            weighted: "Претегляне"
-            weighting:
-                manual: "Ръчно"
-                market_cap: "По пазарна капитализация"
             add_asset: "Добавяне на актив"
             remove_asset: "Премахване"
             max_assets_reached: "Можете да държите до %{max} актива."

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -8,10 +8,6 @@ cs:
             connect_alpaca_html: "Pokud chceš investovat do akcií, nejdřív připoj Alpacu v %{settings_link}."
             settings_link: "Nastavení"
         dca_multi_asset:
-            weighted: "Vážení"
-            weighting:
-                manual: "Ručně"
-                market_cap: "Podle tržní kapitalizace"
             add_asset: "Přidat aktivum"
             remove_asset: "Odebrat"
             max_assets_reached: "V portfoliu můžete mít nejvýše %{max} aktiv."

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -8,10 +8,6 @@ da:
             connect_alpaca_html: "For at investere i aktier skal du først forbinde Alpaca i %{settings_link}."
             settings_link: "Indstillinger"
         dca_multi_asset:
-            weighted: "Vægtning"
-            weighting:
-                manual: "Manuel"
-                market_cap: "Efter markedsværdi"
             add_asset: "Tilføj aktiv"
             remove_asset: "Fjern"
             max_assets_reached: "Du kan have op til %{max} aktiver."

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -8,10 +8,6 @@ de:
             connect_alpaca_html: "Um in Aktien zu investieren, verbinde zuerst Alpaca in den %{settings_link}."
             settings_link: "Einstellungen"
         dca_multi_asset:
-            weighted: "Gewichtung"
-            weighting:
-                manual: "Manuell"
-                market_cap: "Nach Marktkapitalisierung"
             add_asset: "Asset hinzufügen"
             remove_asset: "Entfernen"
             max_assets_reached: "Du kannst bis zu %{max} Assets halten."

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -8,10 +8,6 @@ el:
             connect_alpaca_html: "Για να επενδύσεις σε μετοχές, σύνδεσε πρώτα το Alpaca στις %{settings_link}."
             settings_link: "Ρυθμίσεις"
         dca_multi_asset:
-            weighted: "Στάθμιση"
-            weighting:
-                manual: "Χειροκίνητα"
-                market_cap: "Βάσει κεφαλαιοποίησης αγοράς"
             add_asset: "Προσθήκη περιουσιακού στοιχείου"
             remove_asset: "Αφαίρεση"
             max_assets_reached: "Μπορείτε να διατηρείτε έως %{max} περιουσιακά στοιχεία."

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -8,10 +8,6 @@ en:
             connect_alpaca_html: "To invest in stocks, connect Alpaca in %{settings_link} first."
             settings_link: "Settings"
         dca_multi_asset:
-            weighted: "Weighted"
-            weighting:
-                manual: "Manual"
-                market_cap: "By market cap"
             add_asset: "Add asset"
             remove_asset: "Remove"
             max_assets_reached: "You can hold up to %{max} assets."

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -11,10 +11,6 @@ es:
             connect_alpaca_html: "Para invertir en acciones, conecta antes Alpaca en %{settings_link}."
             settings_link: "Ajustes"
         dca_multi_asset:
-            weighted: "Ponderación"
-            weighting:
-                manual: "Manual"
-                market_cap: "Por capitalización de mercado"
             add_asset: "Añadir activo"
             remove_asset: "Eliminar"
             max_assets_reached: "Puedes tener hasta %{max} activos."

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -11,10 +11,6 @@ fr:
             connect_alpaca_html: "Pour investir en actions, connecte d'abord Alpaca dans les %{settings_link}."
             settings_link: "Réglages"
         dca_multi_asset:
-            weighted: "Pondération"
-            weighting:
-                manual: "Manuel"
-                market_cap: "Par capitalisation boursière"
             add_asset: "Ajouter un actif"
             remove_asset: "Retirer"
             max_assets_reached: "Vous pouvez détenir jusqu’à %{max} actifs."

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -8,10 +8,6 @@ it:
             connect_alpaca_html: "Per investire in azioni, prima collega Alpaca nelle %{settings_link}."
             settings_link: "Impostazioni"
         dca_multi_asset:
-            weighted: "Ponderazione"
-            weighting:
-                manual: "Manuale"
-                market_cap: "Per capitalizzazione di mercato"
             add_asset: "Aggiungi asset"
             remove_asset: "Rimuovi"
             max_assets_reached: "Puoi detenere fino a %{max} asset."

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -11,10 +11,6 @@ nl:
             connect_alpaca_html: "Wil je in aandelen beleggen? Koppel eerst Alpaca via %{settings_link}."
             settings_link: "Instellingen"
         dca_multi_asset:
-            weighted: "Weging"
-            weighting:
-                manual: "Handmatig"
-                market_cap: "Op marktkapitalisatie"
             add_asset: "Asset toevoegen"
             remove_asset: "Verwijderen"
             max_assets_reached: "Je kunt maximaal %{max} assets aanhouden."

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -11,10 +11,6 @@ pl:
             connect_alpaca_html: "Żeby inwestować w akcje, najpierw podłącz Alpaca w %{settings_link}."
             settings_link: "Ustawieniach"
         dca_multi_asset:
-            weighted: "Ważenie"
-            weighting:
-                manual: "Ręcznie"
-                market_cap: "Według kapitalizacji rynkowej"
             add_asset: "Dodaj aktywo"
             remove_asset: "Usuń"
             max_assets_reached: "Możesz posiadać maksymalnie %{max} aktywów."

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -11,10 +11,6 @@ pt:
             connect_alpaca_html: "Para investires em ações, liga primeiro a Alpaca nas %{settings_link}."
             settings_link: "Definições"
         dca_multi_asset:
-            weighted: "Ponderação"
-            weighting:
-                manual: "Manual"
-                market_cap: "Por capitalização de mercado"
             add_asset: "Adicionar ativo"
             remove_asset: "Remover"
             max_assets_reached: "Pode deter até %{max} ativos."

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -11,10 +11,6 @@ ru:
             connect_alpaca_html: "Чтобы инвестировать в акции, сначала подключите Alpaca в %{settings_link}."
             settings_link: "Настройках"
         dca_multi_asset:
-            weighted: "Взвешивание"
-            weighting:
-                manual: "Вручную"
-                market_cap: "По рыночной капитализации"
             add_asset: "Добавить актив"
             remove_asset: "Удалить"
             max_assets_reached: "В портфеле может быть не более %{max} активов."

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -8,10 +8,6 @@ sk:
             connect_alpaca_html: "Ak chceš investovať do akcií, najprv prepoj Alpaca v %{settings_link}."
             settings_link: "Nastaveniach"
         dca_multi_asset:
-            weighted: "Váženie"
-            weighting:
-                manual: "Ručne"
-                market_cap: "Podľa trhovej kapitalizácie"
             add_asset: "Pridať aktívum"
             remove_asset: "Odstrániť"
             max_assets_reached: "V portfóliu môžete mať najviac %{max} aktív."

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -8,10 +8,6 @@ sv:
             connect_alpaca_html: "För att investera i aktier, anslut först Alpaca i %{settings_link}."
             settings_link: "Inställningar"
         dca_multi_asset:
-            weighted: "Viktning"
-            weighting:
-                manual: "Manuell"
-                market_cap: "Efter marknadsvärde"
             add_asset: "Lägg till tillgång"
             remove_asset: "Ta bort"
             max_assets_reached: "Du kan ha upp till %{max} tillgångar."

--- a/test/controllers/bots/dca_multi_assets/settings_update_test.rb
+++ b/test/controllers/bots/dca_multi_assets/settings_update_test.rb
@@ -35,6 +35,48 @@ class Bots::DcaMultiAssetsSettingsUpdateTest < ActionDispatch::IntegrationTest
     assert_match(/disabled/, response.body)
   end
 
+  test 'the market-cap rule is offered when every member carries a market cap' do
+    @first.update!(market_cap: 750.0)
+    @second.update!(market_cap: 250.0)
+
+    get bot_path(id: @bot.id)
+
+    assert_select "input[name='bots_dca_multi_asset[weighting]']"
+  end
+
+  test 'the rule is not offered on a basket of stocks, which carry none' do
+    # The case that prompted this: on a QQQM/IBIT basket the control appeared and did nothing.
+    @first.update!(market_cap: nil, category: 'Stock')
+    @second.update!(market_cap: nil, category: 'Stock')
+
+    get bot_path(id: @bot.id)
+
+    assert_select "input[name='bots_dca_multi_asset[weighting]']", false
+  end
+
+  test 'the rule reads as a toggle, not as a picker' do
+    @first.update!(market_cap: 750.0)
+    @second.update!(market_cap: 250.0)
+
+    get bot_path(id: @bot.id)
+
+    assert_select "input[type='checkbox'][name='bots_dca_multi_asset[weighting]'][value='market_cap']"
+    assert_select "select[name='bots_dca_multi_asset[weighting]']", false
+  end
+
+  test 'unchecking the rule puts the basket back on its own weights' do
+    @first.update!(market_cap: 750.0)
+    @second.update!(market_cap: 250.0)
+    patch bot_path(id: @bot.id), params: { bots_dca_multi_asset: { weighting: 'market_cap' } },
+                                 as: :turbo_stream
+
+    patch bot_path(id: @bot.id), params: { bots_dca_multi_asset: { weighting: 'manual' } },
+                                 as: :turbo_stream
+
+    assert_not @bot.reload.market_cap_weighted?
+    assert_equal({ @first.id => 0.5, @second.id => 0.5 }, composition_weights)
+  end
+
   test 'PATCH add_asset_id admits a third asset at zero' do
     third = create(:asset, symbol: 'SOL', name: 'Solana', external_id: 'solana')
     create(:ticker, exchange: @bot.exchange, base_asset: third, quote_asset: @bot.quote_asset)

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -164,5 +164,4 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     assert_select '.dash-intro[data-broadcast--on-connect-retry-while-value=?]',
                   '#global-pnl .dash-intro__loading'
   end
-
 end

--- a/test/models/bots/dca_multi_asset_weighting_test.rb
+++ b/test/models/bots/dca_multi_asset_weighting_test.rb
@@ -89,6 +89,35 @@ class Bots::DcaMultiAssetWeightingTest < ActiveSupport::TestCase
     assert_in_delta 0.75, weight_of(@btc), 0.0001
   end
 
+  # == when the rule may be offered at all ==
+
+  test 'a basket of assets that all carry a market cap can be weighted by it' do
+    assert @bot.market_cap_weightable?
+  end
+
+  test 'a basket holding a stock cannot — stocks carry no market cap' do
+    # The case that prompted this: QQQM and IBIT are both stocks, market_cap nil on each, so the
+    # rule would have been a switch that changed nothing.
+    @eth.update!(market_cap: nil, category: 'Stock')
+
+    assert_not @bot.market_cap_weightable?
+  end
+
+  test 'a market cap of zero counts as missing, not as a weight' do
+    @eth.update!(market_cap: 0)
+
+    assert_not @bot.market_cap_weightable?
+  end
+
+  test 'a basket already weighted by market cap still says so when its data goes away' do
+    # Otherwise the rule vanishes while still switched on, with no way to turn it off.
+    configure!(weighting: 'market_cap')
+    @eth.update!(market_cap: nil)
+
+    assert_not @bot.market_cap_weightable?
+    assert @bot.market_cap_weighted?
+  end
+
   test 'an unknown weighting is refused' do
     @bot.weighting = 'astrology'
     @bot.set_missed_quote_amount


### PR DESCRIPTION
Fixes how market-cap weighting was presented on the multi-asset bot, from #284.

## It was the wrong control, in the wrong place

It shipped as a `Weighted: Manual / By market cap` picker inside the settings sentence — a shape nothing else on the page uses, sitting above the sliders it governs. The pair bot had already answered this: a rule below the main block, using the same toggle, the same `Market Cap adjusted` wording, and the same info tooltip as every other rule. This moves it there.

A checkbox rather than a picker, because there are only two strategies and the second one is "off". The model still stores a strategy name; the checkbox posts `market_cap` or `manual`.

## It was offered where it cannot work

Stocks and ETFs carry no market cap. A QQQM/IBIT basket has `nil` on both members, and `derive_composition` deliberately keeps the stored weights when any member cannot be sized — so the control appeared, could be switched on, and silently changed nothing.

The rule now renders only when every member has a market cap above zero, or when it is already switched on, so a basket whose data went away can still be switched off rather than being stuck with a rule it can no longer see.

Zero counts as missing rather than as a weight — some assets carry a market cap of `0`, and weighting by it is not a proportion.

## Also

The three locale keys the picker needed are gone from all fifteen files; the rule reuses `bot.utils.mkt_cap_adjusted_html` and its info text, which every locale already has.
