### PR TITLE
Menu and tracker CSS fixes

### DIFF
--- a/app/assets/stylesheets/new/_dropdown.sass
+++ b/app/assets/stylesheets/new/_dropdown.sass
@@ -117,6 +117,8 @@
         background: none // <button>
         width: 100%      // <button>
         color: var(--ash)
+        &:hover
+            background: var(--dropdown-hover)
         // Label left, switch right. The base item is a grid built for a single label; a row that
         // carries a control needs the two ends held apart.
         &--switch
@@ -154,7 +156,5 @@
             cursor: default !important
             &:hover
                 background: none !important
-        &:hover
-            background: var(--dropdown-hover)
 
         

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -186,7 +186,7 @@
         &:hover
             background: var(--paper-on-washed)
     &--anon &__row
-        grid-template-columns: minmax(0, 1fr) 8rem 18rem 6rem 8rem 2rem
+        grid-template-columns: minmax(0, 1fr) 8rem minmax(0, 2fr) 6rem 8rem 2rem
     &__name
         display: flex
         align-items: center
@@ -321,9 +321,6 @@
         &--stated .tracker-row__price__input
             color: var(--ink)
             font-weight: 600
-        // Nothing could price this. An empty box with a mark on it is the honest reading, and the
-        // one place where typing a price actually changes what the page can say.
-        &--none .tracker-row__price__input
     &__cash
         color: var(--stone)
         font-weight: 450


### PR DESCRIPTION
Two small stylesheet corrections.

**The currency picker lit the whole menu row.** In the settings dropdown, hovering the display-currency picker highlighted the entire row the way a link to another page does. The row already declared that it takes no hover of its own, but `.dropdown__item:hover` was written below the modifiers, so at equal specificity it won on source order — which is also why `--divider`, `--note` and `--danger` each needed `!important` to be heard. The base hover now sits above the modifiers and the cascade reads in the intended order.

**The tracker's price column was measured two ways.** With balances hidden, the price column was pinned to `18rem` while the full row gives it `minmax(0, 2fr)`. It flexes in both now. An empty `--none` rule, which compiled to nothing, was removed alongside it.

Stylesheets only; no template or behaviour changes.
