### PR TITLE
Write the denomination by its symbol and a transaction currency by its code

### DIFF
--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -332,6 +332,8 @@ $stack-open: 0.2s ease-out
                 vertical-align: middle
             small:first-child
                 margin-right: 0.25rem
+                position: relative
+                top: -0.0625rem
         td, th
             text-align: right
             border: none

--- a/app/helpers/bot_helper.rb
+++ b/app/helpers/bot_helper.rb
@@ -153,6 +153,15 @@ module BotHelper
   # 0.00 sitting in the same weight as a real balance reads as a number worth comparing, and on a
   # holdings table most of them are not — an average price nobody paid, a value too small to have
   # one. Dimmed rather than blanked: the row still has to state what it holds.
+  # A figure with the currency it is actually in beside it, the CODE in <small>: USDT is what
+  # the bot spends, and a code is how a transaction currency is written. The symbol is reserved
+  # for the reader's own chosen denomination (Denomination#format), which this is not.
+  def quoted_figure(figure, quote)
+    return figure if figure.blank? || quote.blank?
+
+    safe_join([figure, ' ', tag.small(quote)])
+  end
+
   def money_figure(value, precision: 2, **options)
     formatted = number_with_precision(value || 0, precision: precision, delimiter: ',', **options)
     return formatted unless value.to_d.round(precision).zero?

--- a/app/helpers/numbers_helper.rb
+++ b/app/helpers/numbers_helper.rb
@@ -8,7 +8,8 @@ module NumbersHelper
 
     abs_value = value.abs
     if abs_value < 1
-      value.round(max_decimals).to_s.sub(/\.?0+$/, '')
+      # Trailing zeros go; a bare zero is not a trailing zero, and stripping it left an empty tile.
+      value.round(max_decimals).to_s.sub(/\.?0+$/, '').presence || '0'
     else
       format('%.2f', value)
     end

--- a/app/javascript/controllers/bot/chart_controller.js
+++ b/app/javascript/controllers/bot/chart_controller.js
@@ -71,6 +71,10 @@ export default class extends Controller {
     series: Array,
     labels: Array,
     quote: String,
+    // Set only where the money is the reader's own denomination — the tracker — and then the
+    // headline carries that symbol, on the side that currency puts it, instead of the quote code.
+    unit: String,
+    suffixed: Boolean,
     decimals: Number,
     bot: Number,
     pnl: Array,
@@ -401,15 +405,35 @@ export default class extends Controller {
     });
   }
 
-  // `signed` off for a PRICE: the headline is a profit and wants its sign, but "+84,000 USDT"
-  // as the price of a fill reads as a gain.
-  #money(value, { signed = true } = {}) {
+  // Money to the cent above a unit and to the quote's own precision below it — a BTC-quoted
+  // bot's profit is a fraction of a coin, and "0.00 BTC" would say there was none.
+  #number(value, { signed = true } = {}) {
     const decimals = Math.abs(value) >= 1 ? 2 : this.decimalsValue;
-    return `${value.toLocaleString(this.#locale, {
+    return value.toLocaleString(this.#locale, {
       minimumFractionDigits: Math.min(2, decimals),
       maximumFractionDigits: decimals,
       signDisplay: signed ? "exceptZero" : "auto",
-    })} ${this.quoteValue}`;
+    });
+  }
+
+  // The text form, for a price on the date line or a tooltip. `signed` off for a PRICE: the
+  // headline is a profit and wants its sign, but "+84,000 USDT" as the price of a fill reads as
+  // a gain.
+  #money(value, { signed = true } = {}) {
+    return `${this.#number(value, { signed })} ${this.quoteValue}`;
+  }
+
+  // The headline: sign, then the unit in <small> — before the figure, or after it where the
+  // currency is written that way. A bot's chart names its quote by its code, trailing: USDT is the
+  // currency the money was actually in, and a code is how that is said; the symbol is the
+  // tracker's, for the reader's own denomination.
+  #headline(value) {
+    const unit = document.createElement("small");
+    unit.textContent = this.hasUnitValue ? this.unitValue : this.quoteValue;
+    const suffixed = this.hasUnitValue ? this.suffixedValue : true;
+    if (suffixed) return [`${this.#number(value)} `, unit];
+    const sign = value > 0 ? "+" : value < 0 ? "-" : "";
+    return [sign, unit, this.#number(Math.abs(value), { signed: false })];
   }
 
   #percent(fraction) {
@@ -454,7 +478,7 @@ export default class extends Controller {
       .join(" · ");
     // Absent while balances are hidden: the view drops the element rather than hiding it, and
     // Stimulus raises on a missing target.
-    if (this.hasPnlTarget) this.pnlTarget.textContent = this.#money(pnl);
+    if (this.hasPnlTarget) this.pnlTarget.replaceChildren(...this.#headline(pnl));
     // Nothing invested is not "0.00%", it is a percentage of nothing — say so rather than print a
     // return the reader could take for a flat one.
     this.percentTarget.textContent = spent > 0 ? this.#percent(pnl / spent) : "—";

--- a/app/models/denomination.rb
+++ b/app/models/denomination.rb
@@ -50,6 +50,9 @@ class Denomination
   # every one of two hundred rows.
   def unit = UNITS.fetch(currency, currency)
 
+  # Whether the symbol trails the figure, for a client that lays the figure out itself.
+  def suffixed? = SUFFIXED.include?(currency)
+
   def convert(usd_amount)
     usd_amount && (usd_amount.to_d * rate)
   end
@@ -69,24 +72,29 @@ class Denomination
   # The unit rides in <small>, as it does beside a ticker in the tables: the figure is what the
   # column is read for, the symbol only says which unit it is in.
   def format(usd_amount, precision: 2)
-    formatted(usd_amount, ActionController::Base.helpers.tag.small(unit), precision)&.html_safe
+    format_converted(convert(usd_amount), precision: precision)
+  end
+
+  # The same layout for a figure ALREADY in this currency — one carried across at the rate of its
+  # own day, which `format` would move again at today's.
+  def format_converted(amount, precision: 2)
+    formatted(amount, ActionController::Base.helpers.tag.small(unit), precision)&.html_safe
   end
 
   # The same figure with no markup, for somewhere it is not drawn — an aria-label, a sentence —
   # where a tag is spelled out instead of rendered.
   def format_plain(usd_amount, precision: 2)
-    formatted(usd_amount, unit, precision)
+    formatted(convert(usd_amount), unit, precision)
   end
 
   private
 
-  def formatted(usd_amount, unit, precision)
-    return if usd_amount.nil?
+  def formatted(amount, unit, precision)
+    return if amount.nil?
 
-    layout = SUFFIXED.include?(currency) ? '%n %u' : '%u%n'
+    layout = suffixed? ? '%n %u' : '%u%n'
     ActiveSupport::NumberHelper.number_to_currency(
-      convert(usd_amount), unit: unit, format: layout,
-                           negative_format: "-#{layout}", precision: precision
+      amount, unit: unit, format: layout, negative_format: "-#{layout}", precision: precision
     )
   end
 end

--- a/app/views/bots/_assets_table.html.erb
+++ b/app/views/bots/_assets_table.html.erb
@@ -1,11 +1,13 @@
-<%# locals: (rows:, body_id: nil, loading: false, actions: false, hide_money: false) %>
+<%# locals: (rows:, body_id: nil, loading: false, actions: false, hide_money: false, quote: nil) %>
 <%# The holdings table for every bot type — single, dual, index, and the coins that left an index.
-    Rows arrive pre-formatted: only the bot knows its own decimals.
+    Rows arrive pre-formatted: only the bot knows its own decimals. `quote` is the currency the
+    price and the value are in, written beside each figure.
 
     hide_money drops the two columns that state a balance — how much is held and what it is worth.
     The symbol, its average price and its P/L stay: a price is a fact about the venue and a
     percentage is not a balance, and without them the row would say nothing at all. %>
 <% hide_money = local_assigns.fetch(:hide_money, false) %>
+<% quote = local_assigns[:quote] %>
 <% columns = (hide_money ? 4 : 6) + (actions ? 1 : 0) %>
 <table class="table">
   <thead>
@@ -30,13 +32,13 @@
         <td class="table__logo"><%= render 'assets/logo', image_url: row[:asset]&.image_url, color: row[:asset]&.color %></td>
         <td scope="row"><%= row[:symbol] %></td>
         <% unless hide_money %><td><%= row[:amount] %></td><% end %>
-        <td><%= row[:avg_price] || no_value %></td>
+        <td><%= row[:avg_price] ? quoted_figure(row[:avg_price], quote) : no_value %></td>
         <% unless hide_money %>
           <td>
             <% if loading %>
               <div class="loader--small" style="position: unset; float:right"></div>
             <% else %>
-              <%= row[:value] || no_value %>
+              <%= row[:value] ? quoted_figure(row[:value], quote) : no_value %>
             <% end %>
           </td>
         <% end %>

--- a/app/views/bots/_global_pnl.html.erb
+++ b/app/views/bots/_global_pnl.html.erb
@@ -17,7 +17,7 @@
       # "1,200,200" is one number written two ways.
       pnl_spark_delimiter_value: I18n.t('number.currency.format.delimiter',
                                         default: I18n.t('number.format.delimiter', default: ',')),
-      pnl_spark_suffixed_value: Denomination::SUFFIXED.include?(denomination.currency)
+      pnl_spark_suffixed_value: denomination.suffixed?
     } : {} do %>
   <% if global_pnl.present? %>
     <% if spark %>

--- a/app/views/bots/composition/_assets_table.html.erb
+++ b/app/views/bots/composition/_assets_table.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (values:, logo_assets:, body_id: nil, bot: nil, sellable: false, hide_money: false) %>
+<%# locals: (values:, logo_assets:, body_id: nil, bot: nil, sellable: false, hide_money: false, quote: nil) %>
 <%# Composition holdings come from the metrics hash, not from the bot's own columns, so they need
     mapping onto the shared table's rows. Only the exited table passes sellable, because a current
     member is not for sale. %>
 <%= render 'bots/assets_table', body_id: body_id, actions: sellable,
-           hide_money: local_assigns.fetch(:hide_money, false),
+           hide_money: local_assigns.fetch(:hide_money, false), quote: local_assigns[:quote],
            rows: values.map { |symbol, data|
       { asset: logo_assets[symbol]&.base_asset, symbol: symbol,
         amount: number_with_precision(data[:amount] || 0, precision: 6, strip_insignificant_zeros: true),

--- a/app/views/bots/composition/_metrics.html.erb
+++ b/app/views/bots/composition/_metrics.html.erb
@@ -1,6 +1,7 @@
 <% exited = bot.exited_holdings(metrics) %>
 <% realised = metrics[:realised_pnl].to_d %>
 <% hide_money = hide_balances?(bot) %>
+<% quote = bot.quote_asset&.symbol %>
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
   <% if metrics[:prices_stale] %>
     <p class="status-button__hint" role="status">
@@ -20,7 +21,7 @@
           <% if loading %>
             <span class="loading-placeholder">...</span>
           <% else %>
-            <%= money_figure(metrics[:total_quote_amount_invested]) %>
+            <%= quoted_figure(money_figure(metrics[:total_quote_amount_invested]), quote) %>
           <% end %>
         </div>
       </div>
@@ -30,7 +31,7 @@
           <% if loading %>
             <span class="loading-placeholder">...</span>
           <% else %>
-            <%= money_figure(metrics[:total_amount_value_in_quote]) %>
+            <%= quoted_figure(money_figure(metrics[:total_amount_value_in_quote]), quote) %>
           <% end %>
         </div>
       </div>
@@ -53,7 +54,7 @@
             <% if loading %>
               <span class="loading-placeholder">...</span>
             <% else %>
-              <%= realised.negative? ? '' : '+' %><%= number_with_precision(realised, precision: 2, delimiter: ',') %>
+              <%= realised.negative? ? '' : '+' %><%= quoted_figure(number_with_precision(realised, precision: 2, delimiter: ','), quote) %>
             <% end %>
           </div>
           <%= tag.div t('bot.dca_index.realised_pnl_note'), class: 'tooltip tooltip--note' %>
@@ -86,7 +87,7 @@
     <% if composition_values.present? %>
       <div id="assets_metrics_table" class="widget widget--table">
         <%= render 'bots/composition/assets_table', values: composition_values, logo_assets: logo_assets,
-                   body_id: 'assets_metrics_list', hide_money: hide_money %>
+                   body_id: 'assets_metrics_list', hide_money: hide_money, quote: quote %>
       </div>
     <% end %>
   <% end %>
@@ -116,7 +117,7 @@
         <%= render 'bots/composition/assets_table',
                    values: exited.index_by { |holding| holding[:symbol] },
                    logo_assets: logo_assets, body_id: 'exited_metrics_list', bot: bot,
-                   hide_money: hide_money,
+                   hide_money: hide_money, quote: quote,
                    sellable: !bot.liquidation_ambiguous? && !bot.archived? && !bot.deleted? %>
       <% end %>
     </div>

--- a/app/views/bots/dca_dual_assets/_metrics.html.erb
+++ b/app/views/bots/dca_dual_assets/_metrics.html.erb
@@ -1,4 +1,5 @@
 <% hide_money = hide_balances?(bot) %>
+<% quote = bot.quote_asset&.symbol %>
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
   <% if metrics[:prices_stale] %>
     <p class="status-button__hint" role="status">
@@ -11,12 +12,12 @@
     <div class="widget data-grid data-grid--two-columns">
       <%= render partial: "bots/metrics_item", locals: {
         label: t('data_labels.invested'),
-        value: format_value(metrics[:total_quote_amount_invested], max_decimals: bot.decimals[:quote] || 8),
+        value: quoted_figure(format_value(metrics[:total_quote_amount_invested], max_decimals: bot.decimals[:quote] || 8), quote),
         loading: false
       } %>
       <%= render partial: "bots/metrics_item", locals: {
         label: t('data_labels.portfolio_value'),
-        value: format_value(metrics[:total_amount_value_in_quote], max_decimals: bot.decimals[:quote] || 8),
+        value: quoted_figure(format_value(metrics[:total_amount_value_in_quote], max_decimals: bot.decimals[:quote] || 8), quote),
         loading: loading
       } %>
     </div>
@@ -39,6 +40,7 @@
               []
             end %>
   <div id="assets_metrics_table" class="widget widget--table">
-    <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money %>
+    <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money,
+               quote: quote %>
   </div>
 </div>

--- a/app/views/bots/dca_single_assets/_metrics.html.erb
+++ b/app/views/bots/dca_single_assets/_metrics.html.erb
@@ -1,4 +1,5 @@
 <% hide_money = hide_balances?(bot) %>
+<% quote = bot.quote_asset&.symbol %>
 <div id="metrics" style="display: flex; flex-direction: column; gap: 1rem;">
   <% if metrics[:prices_stale] %>
     <p class="status-button__hint" role="status">
@@ -11,12 +12,12 @@
     <div class="widget data-grid data-grid--two-columns">
       <%= render partial: "bots/metrics_item", locals: {
         label: t('data_labels.invested'),
-        value: format_value(metrics[:total_quote_amount_invested], max_decimals: bot.decimals[:quote] || 8),
+        value: quoted_figure(format_value(metrics[:total_quote_amount_invested], max_decimals: bot.decimals[:quote] || 8), quote),
         loading: false
       } %>
       <%= render partial: "bots/metrics_item", locals: {
         label: t('data_labels.portfolio_value'),
-        value: format_value(metrics[:total_amount_value_in_quote], max_decimals: bot.decimals[:quote] || 8),
+        value: quoted_figure(format_value(metrics[:total_amount_value_in_quote], max_decimals: bot.decimals[:quote] || 8), quote),
         loading: loading
       } %>
     </div>
@@ -33,6 +34,7 @@
               []
             end %>
   <div id="assets_metrics_table" class="widget widget--table">
-    <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money %>
+    <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money,
+               quote: quote %>
   </div>
 </div>

--- a/app/views/bots/liquidations/new.html.erb
+++ b/app/views/bots/liquidations/new.html.erb
@@ -21,7 +21,7 @@
           <%= render 'bots/composition/assets_table',
                      values: { @holding[:symbol] => @holding },
                      logo_assets: { @holding[:symbol] => @holding[:ticker] },
-                     body_id: 'liquidation_confirm_list',
+                     body_id: 'liquidation_confirm_list', quote: @bot.quote_asset&.symbol,
                      hide_money: hide_balances?(@bot) %>
         </div>
       <% end %>

--- a/app/views/tracker/_chart.html.erb
+++ b/app/views/tracker/_chart.html.erb
@@ -36,6 +36,11 @@
       # tracker's pin out of every bot's.
       bot__chart_bot_value: 0,
       bot__chart_quote_value: @denomination.currency,
+      # The headline is the reader's own currency, so it is written the way the tiles beside it
+      # are: the symbol in <small>, on the side that currency puts it. A bot's chart passes
+      # neither and keeps its quote's code as text — USDT is what that money actually was.
+      bot__chart_unit_value: @denomination.unit,
+      bot__chart_suffixed_value: @denomination.suffixed?,
       bot__chart_decimals_value: 2,
       # Written WITHOUT a zone on purpose: `new Date('2026-08-21')` is UTC midnight and prints as the
       # 20th anywhere west of it, while a date-TIME with no offset parses as local midnight. A daily

--- a/app/views/tracker/_transaction_row.html.erb
+++ b/app/views/tracker/_transaction_row.html.erb
@@ -36,16 +36,19 @@
     <% if source == :exchange %>
       <%= price %>
     <% elsif source == :cash %>
-      <%= price ? tracker_figure(price, denomination.currency) : no_value %>
+      <%= price ? denomination.format_converted(price) : no_value %>
     <% else %>
       <%= form_with url: price_tracker_transaction_path(at), method: :patch,
                     data: { controller: 'form--submit' } do %>
+        <%# The reader's own currency, so its symbol — on the side that currency writes it. %>
+        <% unit = tag.small(denomination.unit) %>
+        <%= unit unless denomination.suffixed? %>
         <%= number_field_tag :price, (price if source == :stated), step: :any, min: 0,
                              placeholder: (price.to_s if source == :ours) || '—',
                              title: t("tracker.price_source.#{source || 'none'}"),
                              class: 'tracker-row__price__input',
                              data: { action: 'change->form--submit#submit' } %>
-        <small><%= denomination.currency %></small>
+        <%= unit if denomination.suffixed? %>
         <%# The problem is the empty box, and this is the one place it can be fixed — so this is
             where it is explained, and only here. %>
         <% if source.nil? %>

--- a/test/controllers/bots/assets_table_test.rb
+++ b/test/controllers/bots/assets_table_test.rb
@@ -49,6 +49,36 @@ class Bots::AssetsTableTest < ActionDispatch::IntegrationTest
     assert_select '#assets_metrics_table tbody tr[data-symbol="AAA"]', 1
   end
 
+  # A bot's money is in the currency it trades in, and a code is how a transaction currency is
+  # written — the symbol is reserved for the reader's own denomination. The chart's headline
+  # already says USDT; the tiles and the table under it said nothing.
+  test 'invested, value and prices carry the quote currency code beside the figure' do
+    btc = create(:asset, :bitcoin)
+    usd = create(:asset, :usd)
+    binance = create(:binance_exchange)
+    index = create(:dca_index, user: @user, quote_asset: usd)
+    warm_composition_prices(index)
+
+    get bot_path(id: index.id)
+
+    tiles = css_select('#metrics .data-grid__item__value').map { |node| node.text.gsub(/\s+/, ' ').strip }
+    assert_equal 2, tiles.size
+    tiles.each { |tile| assert_match(/\A[\d,.]+ USD\z/, tile) }
+    cells = css_select('#assets_metrics_table tbody tr[data-symbol="AAA"] td').map { |node| node.text.gsub(/\s+/, ' ').strip }
+    assert_equal '100.00 USD', cells[3], 'average price'
+    assert_equal '110.00 USD', cells[4], 'value'
+    assert_select '#assets_metrics_table tbody tr[data-symbol="AAA"] td small', text: 'USD', count: 2
+
+    single = create(:dca_single_asset, user: @user, exchange: binance, base_asset: btc, quote_asset: usd)
+
+    get bot_path(id: single.id)
+
+    # Portfolio value is a spinner on a first load; invested is not.
+    tiles = css_select('#metrics .data-grid__item__value').reject { |tile| tile.css('.loader--small').any? }
+    assert_equal 1, tiles.size
+    assert_equal '0 USD', tiles.first.text.gsub(/\s+/, ' ').strip
+  end
+
   test 'a bot with nothing invested still shows the table, with a placeholder row' do
     bot = create(:dca_single_asset, user: @user)
 

--- a/test/controllers/bots/liquidations_controller_test.rb
+++ b/test/controllers/bots/liquidations_controller_test.rb
@@ -96,6 +96,8 @@ class Bots::LiquidationsControllerTest < ActionDispatch::IntegrationTest
     # The bot page's own table, widget shell included — everything that spaces and aligns a row
     # hangs off .widget--table, so a bare <table> here renders unstyled.
     assert_select '.modal .widget--table #liquidation_confirm_list tr', 1
+    # In the bot's own currency, named the way the holdings row names it.
+    assert_select '#liquidation_confirm_list td small', text: @bot.quote_asset.symbol, count: 2
     assert_select '.modal', /CCC/
     # The other quitter is not part of this sale and must not appear in the list.
     assert_select '.modal', { text: /DDD/, count: 0 }

--- a/test/integration/tracker_history_test.rb
+++ b/test/integration/tracker_history_test.rb
@@ -42,6 +42,10 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
     assert_equal [1_000.0, 2_000.0, 3_000.0], JSON.parse(node['data-bot--chart-pnl-value'])
     assert_equal '0', node['data-bot--chart-bot-value'], 'not a bot — a stable id for the asset pin'
     assert_equal 'USD', node['data-bot--chart-quote-value']
+    # The headline is the reader's own currency, written the way the tiles write it: the
+    # symbol in <small>, on the side that currency puts it.
+    assert_equal '$', node['data-bot--chart-unit-value']
+    assert_equal 'false', node['data-bot--chart-suffixed-value']
     assert_equal 'false', node['data-bot--chart-pnl-only-value']
     assert_select '.widget--chart__plot canvas[data-bot--chart-target="analyzerChart"]'
     # P/L first and P/L on: the tracker chart opens on the same mode a bot's does, under the same
@@ -87,6 +91,8 @@ class TrackerHistoryTest < ActionDispatch::IntegrationTest
     series = JSON.parse(chart_node['data-bot--chart-series-value'])
     assert_equal [124_000.0, 128_000.0, 132_000.0], series[0]
     assert_equal 'PLN', chart_node['data-bot--chart-quote-value']
+    assert_equal 'zł', chart_node['data-bot--chart-unit-value']
+    assert_equal 'true', chart_node['data-bot--chart-suffixed-value']
   end
 
   test 'missing coverage back to the first transaction enqueues the backfill once; the plot spins meanwhile' do

--- a/test/integration/tracker_manual_value_test.rb
+++ b/test/integration/tracker_manual_value_test.rb
@@ -94,7 +94,8 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     assert_includes cell['class'], 'tracker-row__price--ours'
     assert_equal '30000.0', input_for(rebate)['placeholder'], 'our price for that day, per unit'
     assert_nil input_for(rebate)['value'], 'a default is not a statement'
-    assert_includes cell.text, 'USD', 'the page is shown in dollars'
+    assert_equal '$', cell.css('small').text, "the reader's own currency, by its symbol"
+    assert_operator cell.to_html.index('<small>'), :<, cell.to_html.index('tracker-row__price__input'), 'a dollar sign goes first'
     assert_select "##{ActionView::RecordIdentifier.dom_id(rebate)} .tracker-row__info", false, 'priced: nothing to point out'
     assert_equal '15,000.00', value_cell(rebate).text.strip, 'half a coin at 30,000'
     assert_empty value_cell(rebate).css('input'), 'a value is worked out, never typed'
@@ -144,10 +145,10 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     deposited = unquoted(:deposit, 'EUR', 200)
     parked = unquoted(:deposit, 'USDT', 150)
 
-    assert_equal '1.25 USD', price_cell(deposited).text.strip, 'what one euro bought that day'
+    assert_equal '$1.25', price_cell(deposited).text.strip, 'what one euro bought that day'
     assert_empty price_cell(deposited).css('input'), 'money has no price to state'
     assert_equal '250.00', value_cell(deposited).text.strip, '200 EUR on a day the euro bought 1.25 dollars'
-    assert_equal '1.00 USD', price_cell(parked).text.strip, 'a stablecoin at par'
+    assert_equal '$1.00', price_cell(parked).text.strip, 'a stablecoin at par'
     assert_equal '150.00', value_cell(parked).text.strip
   end
 
@@ -214,7 +215,7 @@ class TrackerManualValueTest < ActionDispatch::IntegrationTest
     rebate = unquoted(:airdrop, 'BTC', 0.5)
 
     assert_equal '15000.0', input_for(rebate)['placeholder'], '30,000 dollars is 15,000 euro'
-    assert_includes price_cell(rebate).text, 'EUR'
+    assert_equal '€', price_cell(rebate).css('small').text
     assert_equal '7,500.00', value_cell(rebate).text.strip, 'half a coin at 15,000'
 
     patch price_tracker_transaction_path(id: rebate.id), params: { price: '100' }

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -373,7 +373,8 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     assert_select '.data-grid', false
     assert_select '.tracker-holdings__value', false
     assert_select '.tracker-holdings__pct', text: '75.0%'
-    assert_select '.tracker-record tr.tracker-row td', text: /\$/, count: 0
+    # The price stays — a market level, not a balance — and it is in the reader's currency.
+    assert_select '.tracker-record tr.tracker-row td:not(.tracker-row__price)', text: /\$/, count: 0
     assert_select '.tracker-positions td', text: /\$/, count: 0
     assert_select '.tracker-positions td.text-success', text: /\+25\.0%/, count: 1
     # The figures this page would otherwise print, in every form they could take.

--- a/test/models/denomination_test.rb
+++ b/test/models/denomination_test.rb
@@ -35,6 +35,23 @@ class DenominationTest < ActiveSupport::TestCase
     assert_equal '<small>€</small>22.50', Denomination.for('EUR').format(25)
   end
 
+  # A row's price is converted at the rate of ITS OWN day, before it reaches here; `format`
+  # would convert it again at today's.
+  test 'a figure already in the display currency is laid out the same, unconverted' do
+    stub_rate('PLN', 4)
+
+    assert_equal '95.00 <small>zł</small>', Denomination.for('PLN').format_converted(95)
+    assert_equal '<small>$</small>1.25', Denomination.for('USD').format_converted(1.25)
+    assert_nil Denomination.for('USD').format_converted(nil)
+  end
+
+  test 'says which side of the figure its symbol goes' do
+    stub_rate('PLN', 4)
+
+    assert_predicate Denomination.for('PLN'), :suffixed?
+    assert_not_predicate Denomination.for('USD'), :suffixed?
+  end
+
   test 'a loss keeps its minus sign in either layout' do
     stub_rate('PLN', 4)
 


### PR DESCRIPTION
## One rule for the unit beside a figure

- Money in the reader's chosen **denomination** carries its **symbol** — `$`, `€`, `zł` — placed on the side that currency writes it (`$742.32`, `95.00 zł`).
- Money in the currency a transaction **actually happened in** carries that currency's **code** — `USDT`, `USD`, `PLN`.

Either way the unit sits in `<small>` beside the figure, so the number is what the eye lands on.

## What changes

**Tracker**
- The chart headline read `-242.65 USD` next to tiles reading `-$242.64`. It now reads `-$242.65` with the symbol in `<small>`, like the tiles (`data-bot--chart-unit-value` / `-suffixed-value`; a bot's chart passes neither and keeps its quote code).
- Cash rows in the record (a deposit's rate for the day) and the typed-price box use the symbol, on the correct side of the figure.

**Bot page**
- Invested, Portfolio Value and Realised P/L tiles, and the Avg. Price / Value columns of the holdings table, name the bot's quote currency beside each figure: `2,600.00 USDT`. They showed a bare number under a chart headline that already said `USDT`. Single, dual, index and multi-asset bots all go through the shared table, and the Sell confirmation renders the same table.
- The chart headline wraps its unit in `<small>` too: `+257.60 <small>USDT</small>`. Sub-unit values keep the quote's own precision, so a BTC-quoted bot's `0.000123 BTC` is not rounded to `0.00`.

**Small fixes on the way**
- `format_value(0)` stripped the bare `0` to an empty string, leaving a brand-new bot's Invested tile blank.
- `Denomination#suffixed?` and `#format_converted` (for a figure already converted at the rate of its own day, which `format` would convert again).
- A one-line style nudge for `small:first-child` in table cells.

## Tests

`bin/rails test` — 4861 runs, 0 failures. New coverage: tracker chart unit attributes for USD and PLN, the `$`-before-input order, cash-row prices, quote codes on tiles and table cells for index and single bots, the Sell confirmation's table, `Denomination#format_converted` / `#suffixed?`.
