### PR TITLE
Hold a table's header to the top of the screen while its rows scroll

### DIFF
--- a/app/assets/stylesheets/_styles.sass
+++ b/app/assets/stylesheets/_styles.sass
@@ -49,7 +49,9 @@ body
   text-rendering: geometricPrecision
   background: none
   color: var(--ash)
-  overflow-x: hidden
+  // No overflow of its own: with html already clipping sideways, an overflow on body would not
+  // propagate to the viewport but make body a scroll container — one that never scrolls, yet is
+  // what every `position: sticky` on the page would stick to.
   font-size: 2rem
   line-height: 1.5
 .db-content-body

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -286,6 +286,22 @@ $stack-open: 0.2s ease-out
         overflow-y: auto
         text-wrap: nowrap
         line-height: 3rem
+        // Both set by `table-fit`. Fits: the table is no wider than this box, so nothing needs
+        // clipping and the sticky header below sticks to the screen rather than to this box.
+        // Stuck: the top edge has gone past the top of the screen, so the header is now pinned
+        // there — and gets an edge, since the rows sliding under it no longer start where it ends.
+        position: relative
+        &--fits
+            overflow: visible
+        &--stuck thead
+            box-shadow: 0 1px var(--silver)
+        .table-fit__sentinel
+            position: absolute
+            top: 0
+            height: 1px
+            width: 1px
+            visibility: hidden
+            pointer-events: none
         &--rules,&--tracker
             max-width: calc(100vw - 2rem)
             @media (min-width: 768px)
@@ -321,6 +337,12 @@ $stack-open: 0.2s ease-out
             font-size: 1.5rem
             text-transform: uppercase
             padding: 2.5rem 0 1rem  var(--ui-padding)
+        // A sentence, not a figure: it wraps like prose. Left unwrapped, one long failure message
+        // would make the whole table wider than its widget, and a widget that has to scroll
+        // sideways cannot hold its header to the screen.
+        td.table__sentence
+            text-wrap: auto
+            text-align: left
         td
             padding: 0.75rem 0 0.75rem var(--ui-padding)
             // A cell centres its boxes rather than sitting them on the row's baseline — and that

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -157,6 +157,9 @@ application.register("segmented", SegmentedController)
 import SliderController from "./slider_controller"
 application.register("slider", SliderController)
 
+import TableFitController from "./table_fit_controller"
+application.register("table-fit", TableFitController)
+
 import ThreeDotsController from "./three_dots_controller"
 application.register("three-dots", ThreeDotsController)
 

--- a/app/javascript/controllers/table_fit_controller.js
+++ b/app/javascript/controllers/table_fit_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Lets a table's `position: sticky` header reach the top of the screen, and marks it once it has.
+//
+// Sticky sticks to the nearest scroll container, and a table wider than its widget makes the
+// widget one (it scrolls sideways) — the header would then ride the widget, not the screen.
+// Whether the table fits is the one thing CSS cannot ask, so this asks it: a widget whose
+// table fits stops clipping, and native sticky does the rest.
+//
+// Stuck is not a state CSS can see either. A one-pixel sentinel on the widget's top edge is:
+// once it has left through the top of the viewport, the header is pinned there.
+export default class extends Controller {
+  connect() {
+    this.sentinel =
+      this.element.querySelector(":scope > .table-fit__sentinel") ??
+      this.element.insertAdjacentElement("afterbegin", Object.assign(document.createElement("div"), { className: "table-fit__sentinel" }));
+
+    this.resizes = new ResizeObserver(() => this.#fit());
+    this.resizes.observe(this.element);
+    this.element.querySelectorAll("table").forEach((table) => this.resizes.observe(table));
+
+    this.passing = new IntersectionObserver(([entry]) => this.#stuck(entry), { threshold: 0 });
+    this.passing.observe(this.sentinel);
+  }
+
+  disconnect() {
+    this.resizes.disconnect();
+    this.passing.disconnect();
+  }
+
+  #fit() {
+    this.element.classList.toggle("widget--table--fits", this.element.scrollWidth <= this.element.clientWidth);
+  }
+
+  // Left through the top — not merely out of view below, where the table has yet to be reached.
+  #stuck(entry) {
+    this.element.classList.toggle("widget--table--stuck", !entry.isIntersecting && entry.boundingClientRect.top < 0);
+  }
+}

--- a/app/views/bots/composition/_metrics.html.erb
+++ b/app/views/bots/composition/_metrics.html.erb
@@ -85,7 +85,7 @@
                               metrics[:asset_values].select { |symbol, _| in_index.include?(symbol) }
                             end %>
     <% if composition_values.present? %>
-      <div id="assets_metrics_table" class="widget widget--table">
+      <div id="assets_metrics_table" class="widget widget--table" data-controller="table-fit">
         <%= render 'bots/composition/assets_table', values: composition_values, logo_assets: logo_assets,
                    body_id: 'assets_metrics_list', hide_money: hide_money, quote: quote %>
       </div>
@@ -96,7 +96,7 @@
       the network trouble that produces an unresolved placement in the first place. The Clear action
       has to survive it — resolving an untracked order needs no prices at all. %>
   <% if exited.any? || bot.liquidation_ambiguous? %>
-    <div id="exited_metrics_table" class="widget widget--table">
+    <div id="exited_metrics_table" class="widget widget--table" data-controller="table-fit">
       <div class="exited-header">
         <span class="label"><%= t(exited_title_key) %></span>
         <% if bot.liquidation_ambiguous? %>

--- a/app/views/bots/dca_dual_assets/_metrics.html.erb
+++ b/app/views/bots/dca_dual_assets/_metrics.html.erb
@@ -39,7 +39,7 @@
             else
               []
             end %>
-  <div id="assets_metrics_table" class="widget widget--table">
+  <div id="assets_metrics_table" class="widget widget--table" data-controller="table-fit">
     <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money,
                quote: quote %>
   </div>

--- a/app/views/bots/dca_single_assets/_metrics.html.erb
+++ b/app/views/bots/dca_single_assets/_metrics.html.erb
@@ -33,7 +33,7 @@
             else
               []
             end %>
-  <div id="assets_metrics_table" class="widget widget--table">
+  <div id="assets_metrics_table" class="widget widget--table" data-controller="table-fit">
     <%= render 'bots/assets_table', rows: rows, body_id: 'assets_metrics_list', loading: loading, hide_money: hide_money,
                quote: quote %>
   </div>

--- a/app/views/bots/liquidations/new.html.erb
+++ b/app/views/bots/liquidations/new.html.erb
@@ -17,7 +17,7 @@
           hangs off .widget--table, so the table is bare without it. Absent when the price cache has
           gone cold, which is why the sale never depends on it. %>
       <% if @holding %>
-        <div class="widget widget--table">
+        <div class="widget widget--table" data-controller="table-fit">
           <%= render 'bots/composition/assets_table',
                      values: { @holding[:symbol] => @holding },
                      logo_assets: { @holding[:symbol] => @holding[:ticker] },

--- a/app/views/bots/orders/_activity.html.erb
+++ b/app/views/bots/orders/_activity.html.erb
@@ -6,5 +6,5 @@
 <% hidden = hide_balances?(activity.bot) %>
 <%= tag.tr id: dom_id(activity), class: "text-inactive", data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: hidden ? "other" : "all" } do %>
   <td scope="row" class="table__when"><%= table_when(activity.created_at, current_user.time_zone) %></td>
-  <td colspan="<%= hidden ? 1 : 3 %>" style="text-align: left;"><%= bot_activity_summary(activity) %></td>
+  <td colspan="<%= hidden ? 1 : 3 %>" class="table__sentence"><%= bot_activity_summary(activity) %></td>
 <% end %>

--- a/app/views/bots/orders/_order_timeline.html.erb
+++ b/app/views/bots/orders/_order_timeline.html.erb
@@ -17,7 +17,7 @@
   <% row_class = order.failed? ? 'text-danger' : (inactive_order_row?(order) ? 'text-inactive' : '') %>
   <%= tag.tr id: dom_id(order, :timeline), class: row_class, data: { hw_animate_in_prepend: "animate-order-in", order_filter_target: "row", order_type: hidden ? "other" : (order.other? ? "all other" : "all") } do %>
     <td scope="row" class="table__when"><%= table_when(order.created_at, current_user.time_zone) %></td>
-    <td colspan="<%= hidden ? 1 : 3 %>" style="text-align: left;"><%= transaction_summary(order, decimals) %></td>
+    <td colspan="<%= hidden ? 1 : 3 %>" class="table__sentence"><%= transaction_summary(order, decimals) %></td>
     <td>
       <% if order.open? %>
         <div data-controller="class-toggle" data-class-toggle-toggle-classes-value='["hidden"]'>

--- a/app/views/bots/orders/_orders.html.erb
+++ b/app/views/bots/orders/_orders.html.erb
@@ -13,10 +13,10 @@
   </div>
 
   <%= tag.div class: "widget widget--table", data: has_waiting ? {
-    controller: "broadcast--on-connect",
+    controller: "table-fit broadcast--on-connect",
     broadcast__on_connect_method_value: "fetch_open_orders",
     broadcast__on_connect_method_args_value: { bot_id: bot.id }.to_json
-  } : {} do %>
+  } : { controller: "table-fit" } do %>
     <table class="table">
       <thead>
         <tr>

--- a/app/views/rules/_rule_logs.html.erb
+++ b/app/views/rules/_rule_logs.html.erb
@@ -1,4 +1,4 @@
-<div class="widget widget--table widget--table--rules">
+<div class="widget widget--table widget--table--rules" data-controller="table-fit">
   <% if rule_logs.any? %>
     <table class="table">
       <thead>
@@ -13,7 +13,7 @@
           <tr>
             <td><%= l(log.created_at, format: :short) %></td>
             <td><span class="rule-log-status rule-log-status--<%= log.status %>"><%= log.status %></span></td>
-            <td><%= log.message %></td>
+            <td class="table__sentence"><%= log.message %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -24,7 +24,7 @@
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'), options: type_filters %>
       <% end %>
     </div>
-    <div class="tracker-record__table widget widget--table widget--table--tracker">
+    <div class="tracker-record__table widget widget--table widget--table--tracker" data-controller="table-fit">
       <% if @account_transactions.any? %>
         <table class="table">
           <thead>
@@ -69,7 +69,7 @@
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'), options: status_filters %>
       <% end %>
     </div>
-    <div class="tracker-record__table widget widget--table widget--table--tracker tracker-positions">
+    <div class="tracker-record__table widget widget--table widget--table--tracker tracker-positions" data-controller="table-fit">
       <% if @scoped_ledger.nil? %>
         <div class="loader--small" style="position: unset; margin: 2rem auto;"></div>
       <% else %>


### PR DESCRIPTION
Table headers stay at the top of the screen while the rows scroll, on every table: the tracker's transactions and positions, a bot's log and orders, the assets tables, rule logs. A pinned header draws a hairline under itself; it lets go with the last row.

## Why nothing stuck before

Every header already had `position: sticky`. Sticky pins an element to its nearest scroll container, and there were two between a header and the viewport:

- **`body`.** Both `html` and `body` clipped horizontal overflow. When `html` has an overflow of its own, `body`'s does not propagate to the viewport — it makes `body` a scroll container that never scrolls, and every sticky element on the page was pinned to it. `html` keeps the clip; `body` drops it.
- **The table widget.** It scrolls sideways when its table is wider than it is — right on a narrow screen, but it captures the header. CSS cannot tell whether a table fits, so a small `table-fit` controller asks: a widget whose table fits stops clipping, and native sticky takes over. No scroll-driven transforms.

## The hairline

A one-pixel sentinel on the widget's top edge, watched by an `IntersectionObserver`: once it has left through the top of the viewport the header is pinned, and `box-shadow: 0 1px var(--silver)` marks the edge.

## The bot log

One long failure message in a non-wrapping cell made the log wider than its column, so it scrolled sideways and its header could not stick. Sentence cells (`.table__sentence`: activity and timeline rows, rule-log messages) now wrap like prose.

## Ceiling

A table that is genuinely wider than the screen keeps its sideways scroller, and there the header scrolls away as before. Nothing changes for those tables beyond the wrapping above.
