### PR TITLE
Draw the holdings the ring has room for, instead of levelling them all

### DIFF
--- a/app/assets/stylesheets/_variables.sass
+++ b/app/assets/stylesheets/_variables.sass
@@ -68,7 +68,7 @@
     --washed: #FFFFFF
     --paper-on-washed: #F5F6F8
     --white: #FFFFFF
-    --grass: color(display-p3 0 0.7 0.45)
+    --grass: color(display-p3 0 0.65 0.425)
     --berry: #db0049
     --highlight: var(--sky)
     --autocomplete: #cde

--- a/app/assets/stylesheets/new2/_colors.sass
+++ b/app/assets/stylesheets/new2/_colors.sass
@@ -13,7 +13,7 @@
         --washed: #FFFFFF
         
         --white: #FFFFFF
-        --grass: color(display-p3 0 0.7 0.45)
+        --grass: color(display-p3 0 0.65 0.425)
         --berry: #CF0000
 
     @media (prefers-color-scheme: dark)

--- a/app/helpers/tracker_helper.rb
+++ b/app/helpers/tracker_helper.rb
@@ -21,23 +21,28 @@ module TrackerHelper
   # [{ color:, dash:, offset:, label: }] in the order the rows are listed. The card's SVG is turned
   # a quarter turn by CSS, so the dashes are walked from where a dashed circle starts.
   def holdings_ring_arcs(holdings)
-    total = holdings.sum(0.to_d, &:value)
+    slices = holdings.map { |holding| [holding.value, holding.asset.color, holding.asset.symbol] }
+
+    dashed_ring(ring_slices(slices, t('tracker.other')),
+                circumference: RING_CIRCUMFERENCE, min_span: RING_MIN_SPAN)
+  end
+
+  # The pieces of a portfolio, largest first: everything above RING_MIN_SHARE keeps its own colour
+  # and its own name, and the tail is gathered into one neutral piece, last.
+  #
+  # A single small holding is not an "other" — there is nothing to gather it with, and grey says a
+  # name is being withheld. It keeps its own colour and its own name; a round cap draws it as a dot
+  # whatever it is worth.
+  def ring_slices(slices, label)
+    slices = slices.select { |value, _, _| value.positive? }.sort_by { |value, _, _| -value }
+    total = slices.sum(0.to_d) { |value, _, _| value }
     return [] unless total.positive?
 
-    small, large = holdings.partition { |holding| holding.value / total < RING_MIN_SHARE }
-    # A single small holding is not an "other" — there is nothing to gather it with, and grey says
-    # a name is being withheld. It keeps its own colour and its own name; a round cap draws it as a
-    # dot whatever it is worth. Same reasoning as the icon's, which drops a lone tail rather than
-    # miscolour it — 24px has no room for the dot this ring has.
-    if small.one?
-      large = holdings
-      small = []
-    end
-    slices = large.map { |holding| [holding.value, holding.asset.color, holding.asset.symbol] }
-    folded = small.sum(0.to_d, &:value)
-    slices << [folded, NEUTRAL_COLOR, t('tracker.other')] if folded.positive?
+    small, large = slices.partition { |value, _, _| value / total < RING_MIN_SHARE }
+    return slices if small.one?
 
-    dashed_ring(slices, circumference: RING_CIRCUMFERENCE, min_span: RING_MIN_SPAN)
+    folded = small.sum(0.to_d) { |value, _, _| value }
+    large + (folded.positive? ? [[folded, NEUTRAL_COLOR, label]] : [])
   end
 
   # == the menu icon is this ring, small ==
@@ -51,11 +56,10 @@ module TrackerHelper
   # Between slices. The menu draws the 24-unit viewBox at 24px, so a unit here is a screen pixel.
   ICON_GAP = 2.0
   # What every slice is given whatever it is worth: the whole gap beside it, and a round-capped dash
-  # of nothing, which draws as a dot the width of the stroke. The ring keeps those two before it
-  # keeps the last percent of the reading — a gap that closes or a slice that vanishes is a worse
-  # lie about the portfolio than a small holding drawn slightly large.
+  # of nothing, which draws as a dot the width of the stroke. A slice that vanishes or a gap that
+  # closes is a worse lie about the portfolio than a small holding drawn slightly large — so the
+  # ring keeps those two, and pays for them by drawing fewer holdings rather than by levelling them.
   ICON_MIN_SPAN = ICON_GAP + ICON_STROKE
-  ICON_MAX_SLICES = (ICON_CIRCUMFERENCE / ICON_MIN_SPAN).floor
 
   # [{ color:, dash:, offset: }] for one dashed circle per slice, clockwise from twelve o'clock.
   def allocation_icon_arcs(user)
@@ -460,70 +464,45 @@ module TrackerHelper
   end
 
   def icon_arcs(pairs)
-    dashed_ring(icon_slices(pairs), circumference: ICON_CIRCUMFERENCE, min_span: ICON_MIN_SPAN,
-                                    start: -ICON_CIRCUMFERENCE / 4)
+    slices = pairs.map { |value, color| [value, color, nil] }
+
+    dashed_ring(ring_slices(slices, nil), circumference: ICON_CIRCUMFERENCE,
+                                          min_span: ICON_MIN_SPAN, start: -ICON_CIRCUMFERENCE / 4)
   end
 
-  # [value, color] largest first, with the tail the card's ring also gathers — everything under
-  # RING_MIN_SHARE, deliberately the same threshold — as one neutral slice, last. ONLY the tail:
-  # every holding above it keeps its own colour, however small the ring has to draw it.
-  def icon_slices(pairs)
-    slices = pairs.select { |value, _| value.positive? }.sort_by { |value, _| -value }
-    total = slices.sum(0.to_d) { |value, _| value }
+  # == what the ring has room for ==
+  #
+  # The pieces are placed largest first, each in the span its share deserves but never under
+  # `min_span`, until the ring is full — and then one more, so a ring that has run out of room shows
+  # that it has rather than stopping on a tidy edge. Whatever was never placed is not drawn.
+  #
+  # The placed spans overrun the circumference by exactly what the smallest of them were lifted by,
+  # so they all give up the same fraction of themselves at the end. That is the whole of the fit: an
+  # arc stays at its true share of the portfolio, a dot keeps the room it needs to be a dot, and the
+  # holdings that would have levelled the ring simply are not on it.
+  #
+  # The card's ring never drops anything — every one of its pieces clears its own minimum, so
+  # nothing is lifted, nothing overruns, and the scale is 1.
+  #
+  # [[slice, span], ...] in the order given: placement queues by value, but the ring keeps the
+  # order it was handed, so a gathered remainder stays last however much it is worth.
+  def ring_places(slices, circumference, min_span)
+    total = slices.sum(0.to_d) { |value, _, _| value }
     return [] unless total.positive?
 
-    large, tail = slices.partition { |value, _| value / total >= RING_MIN_SHARE }
-    # Nothing stands out, so nothing is "other": one neutral ring is the icon for a portfolio nobody
-    # has synced. Show the largest holdings instead, read as the whole between them.
-    return slices.first(ICON_MAX_SLICES) if large.empty?
+    spans = {}
+    used = 0.0
+    slices.each_index.sort_by { |index| -slices[index][0] }.each do |index|
+      # Asked before placing, not after: the piece that fills the ring is already on it, and a share
+      # that rounds to the whole circumference must not take the next piece's place with it.
+      break if used > circumference
 
-    gathered = tail.sum(0.to_d) { |value, _| value }
-    # A single holding is not an "other" — there is nothing to gather it with — and a tail worth
-    # less than one holding is dust. Both just go, and the rest is read as the whole.
-    kept = large.first(ICON_MAX_SLICES)
-    return kept if tail.size < 2 || gathered / total < RING_MIN_SHARE
-    # The remainder takes its place by value like anything else: a full ring of holdings that all
-    # outweigh it keeps them. Where it does survive it still displaces the smallest, and is drawn
-    # last whatever it is worth.
-    return kept if kept.size == ICON_MAX_SLICES && gathered <= kept.last.first
-
-    large.first(ICON_MAX_SLICES - 1) + [[gathered, NEUTRAL_COLOR]]
-  end
-
-  # The span each slice is laid out in, in the order given. Every slice is guaranteed `min_span`
-  # and only what is left over is shared out by value, so the gaps and the smallest dot are the
-  # same size wherever they fall — the small slices come out a little large and the big ones a
-  # little short. Lifting one takes circumference from the others and can push another under the
-  # minimum, so the pass repeats; it lifts at least one slice each time, so it cannot run away.
-  def ring_spans(slices, circumference, min_span)
-    return [] if slices.empty?
-
-    total = slices.sum(0.to_d) { |value, _| value }
-    shares = slices.map { |value, _| (value / total).to_f }
-    lifted = []
-    loop do
-      short = ring_short_spans(shares, lifted, circumference, min_span)
-      break if short.empty?
-
-      lifted.concat(short)
+      spans[index] = [(slices[index][0] / total).to_f * circumference, min_span].max
+      used += spans[index]
     end
-    return Array.new(shares.size, circumference / shares.size) if lifted.size == shares.size
 
-    spare, weight = ring_spare(shares, lifted, circumference, min_span)
-    shares.each_index.map { |i| lifted.include?(i) ? min_span : (shares[i] / weight) * spare }
-  end
-
-  # Which of the slices not yet lifted cannot pay for their own minimum out of what is left.
-  def ring_short_spans(shares, lifted, circumference, min_span)
-    spare, weight = ring_spare(shares, lifted, circumference, min_span)
-    shares.each_index.reject { |i| lifted.include?(i) }
-          .select { |i| (shares[i] / weight) * spare < min_span }
-  end
-
-  # What the slices still paying their own way have to share, and what they are worth between them.
-  def ring_spare(shares, lifted, circumference, min_span)
-    [circumference - (lifted.size * min_span),
-     shares.each_with_index.sum { |share, i| lifted.include?(i) ? 0.0 : share }]
+    scale = circumference / used
+    spans.keys.sort.map { |index| [slices[index], spans[index] * scale] }
   end
 
   # The slices drawn, as one dashed circle each — [value, color, label], clockwise in the order
@@ -535,15 +514,15 @@ module TrackerHelper
   # quarter turn into its first offset instead. Offsets run negative because a negative offset is
   # what walks a dash forward.
   def dashed_ring(slices, circumference:, min_span:, start: 0.0)
-    spans = ring_spans(slices, circumference, min_span)
     walked = start
 
-    slices.each_with_index.map do |(_, color, label), index|
-      length = spans[index] - min_span
+    ring_places(slices, circumference, min_span).map do |(_, color, label), span|
+      # A squeezed dot can come out under the minimum; it still draws, as the two round caps meeting.
+      length = [span - min_span, 0.0].max
       arc = { color: ensure_contrast(color.presence || NEUTRAL_COLOR), label: label,
               dash: "#{length.round(2)} #{(circumference - length).round(2)}",
               offset: -(walked + (min_span / 2)).round(2) }
-      walked += spans[index]
+      walked += span
       arc
     end
   end

--- a/test/helpers/tracker_helper_test.rb
+++ b/test/helpers/tracker_helper_test.rb
@@ -65,23 +65,28 @@ class TrackerHelperTest < ActionView::TestCase
                            usd_price: value, usd_value: value, synced_at: Time.current)
   end
 
-  # The share of the RING the slice was given — its own share of the portfolio, unless it was too
-  # small to draw and had to be lifted.
-  def arc_share(arc)
-    visible, rest = arc[:dash].split.map(&:to_f)
-    (visible + TrackerHelper::ICON_MIN_SPAN) / (visible + rest)
-  end
-
   # Where the slice's span begins, as a fraction of the ring clockwise from twelve o'clock.
   def arc_start(arc)
     ((-arc[:offset] - (TrackerHelper::ICON_MIN_SPAN / 2)) / TrackerHelper::ICON_CIRCUMFERENCE) + 0.25
   end
 
+  # The share of the RING each slice was laid out in — read off where the next one starts, which is
+  # the only place the span is stated. They close the ring by construction, so they always sum to 1.
+  def arc_shares(arcs)
+    starts = arcs.map { |arc| arc_start(arc) }
+    (starts + [1.0]).each_cons(2).map { |from, to| to - from }
+  end
+
+  # How many of the slices were too small for an arc and came out as the two round caps meeting.
+  def dots(arcs)
+    arcs.count { |arc| arc[:dash].split.first.to_f.zero? }
+  end
+
   # What survives the fold, as [percent, colour] — the composition, before any of it is drawn.
   def icon_shares(pairs)
-    slices = icon_slices(pairs.map { |value, color| [value.to_d, color] })
-    total = slices.sum(0.to_d) { |value, _| value }
-    slices.map { |value, color| [(value / total * 100).round(1).to_f, color] }
+    slices = ring_slices(pairs.map { |value, color| [value.to_d, color, nil] }, nil)
+    total = slices.sum(0.to_d) { |value, _, _| value }
+    slices.map { |value, color, _| [(value / total * 100).round(1).to_f, color] }
   end
 
   test 'nothing to divide, no arcs: the icon stays a plain circle' do
@@ -102,8 +107,8 @@ class TrackerHelperTest < ActionView::TestCase
     arcs = allocation_icon_arcs(user)
 
     assert_equal([ensure_contrast('#F7931A'), ensure_contrast('#627EEA')], arcs.map { |arc| arc[:color] })
-    assert_in_delta 0.75, arc_share(arcs.first), 0.001
-    assert_in_delta 0.25, arc_share(arcs.last), 0.001
+    assert_in_delta 0.75, arc_shares(arcs).first, 0.001
+    assert_in_delta 0.25, arc_shares(arcs).last, 0.001
     # Clockwise from twelve o'clock, each span starting exactly where the one before it ended.
     assert_in_delta 0.0, arc_start(arcs.first), 0.001
     assert_in_delta 0.75, arc_start(arcs.last), 0.001
@@ -139,34 +144,63 @@ class TrackerHelperTest < ActionView::TestCase
 
   # == what is drawn, and what is gathered ==
   #
-  # The ring keeps its gaps and its smallest dot before it keeps the last percent of the reading, so
-  # a holding worth less than a slice is drawn slightly large and the rest give up the difference.
-  test 'a holding too small to draw at its own size is lifted to the smallest slice' do
+  # The pieces are the card's pieces. How many of them a 24px ring has room for is the layout's
+  # business: they are placed largest first, each in the span its share deserves and never under the
+  # smallest slice, until the ring is full — then one more, and they all give up the same fraction of
+  # themselves to fit it.
+
+  test 'a holding too small to draw at its own size is given the smallest slice' do
     arcs = icon_arcs([[96, '#4C6B4C'], [4, '#1652F0']].map { |value, color| [value.to_d, color] })
 
     assert_equal 2, arcs.size
     # No dash left at all: what is drawn is the two round caps meeting, a dot as wide as the stroke.
     assert_equal '0.0', arcs.last[:dash].split.first
-    assert_in_delta TrackerHelper::ICON_MIN_SPAN / TrackerHelper::ICON_CIRCUMFERENCE,
-                    arc_share(arcs.last), 0.001
-    # And the ring still closes: what the dot was given, the holding above it gave up.
-    assert_in_delta 1.0, arcs.sum { |arc| arc_share(arc) }, 0.001
+    # It cost the holding above it a twentieth of its arc, and the ring still closes.
+    assert_in_delta 0.069, arc_shares(arcs).last, 0.002
+    assert_in_delta 1.0, arc_shares(arcs).sum, 0.001
   end
 
-  test 'every gap is the whole gap, whatever the portfolio' do
+  # The dots are what run the ring out of room, and the holdings behind them are not drawn. What is
+  # drawn keeps the share it really has — the space the dots borrow is exactly the space the pieces
+  # that never got placed gave up, so no arc has to be inflated to close the ring.
+  test 'the ring stops where it runs out, and the arcs keep their true share' do
     arcs = icon_arcs(([[80, '#4C6B4C']] + Array.new(6) { [3.33, '#1652F0'] })
                      .map { |value, color| [value.to_d, color] })
+    shares = arc_shares(arcs)
 
-    assert_equal 7, arcs.size
-    starts = arcs.map { |arc| arc_start(arc) } + [1.0]
-    spans = starts.each_cons(2).map { |from, to| (to - from) * TrackerHelper::ICON_CIRCUMFERENCE }
-
-    spans.each { |span| assert_operator span, :>=, TrackerHelper::ICON_MIN_SPAN - 0.001 }
+    assert_equal 4, arcs.size, 'three dots is all the ring has room for beside an 80% holding'
+    assert_in_delta 0.80, shares.first, 0.01
+    assert_equal 3, dots(arcs)
+    assert_in_delta 1.0, shares.sum, 0.001
   end
 
-  # What the icon used to get wrong: it dropped everything it could not draw, handed that share to
-  # the largest holding and drew the whole ring in one colour. The tail is gathered now — but it is
-  # only the tail, so the two small holdings the card shows keep their own colours here too.
+  # A ring with nothing to say about size says it by being full: every piece is under the smallest
+  # slice, so every piece is a dot, and one more is placed than fits so the ring reads as truncated.
+  test 'more holdings than the ring can hold: the smallest are not drawn' do
+    arcs = icon_arcs(Array.new(40) { [2.5.to_d, '#F7931A'] })
+
+    assert_equal 15, arcs.size
+    assert_equal 15, dots(arcs)
+    assert_in_delta 1.0, arc_shares(arcs).sum, 0.001
+  end
+
+  # A holding can be so much smaller than the one above it that the big one's share rounds to the
+  # whole ring. The next piece still gets placed — the ring is judged full before a piece is laid
+  # down, never after, so no piece is ever squeezed out by the rounding of the one before it.
+  test 'a holding too small to round keeps its dot' do
+    arcs = icon_arcs([[1_000_000_000_000, '#4C6B4C'], [0.00000001, '#1652F0']]
+                     .map { |value, color| [value.to_d, color] })
+
+    assert_equal 2, arcs.size
+    assert_equal 1, dots(arcs)
+    assert_in_delta 1.0, arc_shares(arcs).sum, 0.001
+  end
+
+  # == what is gathered ==
+  #
+  # The fold is the card's, exactly: the icon is that ring at 24px, and a menu that gathers a
+  # different tail from the page below it is a second opinion about the portfolio, from the one
+  # place a reader cannot hold it against anything.
   test 'only the tail is gathered, into one neutral slice, last' do
     user = create(:user)
     icon_balance(user, '#4C6B4C', 78)
@@ -183,57 +217,28 @@ class TrackerHelperTest < ActionView::TestCase
                                    Array.new(9) { [1.5, '#888888'] }).last.first
   end
 
-  test 'a tail worth less than one holding is dust, and is dropped' do
-    assert_equal [[100.0, '#F7931A']],
+  test 'a tail of dust is still gathered, and still drawn' do
+    assert_equal [[99.5, '#F7931A'], [0.5, TrackerHelper::NEUTRAL_COLOR]],
                  icon_shares([[99.5, '#F7931A'], [0.25, '#627EEA'], [0.25, '#26A17B']])
   end
 
-  # One holding is not an "other": there is nothing to gather it with, so it goes and the rest is
-  # the whole.
-  test 'a single holding below the threshold is dropped rather than named a remainder' do
-    assert_equal [[60.6, '#F7931A'], [39.4, '#627EEA']],
+  # One holding is not an "other": there is nothing to gather it with, and grey says a name is being
+  # withheld, so it keeps its own.
+  test 'a single holding below the threshold keeps its own colour' do
+    assert_equal [[60.0, '#F7931A'], [39.0, '#627EEA'], [1.0, '#26A17B']],
                  icon_shares([[60, '#F7931A'], [39, '#627EEA'], [1, '#26A17B']])
   end
 
-  # The gaps and the smallest dot are what cap the count. Past it the ring is a summary and says so
-  # by dropping, rather than sweeping a third of the portfolio into a remainder.
-  test 'more holdings than the ring can hold: the smallest go' do
-    arcs = icon_arcs(Array.new(40) { [2.5.to_d, '#F7931A'] })
-
-    assert_equal TrackerHelper::ICON_MAX_SLICES, arcs.size
-  end
-
-  # The remainder is not privileged: it queues by value with everything else. A ring already full of
-  # holdings that all outweigh it keeps them and says nothing about the rest.
-  test 'a remainder smaller than every holding on a full ring does not displace one' do
-    shares = icon_shares(Array.new(TrackerHelper::ICON_MAX_SLICES) { [7, '#F7931A'] } +
-                         Array.new(2) { [1, '#627EEA'] })
-
-    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
-    assert_equal ['#F7931A'], shares.map(&:last).uniq
-  end
-
-  test 'a remainder larger than the smallest holding on a full ring takes its place' do
-    shares = icon_shares(Array.new(TrackerHelper::ICON_MAX_SLICES) { [5, '#F7931A'] } +
-                         Array.new(30) { [1, '#627EEA'] })
-
-    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
-    assert_equal TrackerHelper::NEUTRAL_COLOR, shares.last.last
-  end
-
-  # With nothing above the threshold there is nothing for a tail to be "other" than, and one neutral
-  # ring is the icon for a portfolio nobody has synced. The largest are shown instead.
-  test 'with no holding above the threshold, the largest are shown' do
-    shares = icon_shares(Array.new(200) { [0.5, '#F7931A'] })
-
-    assert_equal TrackerHelper::ICON_MAX_SLICES, shares.size
-    assert_equal ['#F7931A'], shares.map(&:last).uniq
+  # With nothing above the threshold there is nothing for a tail to be "other" than — the whole
+  # portfolio is the tail, and one neutral ring is what the card draws for it too.
+  test 'with no holding above the threshold, the whole ring is the remainder' do
+    assert_equal [[100.0, TrackerHelper::NEUTRAL_COLOR]], icon_shares(Array.new(200) { [0.5, '#F7931A'] })
   end
 
   test 'every slice keeps its whole share: the spans meet, and they close the ring' do
     arcs = icon_arcs([[60, '#F7931A'], [25, '#627EEA'], [15, '#26A17B']].map { |value, color| [value.to_d, color] })
 
-    assert_in_delta 1.0, arcs.sum { |arc| arc_share(arc) }, 0.001
+    assert_in_delta 1.0, arc_shares(arcs).sum, 0.001
     assert_in_delta 0.6, arc_start(arcs[1]), 0.001
     assert_in_delta 0.85, arc_start(arcs[2]), 0.001
   end
@@ -265,12 +270,14 @@ class TrackerHelperTest < ActionView::TestCase
     assert_equal ensure_contrast(TrackerHelper::NEUTRAL_COLOR), arcs.last[:color]
     # Nothing left to draw but the two round caps meeting: a dot as wide as the stroke.
     assert_equal '0.0', arcs.last[:dash].split.first
-    # The ring still closes, and every span keeps its whole gap.
+    # The ring still closes, and the dot still has a gap either side of it. Making room for a piece
+    # too small to pay for itself costs every piece the same fraction, so a squeezed slice comes out
+    # just under the minimum — here the gap gives up a fiftieth of its width.
     starts = arcs.map { |arc| -arc[:offset] - (TrackerHelper::RING_MIN_SPAN / 2) }
     spans = (starts + [TrackerHelper::RING_CIRCUMFERENCE]).each_cons(2).map { |from, to| to - from }
 
     assert_in_delta 0.0, starts.first, 0.01
-    # The offsets ship rounded to two decimals, so a span may miss its minimum by that much.
-    spans.each { |span| assert_operator span, :>=, TrackerHelper::RING_MIN_SPAN - 0.01 }
+    assert_in_delta TrackerHelper::RING_CIRCUMFERENCE, spans.sum, 0.01
+    spans.each { |span| assert_operator span, :>=, TrackerHelper::RING_STROKE + (TrackerHelper::RING_GAP * 0.97) }
   end
 end


### PR DESCRIPTION
## The problem

Every piece of the allocation ring is guaranteed a gap and a round cap before it draws any arc at all, so that a holding too small for an arc of its own still appears as a dot rather than as nothing. That guarantee had no ceiling. The minimums are paid for out of the same circumference every piece is competing for, so a portfolio with a long tail handed each of its holdings the minimum and the largest holdings paid for all of them.

At 24px the ring is 56 units around and the minimum slice is 4, so fourteen pieces spend the entire circumference on gaps and caps with nothing left for any arc. A portfolio of a 23% holding, a 21% holding and a tail then drew as fourteen identical dots — the icon stated that every holding was the same size, which was the one thing it was there to deny.

## What changed

Pieces are placed largest first, each in the span its share deserves and never under the smallest slice, until the ring is full — and then one more, so a ring that has run out of room shows that it has rather than stopping on a tidy edge. Whatever was never placed is not drawn.

The placed spans overrun the circumference by exactly what the smallest of them were lifted by, so they all give up the same fraction of themselves at the end. That is the whole of the fit, and it is what makes it honest: an arc keeps its true share of the portfolio, a dot keeps the room it needs to be a dot, and the holdings that would have levelled the ring are simply not on it. Nothing has to be renormalised, so no arc is inflated to close the ring.

On a long-tailed portfolio the icon goes from fourteen pieces, twelve of them dots, to nine pieces of which four are arcs — and the three largest now read within a tenth of a percent of their true share, where before they read 7%.

The menu icon and the holdings card also share one rule now for what the pieces even are. The icon used to fold, cap and drop on its own terms, which is how it came to show a different portfolio from the card it is meant to be a small copy of. It takes the card's pieces and lets the layout decide how many fit.

## What this changes for the card ring

Nothing, in every case its own tests describe. None of its pieces is ever lifted, so nothing overruns, the scale is 1, and it draws exactly what it drew before. The one case it can reach is a folded remainder small enough to need lifting — there the gap gives up a fiftieth of its width to make room, which the test now states.

Three icon behaviours move to match the card, all of them in the direction of the two agreeing:

- a tail of dust is gathered and drawn as a neutral dot instead of being dropped
- a single holding below the threshold keeps its own colour instead of being dropped
- a portfolio with nothing above the threshold is one neutral ring, as the card already draws it

## Notes

`ring_spans`, `ring_short_spans` and `ring_spare` are gone, replaced by one `ring_places`. `ICON_MAX_SLICES` is gone too — how many holdings fit is a property of the geometry, not a constant to be picked.

The ring is judged full before a piece is laid down rather than after, so that a dominant share which rounds to the whole circumference in floating point cannot take the next piece's place with it. There is a test for it.

Also carries an unrelated one-line colour tweak: `--grass` darkened a notch.
