### PR TITLE
Measure the segmented control expanded, not from inside its fold

### DIFF
--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -314,8 +314,10 @@
     background: var(--sky)
 
 // The control collapses when its options outgrow the room its PARENT gives it, so that parent
-// needs a width of its own. One that shrink-wraps to the collapsed trigger would report the
-// trigger's width as the room available and never let the control open back up.
+// needs a width of its own — a shrink-wrapped one only ever reports the width already in use.
+// Greedy on purpose, and safe to be: the controller measures itself EXPANDED, which squeezes a
+// stretched neighbour back to what it needs, so taking the slack here is not taking it from
+// whatever else shares the row.
 .filters:has(> .segmented)
     flex: 1
     min-width: 0

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -50,7 +50,9 @@ export default class extends Controller {
     this.optionTargets.forEach((option) => this.observer.observe(option));
     // The room is the PARENT's, never the control's own: once collapsed the control is only as
     // wide as its trigger, and a control measuring itself would never learn that it fits again.
-    this.observer.observe(this.element.parentElement);
+    // Its SIBLINGS too: a row can run out of room without the row changing size, when whatever
+    // shares it grows instead — and a control watching only the parent never hears about that.
+    [this.element.parentElement, ...this.element.parentElement.children].forEach((box) => this.observer.observe(box));
 
     // Last, so the click it may fire lands on a control that is wired and measured.
     this.#restore();
@@ -213,18 +215,25 @@ export default class extends Controller {
   }
 
   #layout() {
-    // Only an expanded control can be asked how wide it wants to be, so the answer is kept.
-    if (!this.#collapsed) this.natural = this.element.getBoundingClientRect().width;
-    // Rounded, because clientWidth is: a parent that shrink-wraps this control reports exactly
-    // its width, and a fraction of a pixel between the two is not a reason to fold anything.
-    const collapse = Math.round(this.natural) > this.#room();
+    // Measured EXPANDED, always — the fold cannot be judged from inside it. Folding shrinks this
+    // control and anything elastic beside it grows into the space it gave up, so a collapsed
+    // control asking its parent for room is asking about a row its own fold rearranged: it would
+    // never learn that it fits again. Unfolding for the measurement puts the row back the way the
+    // answer has to be read, and an EXPANDED neighbour that stretched is squeezed back to what it
+    // actually needs — which is the whole question. Class off and on inside one callback is a
+    // single forced layout and no paint, so nothing is ever seen mid-flip.
+    const was = this.#collapsed;
+    this.element.classList.remove("segmented--collapsed");
+    // Half a pixel of slack rather than rounding the control up to meet it: clientWidth is a whole
+    // number, so a parent that shrink-wraps this control reports a hair less than it measures, and
+    // a fraction of a pixel is not a reason to fold anything. Rounding the other operand instead
+    // overshoots a room that is itself fractional, which is a fold with the row standing empty.
+    const collapse = this.element.getBoundingClientRect().width > this.#room() + 0.5;
+    this.element.classList.toggle("segmented--collapsed", collapse);
 
     // Only on the way in or out: opening the menu resizes the options, which lands back here,
     // and a close on every pass would shut the menu on the very click that opened it.
-    if (this.#collapsed !== collapse) {
-      this.element.classList.toggle("segmented--collapsed", collapse);
-      this.#close();
-    }
+    if (was !== collapse) this.#close();
     this.#moveThumb();
   }
 


### PR DESCRIPTION
The segmented control folds into a dropdown when its options outgrow the room its parent gives it — measured, because the labels are translated and the option count depends on the data, so the width at which it stops fitting is not a number that can be written into a breakpoint.

The measurement was circular. It asked the parent for room in whatever state the control had already reached, and folding changes that state: the control shrinks, anything elastic sharing the row grows into the space it gave up, and the room shrinks with it. Two consequences.

**It folded with the row standing empty.** On the tracker's chart header the mode switch (P/L · Value) shares a row with the date range, whose wrapper is `flex: 1` and takes every spare pixel. The room reported back was therefore the switch's own width, near enough — and `Math.round` on the control's width, there to leave slack against an integer `clientWidth`, crossed it:

```
.widget--chart__modes  clientWidth 772
  .segmented (P/L · Value)      118.070
  .filters   (date range)       646.133   flex: 1
room = 772 − 646.133 − 8 = 117.867   →   Math.round(118.070) = 118 > 117.867   →   fold
```

A fifth of a pixel decided it, with 646px free beside the control.

**It could not unfold.** Once folded the switch was ~95px wide and the range had grown to fill the rest, so the room never came back — at any window width.

## The fix

`#layout` unfolds before it measures and restores the class in the same callback: one forced layout, no paint, nothing seen mid-flip. Read expanded, a stretched neighbour is squeezed back to what it actually needs, which is the question being asked. The `natural` cache goes with it — it only existed because a folded control could not measure itself.

The slack moves off the operand and onto the comparison (`> room + 0.5`), so a fractional room can no longer be crossed by rounding.

Siblings are observed alongside the parent, because a row can run out of room without changing size, when whatever shares it grows instead. That path never re-ran layout: a 118px control sat expanded against 60px of room.

## Verification

Measured in the browser on the tracker chart header, comparing both rules against the same DOM:

| state | control | room | before | after |
|---|---|---|---|---|
| at rest, 646px free | 118.070 | 117.867 | fold | keep |
| genuinely squeezed | 118.070 | 60.0 | fold | fold |
| room returns, asked from inside the fold | — | 117.867 | fold | keep |

4858 runs, 18330 assertions, 0 failures.
