### PR TITLE
Convert a pair bot that holds an open order

### DIFF
--- a/app/jobs/bot/convert_dual_asset_bots_job.rb
+++ b/app/jobs/bot/convert_dual_asset_bots_job.rb
@@ -1,8 +1,8 @@
 # Finishes the pair-to-basket conversion the deploy-time migration could not.
 #
-# A bot that was executing, holding a live order, or running a tick when the migration ran is left
-# alone by design — and on an install nobody operates there is no one to drain job processing and
-# retry. So the conversion recurs until nothing is left, and stops costing anything once the last
+# A bot that was executing or running a tick when the migration ran is left alone by design — and
+# on an install nobody operates there is no one to drain job processing and retry. So the
+# conversion recurs until nothing is left, and stops costing anything once the last
 # pair bot is gone: one indexed count against `bots`.
 #
 # It also keeps running the two self-corrections a single pass cannot guarantee — undoing a stale

--- a/app/models/bot/dual_to_composition.rb
+++ b/app/models/bot/dual_to_composition.rb
@@ -17,9 +17,10 @@
 # release that deletes Bots::DcaDualAsset would then leave rows whose class is gone —
 # ActiveRecord::SubclassNotFound on instantiation, which takes the whole bot list down, not one bot.
 #
-# So quiescence is measured rather than assumed: solid_queue_processes carries a heartbeat, and no
-# live one means no worker. That converts a self-hosted install automatically at upgrade and still
-# defers on a rolling deploy where the previous container is still serving.
+# So quiescence is measured rather than assumed, from the queue's own execution tables: a bot with
+# a claimed, ready, or blocked job, or a scheduled one already due, is deferred; one whose only job
+# is scheduled for later is not. That converts a self-hosted install automatically at upgrade and
+# still defers on a rolling deploy where the previous container is still serving.
 #
 # The reading is taken per bot, inside that bot's own lock, so a worker that starts mid-run defers
 # every bot after it rather than none. It CANNOT rule out a worker starting between that reading
@@ -108,7 +109,10 @@ module Bot::DualToComposition
     return 'missing exchange' if row.exchange_id.blank?
     return 'executing' if row.status == Bot.statuses[:executing]
     return 'rebalance in flight' if (row.transient_data || {})['rebalance_pending'].present?
-    return 'live order' if Transaction.where(bot_id: row.id).waiting.exists?
+    # An open order is NOT a reason to wait. It is a limit bot's resting state — polled by bot_id at
+    # the start of every tick (Bot::LimitOrderable), tracked by a job that carries the Transaction's
+    # GlobalID, not the bot's — and nothing here touches transactions. A discount-limit bot may hold
+    # one for months; refusing it would never convert such a bot at all.
     return 'job in flight' if busy_job?(row.id)
     return 'missing asset rows' unless Asset.where(id: [base0, base1, quote]).count == 3
 

--- a/db/migrate/20260828095813_migrate_dual_asset_bots_to_multi_asset.rb
+++ b/db/migrate/20260828095813_migrate_dual_asset_bots_to_multi_asset.rb
@@ -13,7 +13,7 @@ class MigrateDualAssetBotsToMultiAsset < ActiveRecord::Migration[8.1]
     skipped.each { |id, reason| say "Skipped bot #{id}: #{reason}", true }
     return if skipped.empty?
 
-    # A bot mid-order or mid-tick is left alone on purpose. Bot::ConvertDualAssetBotsJob picks it
+    # A bot mid-tick is left alone on purpose. Bot::ConvertDualAssetBotsJob picks it
     # up on its next pass, so this needs no operator — the message is for anyone watching a deploy.
     say "#{skipped.size} bot(s) still on the old shape; they convert on a later pass."
     say 'To convert them now, with bot job processing drained: bin/rails bots:migrate_dual_to_multi'

--- a/test/models/bot/dual_to_composition_test.rb
+++ b/test/models/bot/dual_to_composition_test.rb
@@ -191,14 +191,17 @@ class Bot::DualToCompositionTest < ActiveSupport::TestCase
     assert_includes skipped.map(&:last), 'rebalance in flight'
   end
 
-  test 'a bot with an order still live on a venue is left alone' do
-    create(:transaction, bot: @bot, status: :submitted, external_status: :open)
+  # A standing limit order is a limit bot's resting state, not money in flight: it is polled by
+  # bot_id at the start of every cycle (Bot::LimitOrderable), so it carries over the flip untouched
+  # and the basket picks it up. Refusing it would never convert a limit-discount bot at all.
+  test 'a bot with an order still open on a venue converts and keeps the order' do
+    order = create(:transaction, bot: @bot, status: :submitted, external_status: :open)
     _, skipped = run!
 
-    # The reason matters: without it this passes just as well when the bot was skipped for a stray
-    # metrics job instead.
-    assert_equal 'Bots::DcaDualAsset', Bot.where(id: @bot.id).pick(:type)
-    assert_includes skipped.map(&:last), 'live order'
+    assert_empty skipped
+    assert_equal 'Bots::DcaMultiAsset', Bot.find(@bot.id).type
+    assert Bot.find(@bot.id).transactions.waiting.exists?(order.id)
+    assert_equal %w[submitted open], order.reload.values_at(:status, :external_status)
   end
 
   test 'a settled order does not block conversion' do


### PR DESCRIPTION
## What

The pair-to-basket converter (`Bot::DualToComposition`) treated an open order as a reason to leave a bot alone. For a limit-order bot that is its resting state — the order placed at the last tick sits on the venue until it fills or the next tick polls it — so such a bot was never converted, and `Bot::ConvertDualAssetBotsJob` re-skipped it on every pass.

This removes that one rule. The other guards (an executing tick, a rebalance mid-flight, a claimed or due job) are unchanged.

## Why it is safe

- The conversion rewrites `bots.type`, `bots.settings`, and `bot_index_assets`, and repoints queued GlobalIDs. It never touches `transactions`.
- Open-order tracking is keyed by bot id and shared by both classes: `Bot::LimitOrderable` polls `transactions.waiting` at the start of every tick; `Bot::FetchAndUpdateOrderJob` carries the transaction's GlobalID, not the bot's, and resolves the bot afresh when it runs.
- `Bot::Composition::OrderSetter` reserves the unfilled remainder of waiting buys when sizing the next order, so an inherited open order cannot be bought twice — the pair setter had no such reservation.
- The carry window is untouched: the flip uses `update_columns`, so `settings_changed_at` does not move and a pre-flip order still draws down `missed_quote_amount` when it fills.

## Also

The module header claimed quiescence was measured from a worker heartbeat; it is read from the queue's execution tables. Comment corrected, along with two others that cited the removed rule.

## Tests

`test/models/bot/dual_to_composition_test.rb`: the "left alone" case becomes "converts and keeps the order" — the bot flips, the waiting row survives with its status intact. Full suite green.
