### PR TITLE
Seat the record's controls on one row

### DIFF
--- a/app/assets/stylesheets/new/_tracker.sass
+++ b/app/assets/stylesheets/new/_tracker.sass
@@ -227,42 +227,52 @@
         &__value
             display: none
 
-// ── the record: one bar, two panes ────────────────────────────────────────────────────────
+// ── the record: one bar over one table ────────────────────────────────────────────────────
 //
-// A grid rather than a flex bar over two blocks, because each pane owns BOTH its contextual filter
-// (up in the bar) and its table (below it) — that is what keeps the control and the rows it
-// filters inside one `order-filter` scope. The pane itself is `display: contents`, so its two
-// children drop straight into these areas.
+// A column of two lines — the controls, then the table — laid out as a WRAPPING ROW rather than a
+// flex column, because each pane owns BOTH its contextual filter (up in the bar) and its table
+// (below it): that is what keeps the control and the rows it filters inside one `order-filter`
+// scope, and it is why the pane is `display: contents` and cannot be a box of its own. `order`
+// gathers every control onto the first line and the table's full-width basis pushes it onto the
+// next. The controls need no breakpoint: the segmented ones fold into their dropdowns when the row
+// runs out of room, which is the only measure that knows what the labels in this locale cost.
 .tracker-record
-    display: grid
-    grid-template-columns: auto 1fr auto
-    grid-template-areas: "switch filters actions" "table table table"
+    display: flex
+    flex-wrap: wrap
     align-items: center
     gap: 1rem
-    &__switch
-        grid-area: switch
-    &__filters
-        grid-area: filters
+    &__switch, &__filters
+        order: 1
+    // The switch is two fixed labels and is never the thing in the way; the contextual filter
+    // beside it is, so that one keeps the greedy `flex: 1` every `.filters` gets — it takes the
+    // whole slack, and folds when the slack is not enough. Two greedy controls would split the
+    // line evenly and fold this one while the row still had room.
+    &__switch.filters
+        flex: none
+    // Two date fields are most of a phone's width, and the bar has a switch and a filter to seat
+    // first. The BOX goes, not the form inside it: an emptied box still takes a gap on the row.
     &__actions
-        grid-area: actions
-        display: flex
+        display: none
+        order: 2
         align-items: center
         gap: 1rem
-        justify-self: end
+        // Full size and hard against the right of the bar, even when nothing beside it grew.
+        flex: none
+        margin-left: auto
+        @media (min-width: 768px)
+            display: flex
     &__table
-        grid-area: table
+        order: 3
+        // A line of its own, and a DEFINITE width for it: the table inside is wider than the page
+        // and would otherwise size this row to its own content instead of scrolling within it.
+        flex: 1 0 100%
+        min-width: 0
     &__pane
         display: contents
     // `display: none` on a `display: contents` element does nothing — its children are what is in
     // the layout, so they are what has to go.
     &__pane--off > *
         display: none
-
-    @media (max-width: 767.9px)
-        grid-template-columns: 1fr auto
-        grid-template-areas: "switch actions" "filters filters" "table table"
-        &__actions
-            justify-self: end
 
 .tracker-row
     &__when
@@ -335,11 +345,9 @@
         opacity: 1
 
 .tracker-date-range
-    display: none
+    display: flex
     align-items: center
     gap: 0.5rem
-    @media (min-width: 768px)
-        display: flex
     input[type="date"]
         max-width: 17.5rem
         width: auto

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -322,11 +322,15 @@ $stack-open: 0.2s ease-out
             width: 1px
             visibility: hidden
             pointer-events: none
-        &--rules,&--tracker
+        // Guessing the page's width from the VIEWPORT's, because the grid this used to sit in
+        // sized its tracks to the table and gave the widget no width to be bounded by. Its flex
+        // parent does, so the tracker needs no guess — the rules table still lives in a layout
+        // that does not hand it one.
+        &--rules
             max-width: calc(100vw - 2rem)
             @media (min-width: 768px)
                 max-width: calc(100vw - 11rem)
-            
+
         table
             margin-bottom: 0
             border-collapse: collapse

--- a/app/views/tracker/_record.html.erb
+++ b/app/views/tracker/_record.html.erb
@@ -24,7 +24,7 @@
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.type'), options: type_filters %>
       <% end %>
     </div>
-    <div class="tracker-record__table widget widget--table widget--table--tracker" data-controller="table-fit">
+    <div class="tracker-record__table widget widget--table" data-controller="table-fit">
       <% if @account_transactions.any? %>
         <table class="table">
           <thead>
@@ -69,7 +69,7 @@
         <%= render 'shared/segmented', fluid: true, label: t('tracker.columns.status'), options: status_filters %>
       <% end %>
     </div>
-    <div class="tracker-record__table widget widget--table widget--table--tracker tracker-positions" data-controller="table-fit">
+    <div class="tracker-record__table widget widget--table tracker-positions" data-controller="table-fit">
       <% if @scoped_ledger.nil? %>
         <div class="loader--small" style="position: unset; margin: 2rem auto;"></div>
       <% else %>

--- a/test/integration/tracker_hide_balances_test.rb
+++ b/test/integration/tracker_hide_balances_test.rb
@@ -119,7 +119,7 @@ class TrackerHideBalancesTest < ActionDispatch::IntegrationTest
   # The money columns name their unit in the header — "Value $" — so a column is matched by the
   # label it starts with rather than by the whole cell.
   def column?(key)
-    css_select('.widget--table--tracker thead th')
+    css_select('.tracker-record__table thead th')
       .any? { |th| th.text.strip.start_with?(I18n.t("tracker.columns.#{key}")) }
   end
 end

--- a/test/integration/tracker_test.rb
+++ b/test/integration/tracker_test.rb
@@ -31,7 +31,7 @@ class TrackerTest < ActionDispatch::IntegrationTest
 
     get tracker_path
     assert_response :success
-    assert_select '.widget--table--tracker'
+    assert_select '.tracker-record__table'
     assert_select 'td', text: 'BTC'
   end
 


### PR DESCRIPTION
The record's bar — the Positions/Transactions switch, the contextual filter beside it and the date
range — was laid out as a grid whose `auto` tracks sized themselves to the table below. That left
the table widget with no width to be bounded by, so it carried a `max-width: calc(100vw - 11rem)`
guess at the page's width instead. Below 768px a media query dropped the filter onto a second row
and hid the date range outright.

It is a wrapping flex row now: `order` gathers the controls onto the first line and the table's
full-width basis pushes it onto the next.

- The controls need no breakpoint of their own. The segmented ones fold into their dropdowns when
  the row runs short, which is the only measure that knows what the labels in a given locale cost —
  the filter is a full track at a desktop width and a single chip by ~1050px.
- Only the contextual filter keeps the greedy `flex: 1` every `.filters` gets. Two greedy controls
  would split the line evenly and fold the filter while the row still had room for it.
- The table widget is bounded by its parent now, so the viewport guess goes, and with it the
  `widget--table--tracker` class that carried nothing else. The two tests that used that class as a
  hook point select on the layout class instead.
- The date range is still desktop-only, but it is the box that is hidden rather than the form inside
  it: an emptied box still took a gap on the row.

Verified in a browser at 1195 / 1050 / 820 / 760 / 400px, on both panes.
