### PR TITLE
Withdrawal wizard starts on the exchange; dashboard hover date; sticky header fix

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -232,6 +232,15 @@ ol, ul
     // The number is set at 8.2rem in a 7rem line box and pulled a further 1rem down: it is MEANT
     // to sit on the line and be cropped by it, which is what this box keeps doing now that the
     // section itself has to let the curve out.
+    // The day under the pointer, just below the zero line and flush with the figure it dates.
+    &__date
+        position: absolute
+        top: calc(var(--dash-height) + 1rem)
+        right: 0
+        color: var(--concrete)
+        font-size: 1.5rem
+        line-height: 1
+        pointer-events: none
     &__figure
         display: flex
         flex-direction: column

--- a/app/assets/stylesheets/new/_rules.sass
+++ b/app/assets/stylesheets/new/_rules.sass
@@ -17,7 +17,7 @@
     display: grid
     grid-template-columns: 1fr
     gap: 1rem
-    @media (min-width: 768px)
+    @media (min-width: 1024px)
         grid-template-columns: 1fr 1fr
 
 .rules-list
@@ -51,11 +51,8 @@
             font-weight: 600 !important    // color: var(--ash) !important
             &:disabled,&[disabled],&--disabled
                 color: var(--stone) !important
-        .sbutton--exchange
-            background: none !important
-            margin: 0 !important
-            padding: 0 !important
-            box-shadow: none !important
+        .rule__exchange
+            color: var(--link) !important
     &--inactive
         box-shadow: none
         background: none
@@ -65,7 +62,3 @@
             color: var(--label-select-inactive) !important
         .sinput
             background: var(--silver)
-    .sbutton--exchange
-        background: none !important
-        box-shadow: none !important
-        padding:    0 !important

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -310,7 +310,10 @@ $stack-open: 0.2s ease-out
         position: relative
         &--fits
             overflow: visible
+        // Opaque only while pinned: a box painted on the widget's own top edge would square off
+        // its rounded corners, and there is nothing under the header to cover until then.
         &--stuck thead
+            background-color: var(--washed)
             box-shadow: 0 1px var(--silver)
         .table-fit__sentinel
             position: absolute
@@ -331,7 +334,6 @@ $stack-open: 0.2s ease-out
         thead
             position: sticky
             top: 0
-            background-color: var(--washed)
             line-height: 1.5rem
 
             z-index: 1

--- a/app/assets/stylesheets/new2/_colors.sass
+++ b/app/assets/stylesheets/new2/_colors.sass
@@ -22,7 +22,7 @@
         --ash: #90aed7
         --stone: #517095
         --concrete: #4F6991
-        --steel: #C5CFD8
+        --steel: #1a395e
         --silver: #E2E6EB
         --paper: #001933
         --washed: #FFFFFF

--- a/app/controllers/rules/withdrawals/add_addresses_controller.rb
+++ b/app/controllers/rules/withdrawals/add_addresses_controller.rb
@@ -6,10 +6,10 @@ class Rules::Withdrawals::AddAddressesController < ApplicationController
     @asset = Asset.find_by(id: @rule_config['asset_id'])
     @exchange = Exchange.find_by(id: @rule_config['exchange_id'])
 
-    if @asset.blank?
-      redirect_to new_rules_withdrawals_pick_asset_path
-    elsif @exchange.blank?
+    if @exchange.blank?
       redirect_to new_rules_withdrawals_pick_exchange_path
+    elsif @asset.blank?
+      redirect_to new_rules_withdrawals_pick_asset_path
     else
       result = auto_select_withdrawal_address
       case result

--- a/app/controllers/rules/withdrawals/add_api_keys_controller.rb
+++ b/app/controllers/rules/withdrawals/add_api_keys_controller.rb
@@ -12,6 +12,10 @@ class Rules::Withdrawals::AddApiKeysController < ApplicationController
       redirect_to new_rules_withdrawals_pick_exchange_path
       return
     end
+    if @asset.blank?
+      redirect_to new_rules_withdrawals_pick_asset_path
+      return
+    end
     return if reject_retired_exchange(@exchange, fallback: new_rules_withdrawals_pick_exchange_path)
 
     if Rails.configuration.dry_run

--- a/app/controllers/rules/withdrawals/confirm_settings_controller.rb
+++ b/app/controllers/rules/withdrawals/confirm_settings_controller.rb
@@ -8,10 +8,10 @@ class Rules::Withdrawals::ConfirmSettingsController < ApplicationController
 
     @address = @rule_config['address']
 
-    if @asset.blank?
-      redirect_to new_rules_withdrawals_pick_asset_path
-    elsif @exchange.blank?
+    if @exchange.blank?
       redirect_to new_rules_withdrawals_pick_exchange_path
+    elsif @asset.blank?
+      redirect_to new_rules_withdrawals_pick_asset_path
     elsif @address.blank?
       redirect_to new_rules_withdrawals_add_address_path
     else

--- a/app/controllers/rules/withdrawals/pick_assets_controller.rb
+++ b/app/controllers/rules/withdrawals/pick_assets_controller.rb
@@ -4,11 +4,18 @@ class Rules::Withdrawals::PickAssetsController < ApplicationController
   include Bots::Searchable
 
   def new
-    session[:withdrawal_rule_config] = {}
-    # Build a temporary bot to reuse Searchable concern for asset search
-    @bot = current_user.bots.dca_single_asset.new
-    @assets = asset_search_results(@bot, search_params[:query], :base_asset)
-    nil if render_asset_page(bot: @bot, asset_field: :asset_id)
+    @rule_config = session[:withdrawal_rule_config] || {}
+    @exchange = Exchange.find_by(id: @rule_config['exchange_id'])
+
+    if @exchange.blank?
+      redirect_to new_rules_withdrawals_pick_exchange_path
+    else
+      # Build a temporary bot to reuse Searchable concern for asset search — carrying the
+      # exchange so the list is scoped to what this exchange actually trades.
+      @bot = current_user.bots.dca_single_asset.new(exchange: @exchange)
+      @assets = asset_search_results(@bot, search_params[:query], :base_asset)
+      nil if render_asset_page(bot: @bot, asset_field: :asset_id)
+    end
   end
 
   def create
@@ -16,8 +23,10 @@ class Rules::Withdrawals::PickAssetsController < ApplicationController
     if asset_id.present?
       session[:withdrawal_rule_config] ||= {}
       session[:withdrawal_rule_config]['asset_id'] = asset_id
-      session[:withdrawal_rule_config].delete('exchange_id')
-      redirect_to new_rules_withdrawals_pick_exchange_path
+      # A destination is listed per asset, so changing the asset invalidates whatever was
+      # picked for the previous one.
+      session[:withdrawal_rule_config].except!('address', 'address_name', 'address_tag', 'network')
+      redirect_to new_rules_withdrawals_add_api_key_path
     else
       redirect_to new_rules_withdrawals_pick_asset_path
     end

--- a/app/controllers/rules/withdrawals/pick_exchanges_controller.rb
+++ b/app/controllers/rules/withdrawals/pick_exchanges_controller.rb
@@ -4,31 +4,21 @@ class Rules::Withdrawals::PickExchangesController < ApplicationController
   include Bots::Searchable
 
   def new
-    @rule_config = session[:withdrawal_rule_config] || {}
-    @asset = Asset.find_by(id: @rule_config['asset_id'])
-
-    if @asset.blank?
-      redirect_to new_rules_withdrawals_pick_asset_path
-    else
-      # Build a temporary bot to reuse Searchable concern for exchange search
-      @bot = current_user.bots.dca_single_asset.new(base_asset_id: @asset.id)
-      @exchanges = exchange_search_results(@bot, search_params[:query]).select(&:supports_withdrawal?)
-    end
+    session[:withdrawal_rule_config] = {}
+    # A temporary bot, for the exchange list (and its stable-first order) the bot wizard draws.
+    @bot = current_user.bots.dca_single_asset.new
+    @exchanges = exchange_search_results(@bot, nil).select(&:supports_withdrawal?)
   end
 
   def create
     exchange_id = params.dig(:bots_dca_single_asset, :exchange_id)
     if exchange_id.present?
+      session[:withdrawal_rule_config] ||= {}
       session[:withdrawal_rule_config]['exchange_id'] = exchange_id
-      redirect_to new_rules_withdrawals_add_api_key_path
+      session[:withdrawal_rule_config].delete('asset_id')
+      redirect_to new_rules_withdrawals_pick_asset_path
     else
       redirect_to new_rules_withdrawals_pick_exchange_path
     end
-  end
-
-  private
-
-  def search_params
-    params.permit(:query)
   end
 end

--- a/app/javascript/controllers/pnl_spark_controller.js
+++ b/app/javascript/controllers/pnl_spark_controller.js
@@ -10,10 +10,12 @@ import { Controller } from "@hotwired/stimulus"
 // screen is a class on <html> (see pnl_format_controller.js), and the reader can flip it while
 // the pointer is still on the curve.
 export default class extends Controller {
-  static targets = ["curve", "dot", "figure", "percent", "amount"]
+  static targets = ["curve", "dot", "figure", "percent", "amount", "date"]
   static values = {
     percent: Array,
     profit: Array,
+    // One moment per column, in epoch seconds.
+    at: Array,
     // The ratio the top of the box is worth — the server's, not re-derived here, or the dot would
     // sit off the curve whenever the ten-percent floor is what set the scale.
     scale: Number,
@@ -56,12 +58,15 @@ export default class extends Controller {
     this.percentTarget.innerHTML = this.live[0]
     if (this.hasAmountTarget) this.amountTarget.innerHTML = this.live[1]
     this.dotTarget.hidden = true
+    this.dateTarget.hidden = true
   }
 
   #show(index, last) {
     const percent = this.percentValue[index]
     this.percentTarget.textContent = this.#percent(percent)
     if (this.hasAmountTarget) this.amountTarget.replaceChildren(...this.#money(this.profitValue[index]))
+    this.dateTarget.textContent = this.#date(this.atValue[index])
+    this.dateTarget.hidden = false
 
     // In the box's own percentages, so the dot rides the curve at any size: the viewBox is 100
     // units above the zero line and the same 100 below it.
@@ -111,6 +116,15 @@ export default class extends Controller {
     const row = document.createElement("div")
     row.append(...content)
     return row
+  }
+
+  // Written the way the bot chart writes its hovered day.
+  #date(seconds) {
+    return new Date(seconds * 1000).toLocaleDateString(document.documentElement.lang || "en", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
   }
 
   #percent(value) {

--- a/app/models/user/pnl_history.rb
+++ b/app/models/user/pnl_history.rb
@@ -23,7 +23,7 @@ class User::PnlHistory
   # past this, and every column is two floats in a data attribute.
   MAX_POINTS = 180
 
-  # { result: { percent:, profit_usd:, days: } | nil, loading: Boolean }, on the same three terms
+  # { result: { percent:, profit_usd:, at:, days: } | nil, loading: Boolean }, on the same three terms
   # as `User#global_pnl_snapshot`: ready, waiting on a cold cache, or nothing to draw.
   # `live:` lets a background job compute what a request may only read.
   def self.snapshot(user, live: false) = new(user, live: live).call
@@ -108,6 +108,7 @@ class User::PnlHistory
     cursors = Array.new(tracks.size, 0)
     percent = []
     profit = []
+    at_seconds = []
 
     columns.times do |i|
       # The last column is the last reading itself, not a fraction that lands a float's breadth
@@ -127,6 +128,7 @@ class User::PnlHistory
         invested += reading[2]
       end
 
+      at_seconds << at.to_i
       pnl = value - invested
       profit << pnl.to_f
       # A percentage of nothing is not zero percent, but a moment before any money went in has no
@@ -134,7 +136,7 @@ class User::PnlHistory
       percent << (invested.positive? ? (pnl / invested).to_f : 0.0)
     end
 
-    { percent: percent, profit_usd: profit, days: span / 1.day }
+    { percent: percent, profit_usd: profit, at: at_seconds, days: span / 1.day }
   end
 
   # One lookup per currency for the whole account, on the same terms as everything else here: a

--- a/app/views/bots/_global_pnl.html.erb
+++ b/app/views/bots/_global_pnl.html.erb
@@ -9,6 +9,7 @@
       # The money is left OUT while balances are hidden — the ratio is not a balance, the profit
       # is, and shipping it in an attribute for CSS to cover is how it leaks.
       pnl_spark_profit_value: (history[:profit_usd].to_json unless hide_balances),
+      pnl_spark_at_value: history[:at].to_json,
       pnl_spark_scale_value: spark[:scale],
       pnl_spark_rate_value: denomination.rate.to_f,
       pnl_spark_unit_value: denomination.unit,
@@ -22,6 +23,8 @@
   <% if global_pnl.present? %>
     <% if spark %>
       <%= render partial: 'bots/pnl_spark', locals: { spark: spark } %>
+      <%# The day the figure is being read at, under the zero line; only there while the pointer is. %>
+      <span class="dash-intro__date" data-pnl-spark-target="date" hidden></span>
     <% end %>
     <%# Switches every PnL on the page — this one and each bot tile — see pnl_format_controller.js.
         With balances hidden there is no second format to switch to, so the headline is a headline

--- a/app/views/rules/_rule_logs.html.erb
+++ b/app/views/rules/_rule_logs.html.erb
@@ -11,7 +11,7 @@
       <tbody>
         <% rule_logs.each do |log| %>
           <tr>
-            <td><%= l(log.created_at, format: :short) %></td>
+            <td class="table__when"><%= table_when(log.created_at, current_user.time_zone) %></td>
             <td><span class="rule-log-status rule-log-status--<%= log.status %>"><%= log.status %></span></td>
             <td class="table__sentence"><%= log.message %></td>
           </tr>

--- a/app/views/rules/_rule_tile.html.erb
+++ b/app/views/rules/_rule_tile.html.erb
@@ -28,10 +28,7 @@
           <span><%= t('rules.withdrawals.sentence.of') %></span>
           <%= tag.span rule.asset.symbol, class: "ticker", style: "background: #{ensure_contrast(rule.asset.color || "#8A9BA8")}", data: ticker_data(rule.asset) %>
           <span><%= t('rules.withdrawals.sentence.from') %></span>
-          <span class="sbutton sbutton--exchange sbutton--exchange--<%= rule.exchange.name_id %>">
-            <%= render "svg/exchange-#{rule.exchange.name_id}", title: rule.exchange.name %>
-            <span class="hide-on-mobile"><%= rule.exchange.name %></span>
-          </span>
+          <span class="rule__exchange"><%= rule.exchange.name %></span>
           <span><%= t('rules.withdrawals.sentence.to') %></span>
           <% has_address_details = rule.network.present? || rule.address_tag.present? %>
           <% display_name = rule.address_name.presence || rule.address %>

--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -4,7 +4,7 @@
     <p><%= t('rules.index.welcome.keep_coins_safe') %></p>
     <p><%= t('rules.index.welcome.create_first') %></p>
     <div style="margin-top: 2rem; transform: scale(1.5)">
-        <%= link_to new_rules_withdrawals_pick_asset_path, class: "sbutton sbutton--sky", data: { turbo_frame: "modal" } do %>
+        <%= link_to new_rules_withdrawals_pick_exchange_path, class: "sbutton sbutton--sky", data: { turbo_frame: "modal" } do %>
           <span class="d-none d-sm-inline"><%= t('button.add') %></span>
           <%= render partial: 'svg/24x24_plus' %>
         <% end %>
@@ -14,7 +14,7 @@
   <div class="page-head">
     <div></div>
     <div>
-      <%= link_to new_rules_withdrawals_pick_asset_path, class: "sbutton sbutton--sky", data: { turbo_frame: "modal" } do %>
+      <%= link_to new_rules_withdrawals_pick_exchange_path, class: "sbutton sbutton--sky", data: { turbo_frame: "modal" } do %>
         <span class="d-none d-sm-inline"><%= t('button.add') %></span>
         <%= render partial: 'svg/24x24_plus' %>
       <% end %>

--- a/app/views/rules/withdrawals/add_addresses/new.html.erb
+++ b/app/views/rules/withdrawals/add_addresses/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :address, steps: { pick_asset: 20, pick_exchange: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :address, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup">
       <%= t('rules.withdrawals.sentence.withdraw_all') %>

--- a/app/views/rules/withdrawals/add_api_keys/new.html.erb
+++ b/app/views/rules/withdrawals/add_api_keys/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :api, steps: { pick_asset: 20, pick_exchange: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :api, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup">
       <%= t('rules.withdrawals.sentence.withdraw_all') %>

--- a/app/views/rules/withdrawals/confirm_settings/new.html.erb
+++ b/app/views/rules/withdrawals/confirm_settings/new.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :settings, steps: { pick_asset: 20, pick_exchange: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :settings, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
 
       <%= form_with url: rules_withdrawals_confirm_settings_path, method: :post,
                     class: "bot-creation-preview",

--- a/app/views/rules/withdrawals/pick_assets/new.html.erb
+++ b/app/views/rules/withdrawals/pick_assets/new.html.erb
@@ -1,14 +1,21 @@
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :pick_asset, steps: { pick_asset: 20, pick_exchange: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :pick_asset, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup">
       <%= t('rules.withdrawals.sentence.withdraw_all') %>
+      100 <%= t('rules.withdrawals.sentence.of_the_amount') %>
+      <%= t('rules.withdrawals.sentence.of') %>
       <%= form_with url: new_rules_withdrawals_pick_asset_path, method: :get,
                     data: { controller: "form--submit-after-delay", turbo_frame: "asset-picker" },
                     class: "ticker active" do |f| %>
         <%= f.text_field :query, autofocus: true, autocomplete: "off", placeholder: "…",
                          data: { action: "input->form--submit-after-delay#submit" } %>
+      <% end %>
+      <%= t('rules.withdrawals.sentence.from') %>
+      <%= link_to new_rules_withdrawals_pick_exchange_path, data: { turbo_frame: "modal_content" }, class: "sbutton sbutton--exchange sbutton--exchange--#{@exchange.name_id}" do %>
+        <%= render "svg/exchange-#{@exchange.name_id}", title: @exchange.name %>
+        <span class="hide-on-mobile"><%= @exchange.name %></span>
       <% end %>
     </div>
 

--- a/app/views/rules/withdrawals/pick_exchanges/new.html.erb
+++ b/app/views/rules/withdrawals/pick_exchanges/new.html.erb
@@ -1,18 +1,10 @@
-<% asset_color = ensure_contrast(@asset.color || "#8A9BA8") %>
-
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :pick_exchange, steps: { pick_asset: 20, pick_exchange: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :pick_exchange, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup">
-      <%= t('rules.withdrawals.sentence.withdraw_all') %>
-      100 <%= t('rules.withdrawals.sentence.of_the_amount') %>
-      <%= t('rules.withdrawals.sentence.of') %>
-      <%= link_to @asset.symbol, new_rules_withdrawals_pick_asset_path, data: { turbo_frame: "modal_content", **ticker_data(@asset) }, class: "ticker", style: "background: #{asset_color}" %>
-      <%= t('rules.withdrawals.sentence.from') %>
-      <%= form_with url: new_rules_withdrawals_pick_exchange_path, method: :get, data: { controller: "form--submit-after-delay", turbo_frame: "exchange-picker" } do |f| %>
-        <%= f.text_field :query, autofocus: true, autocomplete: "off", placeholder: "…", data: { action: "input->form--submit-after-delay#submit" }, class: "conversational__input sinput" %>
-      <% end %>
+      <%# No search box: the tiles below are the input. %>
+      <%= t('rules.withdrawals.sentence.automate_withdrawals_from') %>
     </div>
 
     <%= render "bots/pick_exchanges/table",

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -373,6 +373,7 @@ bg:
                 description: 'Теглене на средства от борси'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Автоматизирай тегленията от'
                 withdraw_all: 'Изтегли'
                 from: 'от'
                 to: 'на'

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -380,6 +380,7 @@ cs:
                 description: 'Výběr prostředků z burz'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatizovat výběry z'
                 withdraw_all: 'Vybrat'
                 from: 'z'
                 to: 'na'

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -373,6 +373,7 @@ da:
                 description: 'Udbetal midler fra børser'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatisér udbetalinger fra'
                 withdraw_all: 'Udbetal'
                 from: 'fra'
                 to: 'til'

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -372,6 +372,7 @@ de:
                 description: 'Guthaben automatisch von Börsen auszahlen'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Auszahlungen automatisieren von'
                 withdraw_all: 'Auszahlen'
                 from: 'von'
                 to: 'an'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -373,6 +373,7 @@ el:
                 description: 'Ανάληψη κεφαλαίων από ανταλλακτήρια'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Αυτοματοποίηση αναλήψεων από'
                 withdraw_all: 'Ανάληψη'
                 from: 'από'
                 to: 'σε'

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -373,6 +373,7 @@ en:
                 description: 'Withdraw funds from exchanges'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automate withdrawals from'
                 withdraw_all: 'Withdraw'
                 from: 'from'
                 to: 'to'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -372,6 +372,7 @@ es:
                 description: 'Retirar fondos de los exchanges'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatizar retiros desde'
                 withdraw_all: 'Retirar'
                 from: 'de'
                 to: 'a'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -372,6 +372,7 @@ fr:
                 description: 'Retirer des fonds des plateformes d''échange'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatiser les retraits depuis'
                 withdraw_all: 'Retirer'
                 from: 'de'
                 to: 'vers'

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -372,6 +372,7 @@ it:
                 description: 'Preleva fondi dagli exchange'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatizza i prelievi da'
                 withdraw_all: 'Preleva'
                 from: 'da'
                 to: 'a'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -372,6 +372,7 @@ nl:
                 description: 'Geld opnemen van exchanges'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatiseer opnames van'
                 withdraw_all: 'Opnemen'
                 from: 'van'
                 to: 'naar'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -374,6 +374,7 @@ pl:
                 description: 'Wypłacaj środki z giełd'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatyzuj wypłaty z'
                 withdraw_all: 'Wypłać'
                 from: 'z'
                 to: 'na'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -371,6 +371,7 @@ pt:
                 description: 'Levantar fundos das corretoras'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatizar levantamentos de'
                 withdraw_all: 'Levantar'
                 from: 'de'
                 to: 'para'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -375,6 +375,7 @@ ru:
                 description: 'Выводить средства с бирж'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Автоматизировать выводы с'
                 withdraw_all: 'Вывести'
                 from: 'с'
                 to: 'на'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -380,6 +380,7 @@ sk:
                 description: 'Výber prostriedkov z búrz'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatizovať výbery z'
                 withdraw_all: 'Vybrať'
                 from: 'z'
                 to: 'na'

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -373,6 +373,7 @@ sv:
                 description: 'Ta ut medel från börser'
         withdrawals:
             sentence:
+                automate_withdrawals_from: 'Automatisera uttag från'
                 withdraw_all: 'Ta ut'
                 from: 'från'
                 to: 'till'

--- a/test/controllers/bots/index_pnl_spark_test.rb
+++ b/test/controllers/bots/index_pnl_spark_test.rb
@@ -88,6 +88,17 @@ class Bots::IndexPnlSparkTest < ActionDispatch::IntegrationTest
     assert_select '.dash-intro__spark svg[viewBox=?]', '0 0 100 200'
   end
 
+  # The day under the pointer is written below the zero line — and only while there is a pointer.
+  test 'the hovered day ships with the curve and its line starts hidden' do
+    now = Time.current
+    stub_history([[now - 1.day, 100, 100], [now, 125, 100]])
+
+    get bots_path
+
+    assert_select '#global-pnl[data-pnl-spark-at-value]'
+    assert_select '#global-pnl .dash-intro__date[data-pnl-spark-target=?][hidden]', 'date'
+  end
+
   test 'the headline still reads as it did, and the figures are the hover targets' do
     now = Time.current
     stub_history([[now - 1.day, 100, 100], [now, 125, 100]])

--- a/test/controllers/rules/withdrawals/address_allowlist_test.rb
+++ b/test/controllers/rules/withdrawals/address_allowlist_test.rb
@@ -26,8 +26,8 @@ class Rules::Withdrawals::AddressAllowlistTest < ActionDispatch::IntegrationTest
     # The address step reads the asset and exchange the earlier steps put in the session, so
     # they have to be walked rather than assumed — otherwise every request below is refused
     # for a missing asset and the assertions pass without exercising the allowlist at all.
-    post rules_withdrawals_pick_asset_path, params: { bots_dca_single_asset: { asset_id: @asset.id } }
     post rules_withdrawals_pick_exchange_path, params: { bots_dca_single_asset: { exchange_id: @exchange.id } }
+    post rules_withdrawals_pick_asset_path, params: { bots_dca_single_asset: { asset_id: @asset.id } }
 
     assert_equal @asset.id.to_s, session.dig('withdrawal_rule_config', 'asset_id').to_s
     assert_equal @exchange.id.to_s, session.dig('withdrawal_rule_config', 'exchange_id').to_s

--- a/test/integration/rules/withdrawal_creation_test.rb
+++ b/test/integration/rules/withdrawal_creation_test.rb
@@ -19,31 +19,53 @@ class Rules::WithdrawalCreationTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
-  # ---- Task 1: asset picker uses .ticker.active on the search form ----
+  # ---- The flow opens on the exchange, not the asset ----
+
+  test 'pick_exchange is the first step and renders the exchange grid' do
+    get new_rules_withdrawals_pick_exchange_path
+    assert_response :success
+
+    assert_match(/Automate withdrawals from/, response.body,
+                 'the opening step should ask which exchange to withdraw from')
+    assert_match(/exchange-grid__item/, response.body,
+                 'exchange picker should render the .exchange-grid__item cards')
+    assert_no_match(/exchange-picker__item--header/, response.body,
+                    'exchange picker should no longer render the old Maker/Taker header row')
+    assert_no_match(/name="query"/, response.body,
+                    'no search box on this step — the exchange is picked by clicking a tile')
+  end
+
+  test 'the asset step is unreachable before an exchange is picked' do
+    get new_rules_withdrawals_pick_asset_path
+    assert_redirected_to new_rules_withdrawals_pick_exchange_path
+  end
+
+  # ---- Asset picker uses .ticker.active on the search form ----
 
   test 'pick_asset step renders the search input as a .ticker.active form, not .sinput' do
-    get new_rules_withdrawals_pick_asset_path
+    # Drive the wizard via real HTTP so session is populated naturally —
+    # do not mutate session[] directly in integration tests.
+    get new_rules_withdrawals_pick_exchange_path
+    post rules_withdrawals_pick_exchange_path,
+         params: { bots_dca_single_asset: { exchange_id: @binance.id } }
+    follow_redirect!
     assert_response :success
+
     assert_match(/class="ticker active"/, response.body,
                  'asset picker should wrap the search form in class="ticker active"')
     assert_no_match(/conversational__input sinput/, response.body,
                     'asset picker should no longer carry .conversational__input.sinput on the input')
+    assert_match(/#{@binance.name}/, response.body,
+                 'asset picker should show the exchange already picked')
   end
 
-  # ---- Task 2: exchange picker swaps the list/header for the grid partial ----
-
-  test 'pick_exchange step renders the new exchange grid, not the old fees-header list' do
-    # Drive the wizard via real HTTP so session is populated naturally —
-    # do not mutate session[] directly in integration tests.
+  test 'picking the asset moves on to the API key step' do
+    get new_rules_withdrawals_pick_exchange_path
+    post rules_withdrawals_pick_exchange_path,
+         params: { bots_dca_single_asset: { exchange_id: @binance.id } }
     post rules_withdrawals_pick_asset_path,
          params: { bots_dca_single_asset: { asset_id: @bitcoin.id } }
-    follow_redirect!
-    assert_response :success
-
-    assert_match(/exchange-grid__item/, response.body,
-                 'exchange picker should render the new .exchange-grid__item cards')
-    assert_no_match(/exchange-picker__item--header/, response.body,
-                    'exchange picker should no longer render the old Maker/Taker header row')
+    assert_redirected_to new_rules_withdrawals_add_api_key_path
   end
 
   # ---- SVG coverage — load-bearing assumption of the grid partial ----

--- a/test/integration/rules/withdrawal_tile_test.rb
+++ b/test/integration/rules/withdrawal_tile_test.rb
@@ -22,6 +22,18 @@ class Rules::WithdrawalTileTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  test 'log history uses the shared table date format' do
+    @user.update!(time_zone: 'UTC')
+    @rule.rule_logs.create!(status: :success, message: 'Withdrew 1.0 BTC',
+                            created_at: Time.utc(2026, 3, 4, 15, 19))
+    Exchanges::Binance.any_instance.stubs(:set_client)
+    Exchanges::Binance.any_instance.stubs(:list_withdrawal_addresses).returns(nil)
+
+    get rules_path
+    assert_response :ok
+    assert_select 'td.table__when', %r{2026/03/04}
+  end
+
   test 'scheduled rule has disabled inputs' do
     @rule.update!(status: :scheduled)
     Exchanges::Binance.any_instance.stubs(:set_client)

--- a/test/models/user/pnl_history_test.rb
+++ b/test/models/user/pnl_history_test.rb
@@ -46,6 +46,18 @@ class User::PnlHistoryTest < ActiveSupport::TestCase
     assert_equal([0.0, 0.0, 10.0, -10.0], history[:profit_usd].map { |value| value.round(6) })
   end
 
+  # Each column knows WHEN it is, so a hover can name the day: the last one is the last reading
+  # exactly, and the opening column sits one step before the first purchase.
+  test 'every column carries its moment' do
+    marked(Bots::DcaSingleAsset, [[@now - 2.days, 100, 100], [@now - 1.day, 110, 100], [@now, 90, 100]])
+    create(:dca_single_asset, user: @user)
+
+    history = User::PnlHistory.snapshot(@user)[:result]
+
+    assert_equal history[:percent].size, history[:at].size
+    assert_equal [(@now - 3.days).to_i, (@now - 2.days).to_i, (@now - 1.day).to_i, @now.to_i], history[:at]
+  end
+
   # The marked series carries the market between purchases, so a bot with no reading in a column
   # is not flat by accident — it is flat because that is what it was last worth.
   test 'a bot with no reading in a column keeps its last one, and the bots are summed' do


### PR DESCRIPTION
## Withdrawal wizard starts on the exchange

- The first step is the exchange, picked by clicking one of its tiles — there is no search box on that step.
- The asset step comes second and lists only what the chosen exchange trades; the exchange sits in the sentence as a link back.
- Every later step redirects to whichever of exchange/asset is missing, in that order.
- Changing the asset drops any destination picked for the previous one, since addresses are listed per asset.
- Progress bar and entry links updated; `automate_withdrawals_from` added to all locales.

## Rule tile

- The exchange in a rule's sentence is plain linked text instead of a button.
- Log history uses the shared table date format (`table_when`).
- Rules grid goes two-up at 1024px instead of 768px.
- Dark theme `--steel` darkened to sit on the dark paper.

## Dashboard curve names the hovered day

- `User::PnlHistory` columns now carry their moment (`at:`, epoch seconds).
- Hovering the `/bots` headline curve writes that day under the zero line, beneath the figure; hidden until the pointer is on the curve. Same date format as the bot chart's hover.

## Sticky table header

- `.widget--table thead` is opaque only while pinned (`widget--table--stuck`, which `table-fit` already sets). Always-opaque, it squared off the widget's rounded top corners on tables that fit.

## Tests

- Exchange-first flow, asset step unreachable before an exchange, no search box on the exchange step, allowlist walk reordered.
- Rule log date format.
- Column moments on the history; the date target and its value on the page.

`bin/rails test`: 4869 runs, 0 failures.
