### PR TITLE
Remember only the chart mode and the record pane across visits

### DIFF
--- a/app/views/bots/orders/_order_filters.html.erb
+++ b/app/views/bots/orders/_order_filters.html.erb
@@ -18,7 +18,7 @@
      data-order-filter-default="<%= default_order_filter(tabs) %>"
      data-action="segmented:change->order-filter#filter">
   <% if show_filters %>
-    <%= render 'shared/segmented', fluid: true, label: t('order_filters.all'), key: 'order-filter',
+    <%= render 'shared/segmented', fluid: true, label: t('order_filters.all'),
                options: tabs.select(&:last).map { |value, label, _|
                  { value: value, label: label, active: order_filter == value }
                } %>

--- a/app/views/tracker/_chart.html.erb
+++ b/app/views/tracker/_chart.html.erb
@@ -61,8 +61,7 @@
             <% ranges = chart_range_options(history) %>
             <% if ranges.any? %>
               <div class="filters" data-action="segmented:change->bot--chart#range">
-                <%= render 'shared/segmented', label: t('tracker.range.all'), key: 'chart-range',
-                           options: ranges %>
+                <%= render 'shared/segmented', label: t('tracker.range.all'), options: ranges %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -21,8 +21,7 @@
         the offset the browser has already clamped, which is the jump itself. %>
     <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if type_filters.any? %>
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'),
-                   key: 'tracker-type', options: type_filters %>
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'), options: type_filters %>
       <% end %>
     </div>
     <div class="tracker-record__table widget widget--table widget--table--tracker">
@@ -67,8 +66,7 @@
         the offset the browser has already clamped, which is the jump itself. %>
     <div class="tracker-record__filters filters" data-action="segmented:change->tracker--record#mark segmented:change->order-filter#filter segmented:change->tracker--record#hold">
       <% if status_filters.any? %>
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'),
-                   key: 'tracker-status', options: status_filters %>
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'), options: status_filters %>
       <% end %>
     </div>
     <div class="tracker-record__table widget widget--table widget--table--tracker tracker-positions">

--- a/app/views/tracker/imports/new.html.erb
+++ b/app/views/tracker/imports/new.html.erb
@@ -14,7 +14,7 @@
           renders buttons, so the hidden field beside it is what the form posts. %>
       <div class="filters" data-controller="form--segmented-field"
            data-action="segmented:change->form--segmented-field#set">
-        <%= render 'shared/segmented', fluid: true, label: t('tracker.import.format'), key: 'import-format',
+        <%= render 'shared/segmented', fluid: true, label: t('tracker.import.format'),
                    options: Import::Run::FORMATS.keys.map { |key|
                      { value: key, label: t("tracker.import.format_#{key}"),
                        active: key == Import::Run::DEFAULT_FORMAT }

--- a/test/controllers/bots/segmented_filters_test.rb
+++ b/test/controllers/bots/segmented_filters_test.rb
@@ -45,8 +45,8 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     assert_select 'button.segmented__option', 3
     assert_select '[data-value="all"].is-on', 1
     assert_select 'button[data-value="other"]', 1
-    # The log tab, on the other hand, is a way of reading and is remembered.
-    assert_select '.segmented[data-segmented-key="order-filter"]', 1
+    # Not remembered either: the log opens on its default tab every visit.
+    assert_select '.segmented[data-segmented-key]', 0
   end
 
   test 'a bot with only one category of orders shows no filter at all' do

--- a/test/integration/tracker_history_test.rb
+++ b/test/integration/tracker_history_test.rb
@@ -55,8 +55,9 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
     assert_select '.widget--chart__head > .widget--chart__modes', 1
     assert_select '.widget--chart__ranges', 0
     assert_select '.widget--chart__modes .filters[data-action*="bot--chart#range"] > .segmented .segmented__option[data-value="30"]'
+    # The range opens on the whole history every visit: only the mode is remembered.
     assert_select '.widget--chart__modes .filters[data-action*="bot--chart#range"] > ' \
-                  '.segmented[data-segmented-key="chart-range"] .segmented__option.is-on[data-value="all"]'
+                  '.segmented:not([data-segmented-key]) .segmented__option.is-on[data-value="all"]'
     assert_select '.widget__placeholder', false
   end
 

--- a/test/integration/tracker_import_test.rb
+++ b/test/integration/tracker_import_test.rb
@@ -46,9 +46,8 @@ class TrackerImportTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".segmented__option[data-value='deltabadger'].is-on"
     assert_select ".segmented__option[data-value='binance']"
-    # Whoever imports from one venue imports from it again: the format is remembered, and the
-    # remembered pick moves the hidden field with it.
-    assert_select ".segmented[data-segmented-key='import-format']", 1
+    # Not remembered: the dialog opens on the default every time, and the hidden field with it.
+    assert_select '.segmented[data-segmented-key]', 0
     # The buttons post nothing on their own; the hidden field is what carries the choice.
     assert_select "input[name=format][value='deltabadger']"
     # Everything else is derived, so nothing else is asked.

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -179,10 +179,10 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
 
     assert_select '.tracker-record .filters > .segmented .segmented__option[data-value="tx"]'
     assert_select '.tracker-record .filters > .segmented .segmented__option[data-value="pos"]'
-    # Every one of these three is a way of reading the page, so every one of them is remembered.
+    # The pane is a way of reading the page and is remembered; the filters inside it are not —
+    # a reader coming back gets the whole record, not the slice they last narrowed it to.
     assert_select '.tracker-record__switch > .segmented[data-segmented-key="tracker-record"]', 1
-    assert_select '.tracker-record .segmented[data-segmented-key="tracker-type"]', 1
-    assert_select '.tracker-record .segmented[data-segmented-key="tracker-status"]', 1
+    assert_select '.tracker-record__filters .segmented[data-segmented-key]', 0
     assert_select '.tracker-record [data-controller~="order-filter"]', 2
     # The types this account actually holds, in the ledger's own order — not a fixed five. A
     # transfer option appears only once a linked pair is on the page.


### PR DESCRIPTION
Segmented controls opt into memory by naming a `key`, and every control that could take one did. Only two of them are a way of reading the page rather than a narrowing of one visit:

- **P/L / Value** on the chart — one `chart-mode` key shared by the bot and tracker charts, so it is one preference
- **Positions / Transactions** on the tracker record — `tracker-record`

These keep their memory. The rest now open on their default every visit:

- chart range
- type and status filters inside the record panes
- bot log tabs (the `order-filter` controller still carries the chosen tab across the broadcast re-render on its own, so nothing changes mid-visit)
- import format

A control without a key never reads storage, so entries users already have saved under the dropped keys are inert and need no cleanup.

Tests asserting the dropped keys now assert their absence.
