### PR TITLE
Choose the display currency from the menu

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -245,8 +245,11 @@ ol, ul
         font-size: 8.2rem
         line-height: 7rem
         max-height: 7rem
-        margin-bottom: -1rem
+        margin-bottom: -0.875rem
         font-weight: 600 !important
+        small
+            position: relative
+            top: -0.125rem
     // Whatever width the number leaves, and the headline's height less the inset, above the zero
     // line and mirrored below it. Fixed rather than cut to each account's worst day — the rest of
     // the page would otherwise sit at a height that means something only to this curve.

--- a/app/assets/stylesheets/new/_dropdown.sass
+++ b/app/assets/stylesheets/new/_dropdown.sass
@@ -124,6 +124,16 @@
             align-items: center
             justify-content: space-between
             gap: 2rem
+        // A row that holds a CONTROL rather than a label: the track brings its own inset and its
+        // own hit areas, so the row gives it the width instead of a reading margin, and takes no
+        // hover of its own — the thing being pointed at is inside it.
+        &--currency
+            display: flex
+            justify-content: center
+            padding: 0.5rem 1rem
+            cursor: default
+            &:hover
+                background: none
         &--danger
             color: var(--berry)
             &:hover

--- a/app/assets/stylesheets/new/_menu-mobile.sass
+++ b/app/assets/stylesheets/new/_menu-mobile.sass
@@ -32,6 +32,10 @@
       align-items: center
       justify-content: center
       gap: 1.5rem
+    // The picker is its own row and centres like the rest of them; the track carries the padding.
+    &--currency
+      display: flex
+      justify-content: center
   &__button
     background: none
     border: none

--- a/app/assets/stylesheets/new/_segmented.sass
+++ b/app/assets/stylesheets/new/_segmented.sass
@@ -321,3 +321,9 @@
 .filters:has(> .segmented)
     flex: 1
     min-width: 0
+
+// A currency picker's labels are SYMBOLS, and a symbol is written the way the countries using it
+// write it — "zł", "Fr.". The track's uppercase would turn them back into codes.
+.segmented[data-currency]
+    .segmented__option, .segmented__thumb
+        text-transform: none

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -84,9 +84,10 @@ class SettingsController < ApplicationController
   def update_display_currency
     if current_user.update(update_display_currency_params)
       flash[:notice] = t('settings.language_and_timezone.currency_updated')
-      # Every normalized figure on every page changes with it, so refresh rather than
-      # swapping the one frame the select sits in.
-      render turbo_stream: turbo_stream_page_refresh
+      # Every normalized figure on the page changes with it, and the picker posting this lives in
+      # the menu rather than in a frame — where `turbo_stream.refresh` is skipped, because the
+      # submit is itself a visit in flight. Come back to the page the choice was made on.
+      redirect_back fallback_location: bots_path, status: :see_other
     else
       render_preference_error
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,10 +25,16 @@ module ApplicationHelper
     time.in_time_zone(zone).strftime('%Y/%m/%d')
   end
 
+  # The clock half of a table date, in the reader's own convention: `3:19 pm` in English and
+  # `15:19` everywhere else (`time.formats.table_clock` in each locale).
+  def table_clock(time, zone)
+    l(time.in_time_zone(zone), format: :table_clock)
+  end
+
   # When a row happened: the date, with the clock time behind it in <small>. The date is what a
   # row is found by and the time is the detail, so they are not set at the same weight.
   def table_when(time, zone)
-    safe_join([table_date(time, zone), ' ', tag.small(time.in_time_zone(zone).strftime('%H:%M'))])
+    safe_join([table_date(time, zone), ' ', tag.small(table_clock(time, zone))])
   end
 
   def ticker_class(asset)

--- a/app/helpers/bot_helper.rb
+++ b/app/helpers/bot_helper.rb
@@ -489,7 +489,8 @@ module BotHelper
   def format_activity_time(value)
     return value if value.blank?
 
-    Time.iso8601(value.to_s).in_time_zone(current_user.time_zone).strftime('%Y/%m/%d %H:%M')
+    at = Time.iso8601(value.to_s)
+    "#{table_date(at, current_user.time_zone)} #{table_clock(at, current_user.time_zone)}"
   rescue ArgumentError
     value
   end

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -265,13 +265,19 @@ export default class extends Controller {
     }
     this.thumbTarget.textContent = "";
 
-    // First placement must not slide in from the left edge.
-    if (!this.placed) this.thumbTarget.style.transition = "none";
     // Rects, not offsetLeft/offsetWidth: those round to whole pixels, and a label half a pixel
     // wider than its slot pushes the chip that half pixel into the track's padding — visible as
     // a thinner gap on whichever side the chip sits.
     const track = this.element.getBoundingClientRect();
     const rect = selected.getBoundingClientRect();
+    // No box at all: the control is inside something still closed — a menu, a hidden pane — and
+    // every rect reads zero. Placing the chip on that spends the un-animated FIRST placement on a
+    // measurement of nothing, so the real one slides in from the left edge the moment the box
+    // opens. Nothing is on screen to place, so there is nothing to do until there is.
+    if (!rect.width) return;
+
+    // First placement must not slide in from the left edge.
+    if (!this.placed) this.thumbTarget.style.transition = "none";
     this.thumbTarget.style.left = `${rect.left - track.left}px`;
     this.thumbTarget.style.width = `${rect.width}px`;
     if (!this.placed) {

--- a/app/models/denomination.rb
+++ b/app/models/denomination.rb
@@ -8,7 +8,7 @@
 class Denomination
   # Rails ships no currency table and the money gem is a dependency for five rows. Suffixed
   # where the currency is written after the amount in the countries that use it.
-  UNITS = { 'USD' => '$', 'EUR' => '€', 'GBP' => '£', 'CHF' => 'CHF', 'PLN' => 'zł' }.freeze
+  UNITS = { 'USD' => '$', 'EUR' => '€', 'GBP' => '£', 'CHF' => 'Fr.', 'PLN' => 'zł' }.freeze
   SUFFIXED = %w[CHF PLN].freeze
 
   attr_reader :currency, :rate

--- a/app/views/layouts/navbar/_display_currency_picker.html.haml
+++ b/app/views/layouts/navbar/_display_currency_picker.html.haml
@@ -1,0 +1,17 @@
+-# The fiat every normalized figure on the page is written in. It lives in the menu rather than on
+  the account page because it changes what the reader is LOOKING AT — the tiles, the chart, the
+  totals — and a preference you have to leave the page to set is one you set once and forget.
+-#
+-# Symbols, not codes: five of them fit on one track, and the symbol is what the amounts beside it
+  are already wearing.
+-#
+-# data-dropdown-keep-open for the same reason the switch above it has: choosing a denominator is
+  the menu's own business, and a menu that closed under the finger would make a second thought a
+  second trip. The hidden field is the whole of the join to the form — `segmented` renders BUTTONS,
+  which post nothing.
+- currencies = User::DISPLAY_CURRENCIES.map { |code| { value: code, label: Denomination::UNITS[code], active: current_user.display_currency == code } }
+= form_with model: current_user, url: settings_update_display_currency_path, method: :patch, class: "switch-row-form", data: { controller: "form--segmented-field form--submit", action: "segmented:change->form--segmented-field#set segmented:change->form--submit#submit" } do |f|
+  %div{ class: "#{item_class} #{item_class}--currency", title: t('settings.language_and_timezone.currency_is_used_for'), data: { dropdown_keep_open: true } }
+    = render 'shared/segmented', options: currencies, label: t('links.display_currency'), fluid: true, data: { currency: true }
+  -# id: nil — the menu is rendered twice, and a hidden field nothing labels needs no id at all.
+  = f.hidden_field :display_currency, id: nil, data: { 'form--segmented-field-target': 'field' }

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -27,6 +27,7 @@
     = t('links.account')
 
   = render 'layouts/navbar/hide_balances_toggle', item_class: 'menu-mobile__item'
+  = render 'layouts/navbar/display_currency_picker', item_class: 'menu-mobile__item'
 
   .menu-mobile__divider
   = button_to destroy_user_session_path, method: :delete, class: "menu-mobile__item menu-mobile__button", data: { turbo: false } do
@@ -75,6 +76,7 @@
         = link_to t('links.connections'), settings_connect_path, class: "dropdown__item"
         = link_to t('links.account'), settings_account_path, class: "dropdown__item"
         = render 'layouts/navbar/hide_balances_toggle', item_class: 'dropdown__item'
+        = render 'layouts/navbar/display_currency_picker', item_class: 'dropdown__item'
         .dropdown__item.dropdown__item--divider
         = button_to destroy_user_session_path, method: :delete, class: "dropdown__item dropdown__item--danger", data: { turbo: false } do
           = t('links.log_out')

--- a/app/views/settings/widgets/_language_and_time_zone.html.erb
+++ b/app/views/settings/widgets/_language_and_time_zone.html.erb
@@ -41,21 +41,11 @@
         </div>
       <% end %>
     <% end %>
-
-    <%= turbo_frame_tag "update_display_currency_form" do %>
-      <%= form_with model: current_user, url: settings_update_display_currency_path, method: :patch, data: { controller: "form--submit", turbo_frame: "update_display_currency_form" } do |f| %>
-        <div class="sinput sinput--select">
-          <%= current_user.display_currency %>
-          <%= f.select :display_currency, User::DISPLAY_CURRENCIES, { selected: current_user.display_currency }, data: { action: "change->form--submit#submit" } %>
-        </div>
-      <% end %>
-    <% end %>
   </div>
 
   <div class="settings-prefs__notes">
     <small data-controller="clock" data-clock-time-zone-value="<%= ActiveSupport::TimeZone[current_user.time_zone].tzinfo.identifier %>">
       <%= t('settings.language_and_timezone.current_time_is') %> <b data-clock-target="timestamp"><%= Time.current.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %I:%M %p") %></b>
     </small>
-    <small><%= t('settings.language_and_timezone.currency_is_used_for') %></small>
   </div>
 </div>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -1,4 +1,7 @@
 bg:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -87,6 +87,7 @@ bg:
             title: Благодарим!
     links:
         hide_balances: 'Скрий балансите'
+        display_currency: 'Валута за показване'
         show_balances: 'Покажи балансите'
         about: За нас
         telegram: 'Telegram'
@@ -111,7 +112,7 @@ bg:
             title: Разширени ботове
             toggle_label: Показване на разширени ботове
         language_and_timezone:
-            title: 'Език, часова зона и валута'
+            title: 'Език и часова зона'
             language_updated: "Езикът е обновен."
             updated: "Часовата зона е обновена."
             current_time_is: "Тази часова зона ще се използва в логовете на бота. Текущото време в нея е"

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -1,4 +1,7 @@
 cs:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -88,6 +88,7 @@ cs:
             title: Děkujeme!
     links:
         hide_balances: 'Skrýt zůstatky'
+        display_currency: 'Zobrazovaná měna'
         show_balances: 'Zobrazit zůstatky'
         about: O nás
         telegram: 'Telegram'
@@ -112,7 +113,7 @@ cs:
             title: Pokročilí boti
             toggle_label: Zobrazit pokročilé boty
         language_and_timezone:
-            title: 'Jazyk, časové pásmo a měna'
+            title: 'Jazyk a časové pásmo'
             language_updated: "Jazyk byl aktualizován."
             updated: "Časové pásmo bylo aktualizováno."
             current_time_is: "Toto časové pásmo se použije v logech bota. Podle něj je aktuální čas"

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -1,4 +1,7 @@
 da:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -87,6 +87,7 @@ da:
             title: Tak!
     links:
         hide_balances: 'Skjul saldi'
+        display_currency: 'Visningsvaluta'
         show_balances: 'Vis saldi'
         about: Om
         telegram: 'Telegram'
@@ -111,7 +112,7 @@ da:
             title: Avancerede bots
             toggle_label: Vis avancerede bots
         language_and_timezone:
-            title: 'Sprog, tidszone og valuta'
+            title: 'Sprog og tidszone'
             language_updated: "Dit sprog er blevet opdateret."
             updated: "Din tidszone er blevet opdateret."
             current_time_is: "Denne tidszone bruges i bot-loggen. Ifølge den er klokken nu"

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -1,4 +1,7 @@
 de:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -86,6 +86,7 @@ de:
             title: Danke!
     links:
         hide_balances: 'Guthaben ausblenden'
+        display_currency: 'Anzeigewährung'
         show_balances: 'Guthaben einblenden'
         about: Über
         telegram: Telegram
@@ -110,7 +111,7 @@ de:
             title: Erweiterte Bots
             toggle_label: Erweiterte Bots anzeigen
         language_and_timezone:
-            title: 'Sprache, Zeitzone & Währung'
+            title: 'Sprache & Zeitzone'
             language_updated: 'Ihre Sprache wurde aktualisiert.'
             updated: 'Ihre Zeitzone wurde aktualisiert.'
             current_time_is: 'Diese Zeitzone wird in den Bot-Logs verwendet. Nach ihr ist die aktuelle Uhrzeit'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -1,4 +1,7 @@
 el:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -87,6 +87,7 @@ el:
             title: Ευχαριστούμε!
     links:
         hide_balances: 'Απόκρυψη υπολοίπων'
+        display_currency: 'Νόμισμα εμφάνισης'
         show_balances: 'Εμφάνιση υπολοίπων'
         about: Σχετικά
         telegram: 'Telegram'
@@ -111,7 +112,7 @@ el:
             title: Προχωρημένα bot
             toggle_label: Εμφάνιση προχωρημένων bot
         language_and_timezone:
-            title: 'Γλώσσα, ζώνη ώρας & νόμισμα'
+            title: 'Γλώσσα & ζώνη ώρας'
             language_updated: "Η γλώσσα σου ενημερώθηκε."
             updated: "Η ζώνη ώρας σου ενημερώθηκε."
             current_time_is: "Αυτή η ζώνη ώρας θα χρησιμοποιείται στα αρχεία καταγραφής του bot. Σύμφωνα με αυτήν, η τρέχουσα ώρα είναι"

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -1,4 +1,7 @@
 en:
+    time:
+        formats:
+            table_clock: '%-l:%M %P'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -87,6 +87,7 @@ en:
             title: Thanks!
     links:
         hide_balances: 'Hide balances'
+        display_currency: 'Display currency'
         show_balances: 'Show balances'
         about: About
         telegram: 'Telegram'
@@ -111,7 +112,7 @@ en:
             title: Advanced Bots
             toggle_label: Show advanced bots
         language_and_timezone:
-            title: 'Language, Timezone & Currency'
+            title: 'Language & Timezone'
             language_updated: "Your language has been updated."
             updated: "Your timezone has been updated."
             current_time_is: "This timezone will be used in the bot logs. According to it, the current time is"

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -1,4 +1,7 @@
 es:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -86,6 +86,7 @@ es:
             title: ¡Gracias!
     links:
         hide_balances: 'Ocultar saldos'
+        display_currency: 'Moneda de visualización'
         show_balances: 'Mostrar saldos'
         about: 'Acerca de'
         telegram: 'Telegram'
@@ -110,7 +111,7 @@ es:
             title: Bots avanzados
             toggle_label: Mostrar bots avanzados
         language_and_timezone:
-            title: 'Idioma, zona horaria y moneda'
+            title: 'Idioma y zona horaria'
             language_updated: 'Tu idioma ha sido actualizado.'
             updated: 'Tu zona horaria ha sido actualizada.'
             current_time_is: 'Esta zona horaria se usará en los logs del bot. Según ella, la hora actual es'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -86,6 +86,7 @@ fr:
             title: 'Merci !'
     links:
         hide_balances: 'Masquer les soldes'
+        display_currency: "Devise d'affichage"
         show_balances: 'Afficher les soldes'
         about: 'À propos'
         telegram: 'Telegram'
@@ -110,7 +111,7 @@ fr:
             title: Bots avancés
             toggle_label: Afficher les bots avancés
         language_and_timezone:
-            title: 'Langue, fuseau horaire et devise'
+            title: 'Langue et fuseau horaire'
             language_updated: 'Votre langue a été mise à jour.'
             updated: 'Votre fuseau horaire a été mis à jour.'
             current_time_is: 'Ce fuseau horaire sera utilisé dans les logs du bot. Selon lui, l''heure actuelle est'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -1,4 +1,7 @@
 fr:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -1,4 +1,7 @@
 it:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -86,6 +86,7 @@ it:
             title: Grazie!
     links:
         hide_balances: 'Nascondi saldi'
+        display_currency: 'Valuta di visualizzazione'
         show_balances: 'Mostra saldi'
         about: Chi siamo
         telegram: 'Telegram'
@@ -110,7 +111,7 @@ it:
             title: Bot avanzati
             toggle_label: Mostra bot avanzati
         language_and_timezone:
-            title: 'Lingua, fuso orario e valuta'
+            title: 'Lingua e fuso orario'
             language_updated: 'La tua lingua è stata aggiornata.'
             updated: 'Il tuo fuso orario è stato aggiornato.'
             current_time_is: 'Questo fuso orario sarà usato nei log del bot. Secondo esso, l''orario attuale è'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -86,6 +86,7 @@ nl:
             title: Bedankt!
     links:
         hide_balances: 'Saldi verbergen'
+        display_currency: 'Weergavevaluta'
         show_balances: 'Saldi tonen'
         about: 'Over ons'
         telegram: 'Telegram'
@@ -110,7 +111,7 @@ nl:
             title: Geavanceerde bots
             toggle_label: Geavanceerde bots tonen
         language_and_timezone:
-            title: 'Taal, Tijdzone & Valuta'
+            title: 'Taal & Tijdzone'
             language_updated: 'Uw taal is bijgewerkt.'
             updated: 'Uw tijdzone is bijgewerkt.'
             current_time_is: 'Deze tijdzone wordt gebruikt in de bot logs. Volgens deze is de huidige tijd'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -1,4 +1,7 @@
 nl:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -1,4 +1,7 @@
 pl:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -88,6 +88,7 @@ pl:
             title: Dzięki!
     links:
         hide_balances: 'Ukryj salda'
+        display_currency: 'Waluta wyświetlania'
         show_balances: 'Pokaż salda'
         about: 'O nas'
         telegram: 'Telegram'
@@ -112,7 +113,7 @@ pl:
             title: Zaawansowane boty
             toggle_label: Pokaż zaawansowane boty
         language_and_timezone:
-            title: 'Język, strefa czasowa i waluta'
+            title: 'Język i strefa czasowa'
             language_updated: 'Twój język został zaktualizowany.'
             updated: 'Twoja strefa czasowa została zaktualizowana.'
             current_time_is: 'Ta strefa czasowa będzie używana w logach bota. Zgodnie z nią, aktualna godzina to'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -86,6 +86,7 @@ pt:
             title: Obrigado!
     links:
         hide_balances: 'Ocultar saldos'
+        display_currency: 'Moeda de exibição'
         show_balances: 'Mostrar saldos'
         about: 'Sobre'
         telegram: 'Telegram'
@@ -110,7 +111,7 @@ pt:
             title: Bots avançados
             toggle_label: Mostrar bots avançados
         language_and_timezone:
-            title: 'Idioma, fuso horário e moeda'
+            title: 'Idioma e fuso horário'
             language_updated: 'O seu idioma foi atualizado.'
             updated: 'O seu fuso horário foi atualizado.'
             current_time_is: 'Este fuso horário será usado nos logs do bot. Segundo ele, a hora actual é'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -1,4 +1,7 @@
 pt:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -1,4 +1,7 @@
 ru:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -88,6 +88,7 @@ ru:
             title: Спасибо!
     links:
         hide_balances: 'Скрыть балансы'
+        display_currency: 'Валюта отображения'
         show_balances: 'Показать балансы'
         about: 'О нас'
         telegram: 'Телеграм'
@@ -114,7 +115,7 @@ ru:
             title: Расширенные боты
             toggle_label: Показать расширенные боты
         language_and_timezone:
-            title: 'Язык, часовой пояс и валюта'
+            title: 'Язык и часовой пояс'
             language_updated: 'Ваш язык был обновлен.'
             updated: 'Ваш часовой пояс был обновлен.'
             current_time_is: 'Этот часовой пояс будет использоваться в журналах бота. Согласно ему, текущее время'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -1,4 +1,7 @@
 sk:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -88,6 +88,7 @@ sk:
             title: Ďakujeme!
     links:
         hide_balances: 'Skryť zostatky'
+        display_currency: 'Zobrazovaná mena'
         show_balances: 'Zobraziť zostatky'
         about: O nás
         telegram: 'Telegram'
@@ -112,7 +113,7 @@ sk:
             title: Pokročilí boti
             toggle_label: Zobraziť pokročilých botov
         language_and_timezone:
-            title: 'Jazyk, časové pásmo a mena'
+            title: 'Jazyk a časové pásmo'
             language_updated: "Jazyk bol aktualizovaný."
             updated: "Časové pásmo bolo aktualizované."
             current_time_is: "Toto časové pásmo sa použije v logoch bota. Podľa neho je aktuálny čas"

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -87,6 +87,7 @@ sv:
             title: Tack!
     links:
         hide_balances: 'Dölj saldon'
+        display_currency: 'Visningsvaluta'
         show_balances: 'Visa saldon'
         about: Om
         telegram: 'Telegram'
@@ -111,7 +112,7 @@ sv:
             title: Avancerade bots
             toggle_label: Visa avancerade bots
         language_and_timezone:
-            title: 'Språk, tidszon och valuta'
+            title: 'Språk och tidszon'
             language_updated: "Ditt språk har uppdaterats."
             updated: "Din tidszon har uppdaterats."
             current_time_is: "Denna tidszon används i botloggen. Enligt den är klockan nu"

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -1,4 +1,7 @@
 sv:
+    time:
+        formats:
+            table_clock: '%H:%M'
     meta:
         title: 'Deltabadger'
     header:

--- a/test/controllers/bots/segmented_filters_test.rb
+++ b/test/controllers/bots/segmented_filters_test.rb
@@ -2,6 +2,9 @@
 
 require 'test_helper'
 
+# Scoped to `.filters`, the page's own filter row: the settings menu carries a segmented control
+# of its own on every signed-in page, so a page-wide count would be counting the menu.
+#
 # The two filter rows are the same control as the chart's VALUE/RETURN switch, in its FLUID
 # sizing: "All" and "Transactions" are nowhere near the same width, and the order filters do not
 # even have a fixed number of options — they appear only for the categories a bot actually has.
@@ -21,15 +24,15 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     get bots_path(filter: 'active')
 
     assert_response :success
-    assert_select '.segmented.segmented--fluid', 1
-    assert_select '.segmented__thumb', 1
-    assert_select 'a.segmented__option', 3
-    assert_select 'a.segmented__option.is-on[aria-current="page"]', 1 do |option|
+    assert_select '.filters .segmented.segmented--fluid', 1
+    assert_select '.filters .segmented__thumb', 1
+    assert_select '.filters a.segmented__option', 3
+    assert_select '.filters a.segmented__option.is-on[aria-current="page"]', 1 do |option|
       assert_equal 'active', option.first['data-value']
     end
     # No memory on a link group: the filter is in the URL, and a remembered one would send the
     # reader somewhere other than the page they asked for.
-    assert_select '.segmented[data-segmented-key]', 0
+    assert_select '.filters .segmented[data-segmented-key]', 0
   end
 
   test 'the order filters are a fluid segmented control the order-filter controller still drives' do
@@ -40,13 +43,13 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     get bot_path(id: bot.id)
 
     assert_response :success
-    assert_select '.segmented.segmented--fluid', 1
+    assert_select '.filters .segmented.segmented--fluid', 1
     # all + transactions + other; no waiting row exists, so no waiting option
-    assert_select 'button.segmented__option', 3
-    assert_select '[data-value="all"].is-on', 1
-    assert_select 'button[data-value="other"]', 1
+    assert_select '.filters button.segmented__option', 3
+    assert_select '.filters [data-value="all"].is-on', 1
+    assert_select '.filters button[data-value="other"]', 1
     # Not remembered either: the log opens on its default tab every visit.
-    assert_select '.segmented[data-segmented-key]', 0
+    assert_select '.filters .segmented[data-segmented-key]', 0
   end
 
   test 'a bot with only one category of orders shows no filter at all' do
@@ -56,6 +59,6 @@ class Bots::SegmentedFiltersTest < ActionDispatch::IntegrationTest
     get bot_path(id: bot.id)
 
     assert_response :success
-    assert_select 'button.segmented__option', 0
+    assert_select '.filters button.segmented__option', 0
   end
 end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -113,16 +113,26 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, 'form__info--invalid'
   end
 
-  test 'the account page offers every supported fiat denominator' do
+  # The picker lives in the menu, which is drawn on every signed-in page and drawn twice — the
+  # desktop dropdown and the mobile drawer — so the count is per menu.
+  test 'the settings menu offers every supported fiat denominator, by its symbol' do
     get settings_account_path
 
-    assert_select 'select[name="user[display_currency]"] option', count: User::DISPLAY_CURRENCIES.size
+    assert_select '.segmented[data-currency] .segmented__option',
+                  count: User::DISPLAY_CURRENCIES.size * 2
+    assert_select '.segmented[data-currency] .segmented__option', text: 'Fr.'
+    assert_select 'select[name="user[display_currency]"]', count: 0
   end
 
-  test 'a currency change flashes a translated confirmation and stores the choice' do
-    patch settings_update_display_currency_path, params: { user: { display_currency: 'PLN' } }
+  # redirect_back, not a refresh stream: the picker is not in a turbo-frame any more, and a
+  # refresh action is skipped while the submit's own visit is in flight.
+  test 'a currency change flashes a translated confirmation and comes back to the page' do
+    patch settings_update_display_currency_path,
+          params: { user: { display_currency: 'PLN' } },
+          headers: { 'HTTP_REFERER' => 'http://www.example.com/tracker' }
 
-    assert_response :success
+    assert_redirected_to '/tracker'
+    assert_response :see_other
     assert_equal 'PLN', @user.reload.display_currency
     assert_equal I18n.t('settings.language_and_timezone.currency_updated'), flash[:notice]
   end
@@ -142,7 +152,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
     patch settings_update_display_currency_path, params: { user: { display_currency: '' } }
 
-    assert_response :success
+    assert_response :see_other
     assert_equal 'USD', @user.reload.display_currency
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -49,4 +49,24 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_nil asset_type_label(nil)
     assert_nil asset_type_label('')
   end
+
+  # Table dates are year-first in every locale; only the clock changes shape with the language.
+  test 'table_when: English shows a 12-hour clock, other locales a 24-hour one' do
+    at = Time.utc(2026, 8, 21, 13, 19)
+
+    I18n.with_locale(:en) do
+      assert_equal '2026/08/21 <small>3:19 pm</small>', table_when(at, 'Europe/Warsaw')
+      assert_equal '2026/08/21 <small>9:19 am</small>', table_when(at, 'America/New_York')
+    end
+
+    I18n.with_locale(:pl) do
+      assert_equal '2026/08/21 <small>15:19</small>', table_when(at, 'Europe/Warsaw')
+    end
+  end
+
+  test 'every locale carries its own table clock format' do
+    I18n.available_locales.each do |locale|
+      assert I18n.exists?('time.formats.table_clock', locale, fallback: false), "#{locale} falls back for the table clock"
+    end
+  end
 end

--- a/test/models/denomination_test.rb
+++ b/test/models/denomination_test.rb
@@ -31,7 +31,7 @@ class DenominationTest < ActiveSupport::TestCase
     stub_rate('CHF', 0.8)
     stub_rate('EUR', 0.9)
 
-    assert_equal '20.00 <small>CHF</small>', Denomination.for('CHF').format(25)
+    assert_equal '20.00 <small>Fr.</small>', Denomination.for('CHF').format(25)
     assert_equal '<small>€</small>22.50', Denomination.for('EUR').format(25)
   end
 

--- a/test/views/table_placeholders_test.rb
+++ b/test/views/table_placeholders_test.rb
@@ -31,7 +31,8 @@ class TablePlaceholdersTest < ActionView::TestCase
     # A bare <tr> is not a document, and the fragment parser drops the row — so the markup is
     # searched rather than a parsed tree.
     assert_includes rendered, 'class="table__when"'
-    # One shape on both pages: year-first date, clock time behind it in <small>.
-    assert_match %r{\d{4}/\d{2}/\d{2} <small>\d{2}:\d{2}</small>}, rendered
+    # One shape on both pages: year-first date, clock time behind it in <small> — a 12-hour clock
+    # under the English locale these tests run in.
+    assert_match %r{\d{4}/\d{2}/\d{2} <small>\d{1,2}:\d{2} [ap]m</small>}, rendered
   end
 end


### PR DESCRIPTION
The display currency now lives in the settings menu, and table timestamps are
told in the reader's own convention.

## Display currency in the menu

The denominator every normalized figure is written in — the dashboard tiles,
the chart, the tracker totals — used to be a select on the account page. It is
now a segmented picker of symbols in the bottom-left settings menu and in the
mobile drawer: `$ € £ Fr. zł`. Changing what you are looking at belongs beside
the other controls that change the view, not behind a page you have to navigate
to first.

`Denomination::UNITS` writes CHF as `Fr.`, so the picker and every amount on
the page read from one map. The picker's uppercase is turned off for the same
reason: a symbol is written the way the places using it write it.

The update action answers with `redirect_back` instead of a page-refresh
stream. That stream worked only while the select sat inside a turbo-frame —
Turbo skips a refresh action while the submitting visit is still in flight — so
outside the frame it would have left the page showing the currency the reader
had just moved away from.

The "Language, Timezone & Currency" widget loses its currency row and its
`& Currency` in every locale.

## A clock in the reader's own convention

Table rows carried a hard-coded `%H:%M`, which is the convention almost
everywhere and the wrong one in English. The clock half of a table date now
comes from `time.formats.table_clock` per locale: English reads `3:19 pm`,
everything else keeps `15:19`. The date stays year-first everywhere — it is
what a row is found by, not something read aloud. The activity log had a second
copy of the same strftime and goes through the shared helpers now.

## Segmented chip placement

The chip's first placement is deliberately un-animated so it does not slide in
from the left edge on load. A control rendered inside something closed — a
menu, a hidden pane — spent that placement on `connect()`, where every rect
reads zero, and the first real measurement then animated the chip in from
nothing the moment the box opened. A zero-width option is nothing to place.

## Known limitation

Both menus render their own copy of the picker, and the desktop menu is
`data-turbo-permanent` so it survives the re-render that follows a change. A
currency chosen in the mobile drawer therefore leaves the desktop copy marking
the previous one until the next full load — visible only if the viewport
crosses the 768px breakpoint without one, such as rotating a tablet. The
record, and every figure on the page, are correct throughout. The hide-balances
switch beside it has the same property.

## Tests

4863 runs, 0 failures. Filter-row assertions in `Bots::SegmentedFiltersTest`
are scoped to `.filters`: the menu now carries a segmented control on every
signed-in page, so a page-wide count was counting the menu.
