### PR TITLE
Close the mobile menu on the item that leads somewhere

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -118,6 +118,9 @@ application.register("index-filter", IndexFilterController)
 import MarqueeController from "./marquee_controller"
 application.register("marquee", MarqueeController)
 
+import MenuMobileController from "./menu_mobile_controller"
+application.register("menu-mobile", MenuMobileController)
+
 import Modal__BaseController from "./modal/base_controller"
 application.register("modal--base", Modal__BaseController)
 

--- a/app/javascript/controllers/menu_mobile_controller.js
+++ b/app/javascript/controllers/menu_mobile_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// The drawer is held open by a turbo-permanent checkbox, so a Turbo visit carries the open state
+// onto the page you just picked and the menu is still covering it. Picking a destination has to
+// close it. A control the drawer OWNS must not — same rule, and the same marker, the dropdown menu
+// follows: flipping a switch is not choosing where to go.
+export default class extends Controller {
+  close(event) {
+    if (event.target.closest("[data-dropdown-keep-open]")) return;
+
+    document.getElementById("hamburger").checked = false;
+  }
+}

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -5,7 +5,7 @@
 .hamburger.hamburger__a
 .hamburger.hamburger__b
 
-.menu-mobile
+.menu-mobile{ data: { controller: 'menu-mobile', action: 'click->menu-mobile#close' } }
   - if single_bot_mode?
     - single_bot_path = bot_path(current_user.bots.not_deleted.first)
     = link_to single_bot_path, class: "menu-mobile__item menu-mobile__item--bots #{'menu-mobile__item--active' if current_page?(single_bot_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do

--- a/test/controllers/mobile_menu_test.rb
+++ b/test/controllers/mobile_menu_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The mobile drawer. It is held open by a turbo-permanent checkbox, so nothing closes it on its own
+# — a Turbo visit carries the open state onto the page you just picked.
+class MobileMenuTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true) # satisfies the onboarding gate (an admin must exist)
+    sign_in create(:user)
+  end
+
+  test 'picking a destination closes the drawer' do
+    get bots_path
+
+    assert_select '.menu-mobile[data-controller=menu-mobile]'
+    assert_select '.menu-mobile[data-action="click->menu-mobile#close"]'
+  end
+end


### PR DESCRIPTION
On a phone, picking an item in the menu navigated to the view and then left the menu covering it. The view was unreachable until the X was tapped.

The drawer is held open by one checkbox, and that checkbox is `data-turbo-permanent` — deliberately, so the "Hide balances" switch and the currency picker inside it can re-render the page without the menu closing mid-flip. Nothing else tracks the drawer's state, so a Turbo visit carried `checked` across and the new page rendered underneath an open menu.

A click inside the menu now unchecks it, unless it landed on a control the menu owns. Those are already marked with `data-dropdown-keep-open` for the desktop dropdown, which follows the same rule, so the marker is reused rather than duplicated.

- `app/javascript/controllers/menu_mobile_controller.js` — one `close` action
- `.menu-mobile` wired to it in `layouts/navbar/_signed_in`
- `test/controllers/mobile_menu_test.rb`
