### PR TITLE
Draw the menu's allocation icon under the tracker's own switch

### DIFF
--- a/app/controllers/tracker_controller.rb
+++ b/app/controllers/tracker_controller.rb
@@ -236,9 +236,7 @@ class TrackerController < ApplicationController
   # Cash and stablecoins are where money waits, not a position anybody picked, so the page is about
   # the active positions unless asked otherwise. Absent means off: the default is the invested
   # portfolio, and `Hide balances` is the separate switch for taking the money off the screen.
-  def show_cash?
-    current_user.tracker_settings&.dig('show_cash').present?
-  end
+  def show_cash? = current_user.show_cash?
   helper_method :show_cash?
 
   # The page only ever reads, so every key that can read serves it — at most one per venue. Memoized

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -61,6 +61,10 @@ module TrackerHelper
   def allocation_icon_arcs(user)
     values = AccountBalance.for_user(user).priced.joins(:asset)
                            .group('assets.symbol', 'assets.color').sum(:usd_value)
+    # Under the tracker's own switch: this is that ring, and a menu keeping a slice the page below
+    # it has dropped is a second opinion about the portfolio, from the one place a reader cannot
+    # hold it against anything. The symbol is already in the group key, so it costs no query.
+    values = values.reject { |(symbol, _), _| Tracker::UnfundedCash.cash?(symbol) } unless user.show_cash?
     icon_arcs(values.sort_by { |_, value| -value }.map { |(_, color), value| [value, color] })
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,11 @@ class User < ApplicationRecord
     save!
   end
 
+  # The tracker's scope switch, on the user rather than in the controller: the menu's allocation
+  # icon is the same ring at 24px and is drawn on every page, not only that one. Absent means off —
+  # the default is the invested portfolio.
+  def show_cash? = tracker_settings&.dig('show_cash').present?
+
   # One per instance: the /bots index reads it for the header and for every tile, and a
   # Solid Cache read is a query.
   def denomination

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -109,6 +109,23 @@ class TrackerHelperTest < ActionView::TestCase
     assert_in_delta 0.75, arc_start(arcs.last), 0.001
   end
 
+  # The icon IS the page's ring at 24px, so it is drawn under the page's own switch. A menu that
+  # keeps a stablecoin slice the page below it has dropped is a second opinion about the portfolio,
+  # from the one place a reader cannot check it against anything.
+  test 'the icon drops the cash the tracker drops, and keeps it when the tracker keeps it' do
+    user = create(:user)
+    icon_balance(user, '#F7931A', 75)
+    AccountBalance.create!(user: user, exchange: (@icon_exchange ||= create(:binance_exchange)),
+                           asset: create(:asset, :usdt, color: '#26A17B'), free: 25, locked: 0,
+                           usd_price: 1, usd_value: 25, synced_at: Time.current)
+
+    assert_equal 1, allocation_icon_arcs(user).size, 'cash is not a position anybody picked'
+
+    user.update!(tracker_settings: { 'show_cash' => true })
+
+    assert_equal 2, allocation_icon_arcs(user).size
+  end
+
   test 'the same coin on two venues is one arc' do
     user = create(:user)
     btc = create(:asset, :bitcoin, color: '#F7931A')


### PR DESCRIPTION
The menu's allocation icon is the tracker's holdings ring at 24px, read off the balances alone. It kept drawing a cash slice after "Show cash" had taken that holding off the page below it, so the two rings disagreed about the same portfolio — and the icon is on every page, where a reader has nothing to check it against.

It now follows the same switch. `show_cash?` moves from the tracker controller onto `User`, since the tracker draws one page under it and the icon is drawn on all of them; the icon's grouped query already carries the symbol, so following the switch costs no extra query.

`bin/rails test` — 4858 runs, 0 failures.
