### PR TITLE
Take the hidden cash off the money in that funds it

### DIFF
--- a/app/controllers/tracker_controller.rb
+++ b/app/controllers/tracker_controller.rb
@@ -233,8 +233,9 @@ class TrackerController < ApplicationController
 
   private
 
-  # Cash and stablecoins are where money waits, not a position anybody picked, so the allocation is
-  # drawn without them unless asked. Absent means off: the default is the invested portfolio.
+  # Cash and stablecoins are where money waits, not a position anybody picked, so the page is about
+  # the active positions unless asked otherwise. Absent means off: the default is the invested
+  # portfolio, and `Hide balances` is the separate switch for taking the money off the screen.
   def show_cash?
     current_user.tracker_settings&.dig('show_cash').present?
   end
@@ -315,6 +316,23 @@ class TrackerController < ApplicationController
       return
     end
 
+    first_transaction = AccountTransaction.for_user(current_user).minimum(:transacted_at)&.to_date
+    # The curve follows the switch too, and a day swept before it cannot answer for the positions —
+    # the cash standing on it is not recoverable from a row that never stated it. Those days are not
+    # drawn (a nil read as zero would be a lie in the shape of a figure), and a sweep is asked for
+    # while any of them is a day a sweep can still reach: the first transaction to yesterday, which
+    # is exactly the window the job writes. Nothing else is asked for on every page load — a row
+    # older than the account's own history is dropped for good, and TODAY's row is the sync's to
+    # rewrite (`record!` states both readings), which it does on the next one.
+    unless show_cash?
+      unswept, @history = @history.partition { |row| row.held_cost_usd.nil? }
+      if unswept.any? { |row| first_transaction && row.date.between?(first_transaction, Date.yesterday) }
+        PortfolioSnapshot::BackfillJob.perform_later(current_user.id, @scope_exchange&.id)
+        @history_loading = @history.empty?
+        return
+      end
+    end
+
     # A day already swept can still be wrong: it was valued at the prices that existed then, and the
     # sweep only ever runs forwards. Prices arriving since — a range the provider could not answer
     # before — change days nothing else revisits, so a history with unvalued days asks for one more
@@ -325,7 +343,6 @@ class TrackerController < ApplicationController
       return
     end
 
-    first_transaction = AccountTransaction.for_user(current_user).minimum(:transacted_at)&.to_date
     return if @scope_exchange || first_transaction.nil? || first_transaction >= Date.current
     return if @history.first && @history.first.date <= first_transaction
 
@@ -355,9 +372,10 @@ class TrackerController < ApplicationController
     # contradict each other with nothing able to notice.
     @figures = Tracker::Figures.for(current_user, ledger: @scoped_ledger, balances: balances,
                                                   pending: quantities_since)
-    # The switch beside the venues, applied once. Everything drawn FROM the holdings — the card, the
-    # ring, the type shares, the positions table — follows; every figure stated ABOUT the portfolio
-    # is untouched, because hiding a balance is not an accounting choice.
+    # The switch beside the venues, applied once — and it scopes the whole page, not only the list:
+    # what is drawn FROM the holdings (the card, the ring, the type shares, the positions table)
+    # and what is stated ABOUT them (money in, value, the P/L between the two). See
+    # `Figures::Result#without_cash` for what that restatement is.
     unless show_cash?
       invested = @figures.without_cash
       # An account holding nothing BUT cash has balances; it just has no invested position to

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -131,6 +131,10 @@ module TrackerHelper
 
   # [value, invested] for the chart, in the display currency.
   #
+  # Which pair depends on the scope switch, exactly as the tiles below it do: the whole portfolio
+  # with cash shown, and what the positions were worth against what they cost with it hidden. Every
+  # day carries both, so the curve is a column choice rather than a second sweep.
+  #
   # While balances are hidden the two curves are NORMALIZED instead: every point divided by the last
   # invested figure, which stands the invested line at 100 and reads value against it. The shape is
   # identical and the payload carries proportions rather than money — the attribute is on the page
@@ -138,8 +142,9 @@ module TrackerHelper
   # back to the last VALUE when nothing was ever invested, and to 1 when both are zero, so what
   # ships is always finite.
   def chart_history_series(history, hide_money)
-    values = history.map { |row| row.value_usd.to_d }
-    invested = history.map { |row| row.invested_usd.to_d }
+    worth, cost = show_cash? ? %i[value_usd invested_usd] : %i[held_value_usd held_cost_usd]
+    values = history.map { |row| row.public_send(worth).to_d }
+    invested = history.map { |row| row.public_send(cost).to_d }
     return denominated_series(values, invested) unless hide_money
 
     divisor = [invested.last, values.last, 1.to_d].find(&:positive?)

--- a/app/jobs/portfolio_snapshot/backfill_job.rb
+++ b/app/jobs/portfolio_snapshot/backfill_job.rb
@@ -75,6 +75,11 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
   # and the tile are one number, and there is no second opinion about what a row contributed. The
   # sweep keeps only what VALUING a day needs: the quantities, and the cash a venue must have had
   # to pay for what it bought.
+  #
+  # Each day is written TWICE over, because the page has two readings of it and "Show cash" picks
+  # between them: the whole portfolio, and the same day with the cash taken off both sides — the
+  # value it stands in, and the money in that funds it. Both come off the day already swept; the
+  # cash of the day is the one extra figure, and the sweep is already valuing it.
   def sweep(first_date)
     balances = Hash.new(0.to_d)
     # Cash per VENUE, beside the balances the day is valued from: dollars at a broker cannot pay for
@@ -104,8 +109,9 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
         # An opening balance is held from the day the ledger booked it, as the ledger holds it.
         balances[term.opens.first] += term.opens.last if term.opens
       end
-      value, unpriced = value_on(balances, date)
+      value, held, unpriced = value_on(balances, date)
       { user_id: @user.id, date: date, value_usd: value, invested_usd: invested,
+        held_value_usd: held, held_cost_usd: invested - (value - held),
         partial: unpriced || invested_incomplete }
     end
   end
@@ -225,13 +231,20 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
     end
   end
 
+  # [everything, the positions inside it, whether a holding went unpriced]. Cash is split out of the
+  # same walk rather than filtered in a second one, so the two readings of a day cannot disagree
+  # about it — and it is split by the predicate the page uses (`UnfundedCash.cash?`), so the curve
+  # and the holdings card mean the same thing by "cash".
+  #
   # A negative balance is history we do not have — an exchange whose ledger window starts after the
   # funding deposit leaves a sale with nothing behind it. Dropping it silently would show the whole
   # position as profit, so the day says it is an estimate instead.
   def value_on(balances, date)
     unpriced = balances.any? { |_symbol, quantity| quantity < -DUST }
-    total = balances.sum(0.to_d) do |symbol, quantity|
-      next 0.to_d unless quantity.positive?
+    total = 0.to_d
+    held = 0.to_d
+    balances.each do |symbol, quantity|
+      next unless quantity.positive?
 
       value = if STABLECOINS.include?(symbol)
                 quantity
@@ -242,9 +255,10 @@ class PortfolioSnapshot::BackfillJob < ApplicationJob
                 price && (quantity * price)
               end
       unpriced ||= value.nil?
-      value || 0.to_d
+      total += value || 0.to_d
+      held += value || 0.to_d unless Tracker::UnfundedCash.cash?(symbol)
     end
-    [total, unpriced]
+    [total, held, unpriced]
   end
 
   def fiat_value(currency, amount, date)

--- a/app/models/portfolio_snapshot.rb
+++ b/app/models/portfolio_snapshot.rb
@@ -28,7 +28,11 @@ class PortfolioSnapshot < ApplicationRecord
     # The same resolution the tiles show, so the chart's last point and the tile are one figure.
     figures = Tracker::Figures.for(user, ledger: ledger, balances: balances,
                                          pending: Tracker::Figures.moved_since(pending_scope(user, exchange), watermarks(user, exchange)))
+    # Both readings of the day, as the tiles state them: the whole portfolio, and the positions
+    # inside it — "Show cash" picks between them on the page, never here.
+    positions = figures.without_cash
     { user_id: user.id, date: Date.current, value_usd: figures.value, invested_usd: figures.invested,
+      held_value_usd: positions.value, held_cost_usd: positions.invested,
       partial: partial?(user, balances) || ledger.incomplete }
   end
 
@@ -85,7 +89,7 @@ class PortfolioSnapshot < ApplicationRecord
   # today, and tomorrow's answer is a different one.
   def self.series_key(user, exchange)
     scope = AccountTransaction.for_user(user).for_exchange(exchange)
-    "tracker_history_v3_#{user.id}_#{exchange.id}_#{Date.current.iso8601}_#{watermarks(user, exchange)[exchange.id]&.to_i}_" \
+    "tracker_history_v4_#{user.id}_#{exchange.id}_#{Date.current.iso8601}_#{watermarks(user, exchange)[exchange.id]&.to_i}_" \
       "#{scope.maximum(:updated_at)&.utc&.iso8601(6)}_#{scope.count}"
   end
 

--- a/app/models/tracker/figures.rb
+++ b/app/models/tracker/figures.rb
@@ -37,12 +37,22 @@ module Tracker
     end
 
     Result = Data.define(:invested, :value, :fees, :realised, :unrealised, :total, :holdings, :notes, :ledger) do
-      # The portfolio as an ALLOCATION: what was actually invested, normalized by whoever draws it.
-      # Only the list changes — every figure beside it is still the whole portfolio, cash and all,
-      # because hiding a balance is not an accounting choice. One filter here rather than one in
-      # each template is what keeps the card, the ring, the type shares and the positions table
-      # reading from the same list.
-      def without_cash = with(holdings: holdings.reject(&:cash?))
+      # The portfolio with the cash TAKEN OFF BOTH SIDES: it leaves the list, it leaves the value,
+      # and the money in that funds it leaves money in — so hiding a balance of a dollar moves the
+      # figures by a dollar, and nothing else moves at all. Fees, what was banked, what is riding
+      # and the total between them are the account's own record either way: a P/L is not a balance,
+      # and cannot be hidden by not looking at one.
+      #
+      # (Money in less idle cash, not the cost of what is held: those differ by everything a closed
+      # trade won or lost, and no reading of a cash BALANCE should turn on that.)
+      #
+      # One restatement here rather than one in each template is what keeps the tiles, the card, the
+      # ring, the type shares and the positions table reading from one result.
+      def without_cash
+        idle = holdings.sum(0.to_d) { |holding| holding.cash? ? holding.value : 0.to_d }
+        with(holdings: holdings.reject(&:cash?), value: value - idle,
+             invested: invested && (invested - idle))
+      end
     end
 
     # `pending` is what the ledger has recorded SINCE the balances were taken — a balance is a

--- a/db/migrate/20260828175918_add_positions_to_portfolio_snapshots.rb
+++ b/db/migrate/20260828175918_add_positions_to_portfolio_snapshots.rb
@@ -1,0 +1,9 @@
+# The curve follows the "Show cash" switch, so each day carries the second reading too: what the
+# positions held that day were worth, and what they cost. NULL means a day swept before the switch
+# reached the chart — the sweep fills it in, it is never a figure of zero.
+class AddPositionsToPortfolioSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    add_column :portfolio_snapshots, :held_value_usd, :decimal, precision: 20, scale: 8
+    add_column :portfolio_snapshots, :held_cost_usd, :decimal, precision: 20, scale: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_095813) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_175918) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false
@@ -417,6 +417,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_095813) do
   create_table "portfolio_snapshots", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
+    t.decimal "held_cost_usd", precision: 20, scale: 8
+    t.decimal "held_value_usd", precision: 20, scale: 8
     t.decimal "invested_usd", precision: 20, scale: 8, default: "0.0", null: false
     t.boolean "partial", default: false, null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -164,5 +164,4 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     assert_select '.dash-intro[data-broadcast--on-connect-retry-while-value=?]',
                   '#global-pnl .dash-intro__loading'
   end
-
 end

--- a/test/integration/tracker_history_test.rb
+++ b/test/integration/tracker_history_test.rb
@@ -18,8 +18,11 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
     # Spread over months, not days: a window shorter than the history is what makes the range
     # control a choice at all, and 30D on a three-day history draws the same picture as ALL.
     (1..3).each do |n|
+      # An account with no cash in it, so both readings of a day are the same figures — this file
+      # is about the plumbing, and `tracker_show_cash_test.rb` about which pair the switch picks.
       PortfolioSnapshot.create!(user: @user, date: Date.current - (400 - (n * 100)), value_usd: 30_000 + (n * 1_000),
-                                invested_usd: 30_000, partial: false)
+                                invested_usd: 30_000, held_value_usd: 30_000 + (n * 1_000),
+                                held_cost_usd: 30_000, partial: false)
     end
     sign_in @user
   end
@@ -107,7 +110,7 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
   end
 
   test 'with balances hidden and both value and invested at zero, the payload is zeros, not NaN' do
-    PortfolioSnapshot.for_user(@user).update_all(invested_usd: 0, value_usd: 0)
+    PortfolioSnapshot.for_user(@user).update_all(invested_usd: 0, value_usd: 0, held_cost_usd: 0, held_value_usd: 0)
     @user.update!(hide_balances: true)
     get tracker_path
 
@@ -117,7 +120,7 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
   end
 
   test 'with balances hidden and nothing invested, the payload is still finite and money-free' do
-    PortfolioSnapshot.for_user(@user).update_all(invested_usd: 0)
+    PortfolioSnapshot.for_user(@user).update_all(invested_usd: 0, held_cost_usd: 0)
     @user.update!(hide_balances: true)
     get tracker_path
 

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -76,7 +76,7 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     # 30,000 in − 1,000 out + the 5,020 each venue spent without reporting its arrival = 34,020; then
     # the resolution against the balances: 10 ETH the exchange holds with no history behind them,
     # taken as arrived at its price (+20,000), and the sale's 5,000 the exchange no longer shows,
-    # taken as moved out (−5,000).
+    # taken as moved out (−5,000). No cash is held, so the switch has nothing to take off it.
     assert_select '.data-grid__item__value', text: /\$49,020\.00/
     assert_select '.data-grid__item__value', text: /\$80,000\.00/
     assert_select '.data-grid__item__value.text-success', text: /1,000\.00/ # the ETH round-trip

--- a/test/integration/tracker_show_cash_test.rb
+++ b/test/integration/tracker_show_cash_test.rb
@@ -6,9 +6,11 @@ require 'test_helper'
 # that is a fifth USDT gives its second-biggest arc to a coin nobody chose, so by default the
 # allocation is drawn from what was actually invested and the rest is normalized to 100%.
 #
-# It hides a BALANCE, not a figure. Every number the page states about how the account has done —
-# what went in, what it is worth, fees, realised, unrealised, total P/L, and the curve above them —
-# is the whole portfolio whichever way the switch is thrown. Nothing here is an accounting choice.
+# It scopes the page to that: the list, and the figures that describe it. With cash hidden, money
+# in is what the holdings left over COST, the value is what that portion is worth now, and the P/L
+# between them is the one still riding. Fees paid and gains banked are the account's record of what
+# it has already done and stay whole either way — as does the curve above them, which is stored
+# history and knows nothing of the switch.
 class TrackerShowCashTest < ActionDispatch::IntegrationTest
   setup do
     Tax::EcbFxRates.stubs(:ensure_loaded!)
@@ -125,37 +127,80 @@ class TrackerShowCashTest < ActionDispatch::IntegrationTest
     assert_select '.tracker-positions .tracker-row__asset', text: /USDT/, count: 1
   end
 
+  # ---- what it restates ---------------------------------------------------
+
+  # 40,000 came in, 30,000 of it bought the BTC now worth 36,000, and 10,000 is still waiting. With
+  # the cash hidden the page is about the 30,000 that was put to work and what it has become.
+  test 'money in and value follow the switch' do
+    get tracker_path
+    hidden = tiles
+
+    assert_equal '$30,000.00', hidden[I18n.t('bot.details.stats.total_invested')]
+    assert_equal '$36,000.00', hidden[I18n.t('bot.details.stats.portfolio_value')]
+    assert_equal '+$6,000.00', hidden[I18n.t('tracker.tiles.total_pnl')]
+
+    show_cash!
+    get tracker_path
+    shown = tiles
+
+    assert_equal '$40,000.00', shown[I18n.t('bot.details.stats.total_invested')]
+    assert_equal '$46,000.00', shown[I18n.t('bot.details.stats.portfolio_value')]
+    assert_equal '+$6,000.00', shown[I18n.t('tracker.tiles.total_pnl')]
+  end
+
   # ---- what it must not touch ---------------------------------------------
 
-  # Hiding a balance is not an accounting choice. Every figure is the whole portfolio either way.
-  test 'not one figure moves' do
+  # Hiding a balance does not unspend a fee or unbank a gain.
+  test 'fees and what was realised are the whole account either way' do
     get tracker_path
     hidden = tiles
 
     show_cash!
     get tracker_path
 
-    assert_equal tiles, hidden, 'the tiles state the whole portfolio whichever way the switch is thrown'
-    assert_equal '$46,000.00', hidden[I18n.t('bot.details.stats.portfolio_value')]
-    assert_equal '$40,000.00', hidden[I18n.t('bot.details.stats.total_invested')]
-    assert_equal '+$6,000.00', hidden[I18n.t('tracker.tiles.total_pnl')]
+    labels = [I18n.t('tracker.fees_paid'), I18n.t('bot.dca_index.realised_pnl')]
+
+    assert_equal tiles.values_at(*labels), hidden.values_at(*labels)
   end
 
-  test 'the chart is the whole portfolio either way' do
+  # The curve is the same reading as the tiles under it: the whole portfolio with cash shown, the
+  # positions inside it with cash hidden. Both pairs are on every day, so the switch picks a column.
+  test 'the curve follows the switch' do
     (1..3).each do |n|
       PortfolioSnapshot.create!(user: @user, date: Date.current - (400 - (n * 100)),
-                                value_usd: 40_000 + (n * 1_000), invested_usd: 40_000, partial: false)
+                                value_usd: 40_000 + (n * 1_000), invested_usd: 40_000,
+                                held_value_usd: 30_000 + (n * 1_000), held_cost_usd: 30_000, partial: false)
     end
     series = lambda do
       get tracker_path
-      css_select('[data-controller="bot--chart"]').first['data-bot--chart-series-value']
+      JSON.parse(css_select('[data-controller="bot--chart"]').first['data-bot--chart-series-value'])
     end
 
-    hidden = series.call
+    assert_equal [[31_000.0, 32_000.0, 33_000.0], [30_000.0] * 3], series.call
+
     show_cash!
 
-    assert_equal [[41_000.0, 42_000.0, 43_000.0], [40_000.0] * 3], JSON.parse(hidden)
-    assert_equal hidden, series.call
+    assert_equal [[41_000.0, 42_000.0, 43_000.0], [40_000.0] * 3], series.call
+  end
+
+  # A history swept before the curve learned about the switch has only the whole-portfolio pair,
+  # and no reading of it can recover the cash standing on those days. It is swept again rather than
+  # drawn as something it is not — and with cash shown there is nothing missing to wait for.
+  test 'a history from before the switch is swept again rather than drawn wrong' do
+    # Dated at the first transaction, so the only reason to sweep is the missing pair.
+    PortfolioSnapshot.create!(user: @user, date: 10.days.ago.to_date, value_usd: 46_000,
+                              invested_usd: 40_000, partial: false)
+    PortfolioSnapshot::BackfillJob.expects(:perform_later).with(@user.id, nil).once
+
+    get tracker_path
+
+    assert_select '.widget--chart__plot .loader'
+    assert_select '[data-controller="bot--chart"]', false
+
+    show_cash!
+    get tracker_path
+
+    assert_select '[data-controller="bot--chart"]'
   end
 
   # An account holding nothing BUT cash has balances; it just has no invested position to draw.

--- a/test/integration/tracker_tiles_test.rb
+++ b/test/integration/tracker_tiles_test.rb
@@ -89,10 +89,8 @@ class TrackerTilesTest < ActionDispatch::IntegrationTest
                  money(figures, I18n.t('tracker.tiles.unrealised_pnl'))
   end
 
-  # Fees are already off both halves — a disposal's gain is proceeds less cost less fee, and an
-  # acquisition's fee is capitalised into the basis. Subtracting the Fees tile again would charge
-  # them twice.
-  test 'fees are not subtracted a second time' do
+  # Half the BTC sold for 15,000 with a 100 fee: 4,900 banked, 5,000 still riding, 14,900 in cash.
+  def sell_half!
     create(:account_transaction, api_key: @key, exchange: @binance, entry_type: :sell,
                                  base_currency: 'BTC', base_amount: 0.5, quote_currency: 'USD',
                                  quote_amount: 15_000, fee_amount: 100, fee_currency: 'USD',
@@ -105,6 +103,14 @@ class TrackerTilesTest < ActionDispatch::IntegrationTest
     AccountBalance.create!(user: @user, exchange: @binance, asset: usd, free: 14_900, locked: 0,
                            usd_price: 1, usd_value: 14_900, synced_at: Time.current, priced_at: Time.current)
     Tracker::Ledger.compute!(@user)
+  end
+
+  # Fees are already off both halves — a disposal's gain is proceeds less cost less fee, and an
+  # acquisition's fee is capitalised into the basis. Subtracting the Fees tile again would charge
+  # them twice.
+  test 'fees are not subtracted a second time' do
+    sell_half!
+    @user.update!(tracker_settings: { 'show_cash' => true })
 
     figures = tiles
 
@@ -113,6 +119,23 @@ class TrackerTilesTest < ActionDispatch::IntegrationTest
                  money(figures, I18n.t('bot.dca_index.realised_pnl')) +
                  money(figures, I18n.t('tracker.tiles.unrealised_pnl')),
                  'the components still come to the total, with the fee already inside them'
+  end
+
+  # And with cash hidden they still come to it: the 14,900 the sale returned comes off the value
+  # AND off the money in that funds it, so the difference between them — every outcome the grid
+  # states — is exactly where it was.
+  test 'hiding the cash moves both sides and no outcome' do
+    sell_half!
+
+    figures = tiles
+
+    assert_equal 5_100.to_d, money(figures, I18n.t('bot.details.stats.total_invested')),
+                 '20,000 in, less the 14,900 standing in cash'
+    assert_equal 15_000.to_d, money(figures, I18n.t('bot.details.stats.portfolio_value'))
+    assert_equal money(figures, I18n.t('tracker.tiles.total_pnl')),
+                 money(figures, I18n.t('bot.dca_index.realised_pnl')) +
+                 money(figures, I18n.t('tracker.tiles.unrealised_pnl'))
+    assert_equal 9_900.to_d, money(figures, I18n.t('tracker.tiles.total_pnl'))
   end
 
   test 'hiding balances takes the whole grid, hint and all' do

--- a/test/jobs/portfolio_snapshot/backfill_job_test.rb
+++ b/test/jobs/portfolio_snapshot/backfill_job_test.rb
@@ -60,6 +60,29 @@ class PortfolioSnapshot::BackfillJobTest < ActiveSupport::TestCase
     assert rows.none?(&:partial)
   end
 
+  # The second reading of the same days, for the page with cash hidden: the day with its cash taken
+  # off both sides — the value it stood in, and the money in that funded it. Both come off the day
+  # already swept, so the two readings can never disagree about what the cash was.
+  test 'every day states the positions inside it as well as the portfolio around them' do
+    seed_ledger
+    seed_prices
+    MarketData.stubs(:get_historical_price_range).returns(Result::Failure.new('offline'))
+    Tracker::LedgerJob.stubs(:perform_later)
+
+    travel_to @day.call(6) do
+      PortfolioSnapshot::BackfillJob.perform_now(@user.id)
+    end
+
+    rows = PortfolioSnapshot.for_user(@user).order(:date).to_a
+    assert_equal [0, 10_000, 10_000, 12_000, 12_600, 7_200].map(&:to_d), rows.map(&:held_value_usd),
+                 'the cash of the day is out: 12k waiting on day 0, 7k again once half the BTC is sold'
+    assert_equal [0, 10_000, 10_000, 11_000, 11_000, 5_000].map(&:to_d), rows.map(&:held_cost_usd),
+                 'the same 12,000 of money in, less that same cash'
+    assert_equal rows.map { |row| row.value_usd - row.invested_usd },
+                 rows.map { |row| row.held_value_usd - row.held_cost_usd },
+                 'the cash comes off both sides, so the P/L between them never moves'
+  end
+
   test 'cash the ledger never saw arrive is money in, on the day it was spent' do
     tx(:buy, day: 1, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 10_000)
     (1..3).each { |n| price('BTC', n, 10_000) }

--- a/test/models/tracker/figures_test.rb
+++ b/test/models/tracker/figures_test.rb
@@ -180,11 +180,16 @@ class Tracker::FiguresTest < ActiveSupport::TestCase
     assert_equal 500.to_d, result.notes.find { |note| note.kind == :figures_disagree }.amount_usd
   end
 
-  # The one operation "Show cash: off" performs: the cash holdings leave the LIST, and nothing else
-  # moves. Every figure is still the whole portfolio — hiding a balance is not an accounting choice
-  # — and doing it here rather than in each template is what keeps the card, the ring, the type
-  # shares and the positions table reading from one list.
-  test 'without_cash drops the cash holdings and leaves every figure where it was' do
+  # ── "Show cash: off" ─────────────────────────────────────────────────────────────────────
+  #
+  # The cash leaves the list, the value it stands in, and the money in that funds it — all three,
+  # so a hidden balance of a dollar moves the figures by a dollar. Everything the account has DONE
+  # — fees, what was banked, what is riding, the total between them — is untouched: a P/L is not a
+  # balance, and cannot be hidden by not looking at one.
+  #
+  # Restating it here rather than in each template is what keeps the tiles, the card, the ring, the
+  # type shares and the positions table reading from one result.
+  test 'without_cash takes the cash off the value and off the money in that funds it' do
     tx(:deposit, day: 1, base_currency: 'USDC', base_amount: 1_000)
     tx(:buy, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 600)
     balance(@btc, 1, 900)
@@ -195,19 +200,45 @@ class Tracker::FiguresTest < ActiveSupport::TestCase
 
     assert_equal %w[BTC USDC], full.holdings.map { |holding| holding.asset.symbol }.sort
     assert_equal(%w[BTC], lean.holdings.map { |holding| holding.asset.symbol })
-    assert_equal full.to_h.except(:holdings), lean.to_h.except(:holdings)
-    assert_equal 1_300.to_d, lean.value, 'the portfolio is still worth what it is worth'
+    assert_equal [1_000.to_d, 1_300.to_d], [full.invested, full.value]
+    assert_equal 600.to_d, lean.invested, 'the 400 waiting is not money at work'
+    assert_equal 900.to_d, lean.value, 'what that portion is worth now'
+    assert_equal full.to_h.slice(:fees, :realised, :unrealised, :total, :notes, :ledger),
+                 lean.to_h.slice(:fees, :realised, :unrealised, :total, :notes, :ledger),
+                 'what the account has done is not a balance to hide'
   end
 
-  # A portfolio with no cash in it is the same portfolio, and a ledger still warming has holdings
-  # to filter before it has any figures at all.
+  # The P/L is the account's whichever way the switch is thrown, so a gain banked and left in cash
+  # moves BOTH figures by that cash and neither of the outcomes. The tile hint stays true with it:
+  # what is stated is still the value less the money in.
+  test 'a gain sitting in cash leaves both sides together' do
+    tx(:deposit, day: 1, base_currency: 'USDC', base_amount: 1_000)
+    tx(:buy, day: 2, base_currency: 'BTC', base_amount: 1, quote_currency: 'USDC', quote_amount: 600)
+    tx(:sell, day: 3, base_currency: 'BTC', base_amount: 0.5, quote_currency: 'USDC', quote_amount: 400)
+    balance(@btc, 0.5, 450)
+    balance(create(:asset, symbol: 'USDC', name: 'USD Coin', external_id: 'usd-coin'), 800, 800)
+
+    full = figures
+    lean = full.without_cash
+
+    assert_equal [1_000.to_d, 1_250.to_d, 250.to_d], [full.invested, full.value, full.total]
+    assert_equal [200.to_d, 450.to_d], [lean.invested, lean.value], 'both sides, less the 800'
+    assert_equal full.total, lean.value - lean.invested
+    assert_equal 100.to_d, lean.realised
+  end
+
+  # A portfolio holding no cash is the same portfolio either way; a ledger still warming has
+  # holdings to filter before it has any figures to restate.
   test 'without_cash is a no-op on a portfolio holding none, and safe while the ledger warms' do
     balance(@btc, 1, 900)
+    full = figures
 
-    assert_equal figures.holdings, figures.without_cash.holdings
+    assert_equal full.to_h, full.without_cash.to_h
 
     warming = Tracker::Figures.for(@user, ledger: nil, balances: AccountBalance.for_user(@user).includes(:asset).to_a)
+
     assert_nil warming.without_cash.invested
+    assert_equal 900.to_d, warming.without_cash.value
     assert_equal(%w[BTC], warming.without_cash.holdings.map { |holding| holding.asset.symbol })
   end
 end


### PR DESCRIPTION
"Show cash: off" scopes the tracker to the invested holdings. It hid the cash from the list and left every figure beside the list stating the whole portfolio, so the page measured the invested holdings against money that was waiting rather than working — and stated a P/L percentage against everything ever deposited.

## The figures

The cash now leaves three places together: the list, the value it stood in, and the money in that funds it.

|  | cash shown | cash hidden |
|---|---|---|
| Total invested | money in | money in, less the cash on hand |
| Portfolio value | everything held | everything held, less that cash |
| Fees, Realised, Unrealised, Total P/L | unchanged | unchanged |

Hiding a balance of a dollar moves both figures by a dollar and no outcome at all. A P/L is not a balance and cannot be hidden by not looking at one, so what the account has *done* reads the same either way, and the Total P/L tile's own formula — portfolio value less total invested — holds in both readings. The percentage beside the curve is then measured against money at work.

Deliberately not the cost basis of what is held: that differs from money in by everything a closed trade won or lost, and no reading of a cash *balance* should turn on that.

## The curve

`portfolio_snapshots` gains `held_value_usd` and `held_cost_usd`: the same day with its cash taken off both sides. Both come off the day the sweep is already valuing, so the two readings can never disagree about what the cash was, and the chart picks a column pair from the switch rather than asking for a second sweep.

Value mode shifts by the day's cash. P/L mode is unchanged by construction — the same amount leaves both terms — which is asserted per swept day: `value − invested == held_value − held_cost`.

## Histories written before this

A day swept before those columns existed cannot answer for them; the cash standing on it is not recoverable from a row that never stated it. Such days are not drawn — a null read as zero would be a lie in the shape of a figure — and one backfill is asked for while any of them falls inside the window the sweep writes (first transaction to yesterday). Today's row is the balance sync's to rewrite, so no page load can ask for a sweep that returns immediately. In practice a tracker opened with cash hidden re-sweeps once and draws on the next load.

## Tests

`bin/rails test` — 4849 runs, 0 failures. New coverage: both readings in `Tracker::Figures`, the tiles under both settings, the curve following the switch, a history from before the columns being swept again rather than drawn wrong, and the per-day invariant in the backfill sweep.
