### PR TITLE
Fold the tracker's secondary actions into a ⋮ menu

### DIFF
--- a/app/assets/stylesheets/new/_toggle.sass
+++ b/app/assets/stylesheets/new/_toggle.sass
@@ -129,9 +129,9 @@ input[type=checkbox]
     .label
         font-size: 2rem
 
-// A toggle and its label on ONE line, the label being the hit area: the tracker's "Show cash"
-// and the chart's "Show orders" are the same control in two places, and were two copies of the
-// same five lines drifting apart. Opt-in rather than `label:has(> .toggle)`, which outranks
+// A toggle and its label on ONE line, the label being the hit area: the chart's "Show orders"
+// and "Show prices" are the same control in two places, and were two copies of the same five
+// lines drifting apart. Opt-in rather than `label:has(> .toggle)`, which outranks
 // `.toggle-group__label` on specificity and would re-align every settings widget — those align
 // to `flex-start` on purpose, so a label running to two lines keeps its switch on the first.
 .toggle-inline

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -90,6 +90,9 @@
     align-items: center
     gap: 1rem
     white-space: nowrap
+    // The phone's line has room for the controls, not for a sentence about them.
+    @media (max-width: 767.9px)
+        display: none
     &__dot
         width: 0.875rem
         height: 0.875rem

--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -27,24 +27,13 @@
     padding-top: 6rem
     @media (min-width: 768px)
         padding-top: 1rem
-    // The + rides inside the venue switch, so this row holds that and "Show cash" — and
+    // The + rides inside the venue switch, so this row holds only that — and
     // `.filters:has(> .segmented)` hands it the whole line for the segmented to measure itself
-    // against, less whatever else is standing in it.
+    // against.
     > .filters
         flex-wrap: nowrap
         align-items: center
         gap: 1rem
-    // "Show cash", packed left directly after the venues. A real box rather than
-    // `display: contents`, because the venue switch measures its siblings to know its own room and
-    // an element generating no box has no width to subtract.
-    &__switch
-        flex: none
-        > label
-            display: flex
-            align-items: center
-            gap: 1rem
-            cursor: pointer
-            white-space: nowrap
     // Everything past the scope switch, kept together so `space-between` has two sides to push
     // apart rather than three things to spread.
     &__end

--- a/app/views/bots/_chart.html.erb
+++ b/app/views/bots/_chart.html.erb
@@ -128,8 +128,8 @@
         <div class="widget--chart__axis" data-bot--chart-target="axis"></div>
         <%# Off by choice, not by default: the marks sit over the curve, and a reader who came for
             the shape of the line should get the line. The choice is remembered per browser. %>
-        <%# The tracker's Show cash switch, in the same shape: small toggle, label as the hit area.
-            No form behind it — this one is a way of reading the chart in front of you, so it is
+        <%# The account menu's switch, in its shape: small toggle, label as the hit area. No form
+            behind it — this one is a way of reading the chart in front of you, so it is
             remembered in the browser rather than posted and stored against the account. %>
         <div class="widget--chart__orders">
           <label class="toggle-inline">

--- a/app/views/tracker/_exchange_filters.html.erb
+++ b/app/views/tracker/_exchange_filters.html.erb
@@ -49,26 +49,6 @@
         <%= render connect[:icon] %>
       <% end %>
     <% end %>
-
-    <%# The second scope control, in the same row and directly after the one that says WHERE. Cash
-        and stablecoins are where money WAITS rather than a position anybody picked, so the
-        allocation is drawn without them and what is left is normalized to 100%. It hides a
-        BALANCE, not a figure — the tiles and the chart state the whole portfolio either way.
-
-        The account menu's switch, in the account menu's shape: the label is the hit area, and the
-        hidden field is what makes an unchecked box mean something — a checkbox posts nothing when
-        it is off, and the action stores what was submitted rather than flipping what it finds. %>
-    <%= form_with url: settings_update_show_cash_path, method: :patch,
-                  class: 'tracker-exchanges__switch', data: { controller: 'form--submit' } do %>
-      <label>
-        <div class="toggle toggle--small">
-          <%= hidden_field_tag :show_cash, '0' %>
-          <%= check_box_tag :show_cash, '1', show_cash?, data: { action: 'change->form--submit#submit' } %>
-          <div class="toggle__style"></div>
-        </div>
-        <span class="label"><%= t('tracker.show_cash') %></span>
-      </label>
-    <% end %>
   </div>
 
   <%# The far end of the line: what the page can hand you, after the scope that decides what goes
@@ -89,14 +69,45 @@
       <% end %>
     </div>
 
-    <%= link_to t('bot.details.stats.download_csv'),
-                export_tracker_path(exchange_id: params[:exchange_id], from: params[:from], to: params[:to]),
-                class: 'rbutton' %>
-    <%# Beside the export, because it reads the same file the export writes — plus the venues' own. %>
-    <%= link_to t('tracker.import.title'), new_tracker_import_path, class: 'rbutton',
-                data: { turbo_frame: 'modal' } %>
     <% if @exchanges.any? %>
       <%= link_to t('tracker.get_report'), export_modal_tracker_path, class: 'rbutton', data: { turbo_frame: 'modal' } %>
     <% end %>
+
+    <%# The bot view's ⋮, holding what the line no longer has room to say outright. Not
+        turbo-permanent like the account menu: the export link carries the scope and the dates,
+        which a node held across visits would go on stating wrong. %>
+    <div data-controller="dropdown" data-action="click->dropdown#toggle" data-dropdown-target="wrapper" class="sbutton sbutton--link dropdown-wrapper dropdown-wrapper--right">
+      <%= render 'svg/24x24_dot_menu' %>
+      <div class="dropdown">
+        <%# The second scope control. Cash and stablecoins are where money WAITS rather than a
+            position anybody picked, so the allocation is drawn without them and what is left is
+            normalized to 100%. It hides a BALANCE, not a figure — the tiles and the chart state
+            the whole portfolio either way.
+
+            The account menu's switch row, in its shape: the label is the row and the hit area,
+            the click is kept from closing the menu on its way up, and the hidden field is what
+            makes an unchecked box mean something — a checkbox posts nothing when it is off, and
+            the action stores what was submitted rather than flipping what it finds. %>
+        <%= form_with url: settings_update_show_cash_path, method: :patch,
+                      class: 'switch-row-form', data: { controller: 'form--submit' } do %>
+          <label class="dropdown__item dropdown__item--switch" data-dropdown-keep-open>
+            <span><%= t('tracker.show_cash') %></span>
+            <div class="toggle toggle--small">
+              <%= hidden_field_tag :show_cash, '0' %>
+              <%= check_box_tag :show_cash, '1', show_cash?, data: { action: 'change->form--submit#submit' } %>
+              <div class="toggle__style"></div>
+            </div>
+          </label>
+        <% end %>
+        <div class="dropdown__item dropdown__item--divider"></div>
+        <%# Both read the venue and the dates from the same params the switch writes; the import
+            reads the same file the export writes — plus the venues' own. %>
+        <%= link_to t('bot.details.stats.download_csv'),
+                    export_tracker_path(exchange_id: params[:exchange_id], from: params[:from], to: params[:to]),
+                    class: 'dropdown__item' %>
+        <%= link_to t('tracker.import.title'), new_tracker_import_path, class: 'dropdown__item',
+                    data: { turbo_frame: 'modal' } %>
+      </div>
+    </div>
   </div>
 </div>

--- a/test/integration/tracker_page_test.rb
+++ b/test/integration/tracker_page_test.rb
@@ -109,14 +109,9 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     # menu — at the end of the track, at the foot of the list once the control has folded.
     assert_select ".segmented__menu > *:last-child.segmented__option--action[href='#{new_tracker_pick_exchange_path}'][data-turbo-frame='modal']", 1
     assert_select '.tracker-exchanges .dropdown--exchanges', 0, 'one destination now: the picker modal'
-    # "Show cash" shares that box, so the switch cannot read the whole line as room of its own —
-    # it measures its siblings out. Which means every sibling must GENERATE a box: an element laid
-    # out as `display: contents` has no width to subtract, and the switch would believe it fits and
-    # run over the sync state instead.
-    assert_select '.tracker-exchanges > .filters' do
-      assert_select '> .segmented', 1
-      assert_select '> form.tracker-exchanges__switch:not(.switch-row-form)', 1
-    end
+    # The venue switch has the box to itself: "Show cash" moved into the ⋮ menu.
+    assert_select '.tracker-exchanges > .filters > *', 1
+    assert_select '.tracker-exchanges > .filters > .segmented', 1
     assert_select '.tracker-exchanges .tracker-sync', text: /ago/i
     assert_select ".tracker-exchanges form[action='#{sync_tracker_path}'] .rbutton"
   end
@@ -272,14 +267,29 @@ class TrackerPageTest < ActionDispatch::IntegrationTest
     get tracker_path
 
     assert_select '.tracker-exchanges > .filters:first-child', true, 'the scope switch opens the line'
-    # `bot.details.stats.download_csv`, not `bot.details.download_csv`: the plan named the shorter
-    # path, but the key the bot page has actually carried in all 15 locales since it shipped is the
-    # one under `stats`. Reusing it beats adding a fifteen-file duplicate that says "Export" twice.
-    assert_select ".tracker-exchanges__end a.rbutton[href^='#{export_tracker_path}']",
-                  text: I18n.t('bot.details.stats.download_csv')
+    # The report stays a button: it is the one thing here most readers came for.
     assert_select ".tracker-exchanges__end a.rbutton[href='#{export_modal_tracker_path}']",
                   text: I18n.t('tracker.get_report')
+    # The rest folds into the ⋮ menu the bot view has, last on the line.
+    assert_select '.tracker-exchanges__end > *:last-child.dropdown-wrapper.dropdown-wrapper--right' do
+      assert_select 'svg', 1
+      assert_select '.dropdown' do
+        # `bot.details.stats.download_csv`: the key the bot page has carried in all 15 locales
+        # since it shipped. Reusing it beats a fifteen-file duplicate that says "Export" twice.
+        assert_select "a.dropdown__item[href^='#{export_tracker_path}']",
+                      text: I18n.t('bot.details.stats.download_csv')
+        assert_select "a.dropdown__item[href='#{new_tracker_import_path}'][data-turbo-frame='modal']",
+                      text: I18n.t('tracker.import.title')
+        assert_select 'a.rbutton', 0
+      end
+    end
     assert_select '.tracker-exchanges > *:last-child.tracker-exchanges__end', true, 'and they close it'
+  end
+
+  test 'the export in the menu carries the scope and the dates the switch wrote' do
+    get tracker_path(exchange_id: @binance.id, from: '2024-01-01', to: '2024-12-31')
+
+    assert_select ".dropdown a.dropdown__item[href='#{export_tracker_path(exchange_id: @binance.id, from: '2024-01-01', to: '2024-12-31')}']"
   end
 
   # ── 6 · transactions table ───────────────────────────────────────────────────────────────────

--- a/test/integration/tracker_show_cash_test.rb
+++ b/test/integration/tracker_show_cash_test.rb
@@ -50,18 +50,20 @@ class TrackerShowCashTest < ActionDispatch::IntegrationTest
 
   # ---- the control itself -------------------------------------------------
 
-  # The same switch the account menu uses, in the row that already says what the page is scoped to.
-  # Packed left in the scope row, directly after the venue switch, and the switch itself reads
-  # first — the control, then what it is for.
-  test 'the toggle rides in the scope row after the venue switch, small, and off by default' do
+  # The same switch row the account menu uses, in the page's ⋮ menu: label first, toggle at the
+  # end, the whole row the hit area, and the click kept from closing the menu on its way up.
+  test 'the toggle is a switch row in the ⋮ menu, small, and off by default' do
     get tracker_path
 
-    assert_select '.tracker-exchanges > .filters > form.tracker-exchanges__switch' do
-      assert_select 'label > *:first-child.toggle.toggle--small'
-      assert_select 'label > span:last-child', text: I18n.t('tracker.show_cash')
+    assert_select '.tracker-exchanges__end .dropdown form.switch-row-form' do
+      assert_select 'label.dropdown__item.dropdown__item--switch[data-dropdown-keep-open]' do
+        assert_select '> span:first-child', text: I18n.t('tracker.show_cash')
+        assert_select '> *:last-child.toggle.toggle--small'
+      end
       assert_select 'input[type=hidden][name=show_cash][value="0"]'
       assert_select '.toggle.toggle--small input[type=checkbox][name=show_cash]:not([checked])'
     end
+    assert_select '.tracker-exchanges__switch', 0, 'no longer standing in the scope row'
   end
 
   test 'the toggle reads back on once the preference is set' do


### PR DESCRIPTION
The tracker's scope line ends the way the bot view's header does: a ⋮ menu holding the secondary actions.

**Before:** past the venue switch sat Show cash (inside the switch's own box), the sync state, Export, Import and Tax Report.

**After:**
- **Tax Report** stays a button.
- **⋮ menu:** Show cash as a switch row (same shape as the account menu's Hide balances: the whole row is the hit area, and toggling keeps the menu open on the click), a divider, then **Export** and **Import**. Export still carries the selected venue and date range.
- The **"Synced N ago"** label is hidden below 768px; the sync button stays.

Tests cover the menu's contents and order, the switch row's shape and default state, and that Export keeps the scope params.
