### PR TITLE
Read indicators from a split-adjusted price history

### DIFF
--- a/app/models/clients/alpaca.rb
+++ b/app/models/clients/alpaca.rb
@@ -4,6 +4,7 @@ class Clients::Alpaca < Client
   TRADING_URL = 'https://api.alpaca.markets'.freeze
   PAPER_TRADING_URL = 'https://paper-api.alpaca.markets'.freeze
   DATA_URL = 'https://data.alpaca.markets'.freeze
+  MAX_BARS = 10_000
 
   def initialize(api_key: nil, api_secret: nil, paper: false)
     super()
@@ -195,12 +196,22 @@ class Clients::Alpaca < Client
   # @param timeframe [String] e.g., '1Day', '1Hour'
   # @param start_time [String] RFC 3339 timestamp
   # @param end_time [String] RFC 3339 timestamp
-  def get_bars(symbol:, timeframe:, start_time: nil, end_time: nil)
+  # `adjustment` is Alpaca's corporate-action basis: unset (its own default) means `raw`, the
+  # prices as they traded, which is what any series paired with an as-traded ledger quantity
+  # needs. `split` restates the whole history onto today's share basis, which is what an
+  # indicator wants — see Exchange#get_indicator_candles.
+  #
+  # ponytail: MAX_BARS is one page. Alpaca answers a longer range with the OLDEST page and a
+  # `next_page_token` nobody reads here, so without a limit a 20-year daily request came back
+  # ending in 2019. Every symbol Alpaca serves fits in one page today (its data begins in 2016,
+  # ~2700 daily bars); follow the token if a finer timeframe ever needs a deeper window.
+  def get_bars(symbol:, timeframe:, start_time: nil, end_time: nil, adjustment: nil)
     with_rescue do
       response = data_connection.get do |req|
         req.url "/v2/stocks/#{symbol}/bars"
         req.headers = authenticated_headers
-        req.params = { timeframe: timeframe, start: start_time, end: end_time }.compact
+        req.params = { timeframe: timeframe, start: start_time, end: end_time,
+                       adjustment: adjustment, limit: MAX_BARS }.compact
       end
       Result::Success.new(response.body)
     end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -197,6 +197,27 @@ class Exchange < ApplicationRecord
     raise NotImplementedError, "#{self.class.name} must implement get_candles"
   end
 
+  # Candles as an INDICATOR input: an RSI, a moving average, an all-time high. Nothing is paired
+  # against these, so they want the symbol's history restated onto today's share basis — otherwise
+  # a stock split leaves a 10x step in the middle of the series and the average, or the high, is
+  # computed across two different units.
+  #
+  # `get_candles` stays as-traded, because everything else multiplies a candle price by a ledger
+  # quantity and every ledger in this app is in as-traded units.
+  #
+  # Corporate actions only happen on stock venues, so for a crypto exchange this IS `get_candles`
+  # and none of their signatures change.
+  def get_indicator_candles(ticker:, start_at:, timeframe:)
+    get_candles(ticker: ticker, start_at: start_at, timeframe: timeframe)
+  end
+
+  # Does this venue rewrite the price history of this symbol behind us? True only where corporate
+  # actions apply, which is what makes an all-time high a running maximum on one venue and a value
+  # that can only be recomputed on another.
+  def restated_candles?(_ticker)
+    false
+  end
+
   def market_buy(ticker:, amount:, amount_type:)
     raise NotImplementedError, "#{self.class.name} must implement market_buy"
   end

--- a/app/models/exchanges/alpaca.rb
+++ b/app/models/exchanges/alpaca.rb
@@ -336,7 +336,20 @@ class Exchanges::Alpaca < Exchange
     Result::Success.new(price)
   end
 
-  def get_candles(ticker:, start_at:, timeframe:)
+  def get_indicator_candles(ticker:, start_at:, timeframe:)
+    get_candles(ticker: ticker, start_at: start_at, timeframe: timeframe, adjustment: 'split')
+  end
+
+  # A stock's history is restated by every split and the whole series moves; a crypto pair on the
+  # same venue has no corporate actions at all.
+  def restated_candles?(ticker)
+    !crypto_ticker?(ticker)
+  end
+
+  # `adjustment` is Alpaca's corporate-action basis and is deliberately nil by default — see
+  # Exchange#get_indicator_candles for which callers want which. It reaches the stock branch only:
+  # the crypto bars endpoint has no such parameter, and needs none.
+  def get_candles(ticker:, start_at:, timeframe:, adjustment: nil)
     alpaca_timeframes = {
       1.minute => '1Min',
       5.minutes => '5Min',
@@ -354,7 +367,8 @@ class Exchanges::Alpaca < Exchange
     result = if is_crypto
                market_data_client.get_crypto_bars(symbol: ticker.ticker, timeframe: tf, start_time: start_at.iso8601)
              else
-               market_data_client.get_bars(symbol: ticker.base, timeframe: tf, start_time: start_at.iso8601)
+               market_data_client.get_bars(symbol: ticker.base, timeframe: tf,
+                                           start_time: start_at.iso8601, adjustment: adjustment)
              end
     return result if result.failure?
 

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -75,6 +75,14 @@ class Ticker < ApplicationRecord
     exchange.get_candles(ticker: self, start_at: start_at, timeframe: timeframe)
   end
 
+  def get_indicator_candles(start_at:, timeframe:)
+    exchange.get_indicator_candles(ticker: self, start_at: start_at, timeframe: timeframe)
+  end
+
+  def restated_candles?
+    exchange.restated_candles?(self)
+  end
+
   def market_buy(amount:, amount_type:)
     exchange.market_buy(ticker: self, amount: amount, amount_type: amount_type)
   end

--- a/app/models/ticker/technically_analyzable.rb
+++ b/app/models/ticker/technically_analyzable.rb
@@ -9,7 +9,7 @@ module Ticker::TechnicallyAnalyzable
   ATH_SEED_FALLBACK_WINDOWS = [5.years, 2.years, 1.year, 90.days, 30.days, 7.days].freeze
 
   def get_rsi_value(timeframe:, period: 14)
-    cache_key = "exchange_ticker_#{id}_rsi_value_#{period}_#{timeframe}"
+    cache_key = "exchange_ticker_#{id}_rsi_value_v2_#{period}_#{timeframe}"
     expires_in = Utilities::Time.seconds_to_current_candle_close(timeframe)
     rsi_value = Rails.cache.fetch(cache_key, expires_in: expires_in) do
       # Although RSI only "needs" 15 candles the calculation actually accounts for previous gains/losses.
@@ -39,7 +39,7 @@ module Ticker::TechnicallyAnalyzable
   end
 
   def get_moving_average_value(timeframe:, period: 9, type: 'sma')
-    cache_key = "exchange_ticker_#{id}_moving_averages_values_#{period}_#{timeframe}"
+    cache_key = "exchange_ticker_#{id}_moving_averages_values_v2_#{period}_#{timeframe}"
     expires_in = Utilities::Time.seconds_to_current_candle_close(timeframe)
     ma_values = Rails.cache.fetch(cache_key, expires_in: expires_in) do
       # Although EMA only "needs" 21 candles the calculation actually accounts for previous gains/losses.
@@ -73,19 +73,28 @@ module Ticker::TechnicallyAnalyzable
         next result.data
       end
 
-      if ath_updated_at.present?
-        # Already seeded: ath is a running maximum, so we only need the window since the
-        # last update — never the full history again.
+      # A venue that restates its history (a stock split rewrites every bar) can never take the
+      # incremental path: the restated tail is entirely BELOW the stored high, so the maximum
+      # would carry a pre-split number — in units that no longer exist — forever. It re-walks the
+      # full history instead, which costs the same one request now that a whole history fits in
+      # a single page.
+      restated = restated_candles?
+      deep = false
+
+      if ath_updated_at.present? && !restated
+        # Already seeded on a history that cannot change: ath is a running maximum, so we only
+        # need the window since the last update — never the full history again.
         result = high_for_duration(Time.now.utc - ath_updated_at)
         return result if result.failure?
       else
-        # First computation: skip the deep walk entirely if we've already learned this
-        # ticker has no candle history (guarded to the unseeded path, so a persisted ath
-        # is never overwritten with nil).
-        next nil if ath_seed_known_empty?
+        # Skip the deep walk entirely if we've already learned this ticker has no candle history
+        # (guarded to the unseeded case, so a persisted ath is never overwritten with nil).
+        next nil if ath.blank? && ath_seed_known_empty?
 
         result = high_for_duration(Time.now.utc - 20.years.ago)
         return result if result.failure?
+
+        deep = result.data.present?
 
         if result.data.blank?
           ATH_SEED_FALLBACK_WINDOWS.each do |window|
@@ -100,14 +109,19 @@ module Ticker::TechnicallyAnalyzable
         end
 
         if result.data.blank?
-          mark_ath_seed_empty!
-          next nil
+          # An empty answer is not evidence the high is gone, so a ticker that already has one
+          # keeps it; only an unseeded ticker learns there is nothing to seed from.
+          mark_ath_seed_empty! if ath.blank?
+          next ath
         end
       end
 
-      # Incremental max: never downgrade a higher persisted ath (also guards the anomalous
-      # ath-without-ath_updated_at state when seeding from a shorter fallback window).
-      new_high = [ath, result.data].compact.max
+      # The full history REPLACES a restated ticker's high — nothing else can undo a split.
+      # Only the full walk may do so: a shorter fallback window would downgrade a good deep value
+      # to a shallow one. Everywhere else this is an incremental max that never downgrades a
+      # higher persisted ath (which also guards the anomalous ath-without-ath_updated_at state
+      # when seeding from a shorter fallback window).
+      new_high = restated && deep ? result.data : [ath, result.data].compact.max
       update!(ath: new_high, ath_updated_at: Time.now.utc) if new_high.present?
       new_high
     end
@@ -142,7 +156,7 @@ module Ticker::TechnicallyAnalyzable
   # was closed: the indicator-limit settings spinner never resolved and the gate check failed.
   def closed_candle_closes(timeframe:, lookback_multiplier:)
     since = Time.now.utc - ((lookback_multiplier * timeframe) + (2 * timeframe))
-    result = get_candles(start_at: since, timeframe: timeframe)
+    result = get_indicator_candles(start_at: since, timeframe: timeframe)
     return result if result.failure?
 
     candles = result.data
@@ -199,7 +213,7 @@ module Ticker::TechnicallyAnalyzable
   end
 
   def get_high(start_at, timeframe)
-    result = get_candles(
+    result = get_indicator_candles(
       start_at: start_at,
       timeframe: timeframe
     )
@@ -211,7 +225,7 @@ module Ticker::TechnicallyAnalyzable
   end
 
   def get_low(start_at, timeframe)
-    result = get_candles(
+    result = get_indicator_candles(
       start_at: start_at,
       timeframe: timeframe
     )

--- a/db/migrate/20260830120000_clear_restated_stock_aths.rb
+++ b/db/migrate/20260830120000_clear_restated_stock_aths.rb
@@ -1,0 +1,20 @@
+# `tickers.ath` is an incremental maximum, which only holds while a price history is immutable.
+# Alpaca's stock bars were fetched unadjusted, so every corporate action left a pre-split high
+# standing in units that no longer exist — and the same request was silently capped at Alpaca's
+# default page, so the seeded value came from a window that ended years ago either way.
+#
+# Nulling the column re-seeds it from the full, split-adjusted history on the next read. Crypto
+# tickers on the same venue are left alone: they have no corporate actions, and their stored
+# maximum is still a maximum.
+class ClearRestatedStockAths < ActiveRecord::Migration[8.1]
+  def up
+    Ticker.where.not(ath: nil)
+          .where(exchange: Exchange.where(type: 'Exchanges::Alpaca'))
+          .where.not(base_asset: Asset.where(category: 'Cryptocurrency'))
+          .update_all(ath: nil, ath_updated_at: nil)
+  end
+
+  def down
+    # Nothing to restore: the values were computed on a basis that no longer exists.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_29_132450) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_120000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false

--- a/test/migrations/clear_restated_stock_aths_test.rb
+++ b/test/migrations/clear_restated_stock_aths_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260830120000_clear_restated_stock_aths.rb')
+
+# A stock split rewrites every bar of a symbol's history, so an all-time high carried forward
+# across one is not a high — it is a number in units that no longer exist.
+class ClearRestatedStockAthsTest < ActiveSupport::TestCase
+  setup do
+    @alpaca = create(:alpaca_exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+  end
+
+  test 'an Alpaca stock ticker loses its high, and its update stamp with it' do
+    ticker = stock_ticker('KLAC', ath: 2411, ath_updated_at: 1.day.ago)
+
+    migrate!
+
+    ticker.reload
+    assert_nil ticker.ath
+    assert_nil ticker.ath_updated_at
+  end
+
+  test 'crypto on the same venue keeps its high' do
+    ticker = crypto_ticker('AAVE', exchange: @alpaca, ath: 300)
+
+    migrate!
+
+    assert_equal 300.to_d, ticker.reload.ath
+  end
+
+  test 'another venue is untouched' do
+    ticker = crypto_ticker('BTC', exchange: create(:binance_exchange), ath: 120_000)
+
+    migrate!
+
+    assert_equal 120_000.to_d, ticker.reload.ath
+  end
+
+  test 'a stock ticker that never seeded a high is left as it is' do
+    ticker = stock_ticker('AAPL', ath: nil, ath_updated_at: nil)
+
+    migrate!
+
+    assert_nil ticker.reload.ath
+  end
+
+  def stock_ticker(symbol, ath:, ath_updated_at:)
+    asset = create(:asset, external_id: symbol.downcase, symbol: symbol, category: 'Stock')
+    create(:ticker, exchange: @alpaca, base_asset: asset, quote_asset: @usd, ticker: symbol,
+                    ath: ath, ath_updated_at: ath_updated_at)
+  end
+
+  def crypto_ticker(symbol, exchange:, ath:)
+    asset = create(:asset, external_id: symbol.downcase, symbol: symbol, category: 'Cryptocurrency')
+    create(:ticker, exchange: exchange, base_asset: asset, quote_asset: @usd,
+                    ticker: "#{symbol}/USD", ath: ath, ath_updated_at: 1.day.ago)
+  end
+
+  def migrate!
+    ClearRestatedStockAths.new.tap { |m| m.verbose = false }.up
+  end
+end

--- a/test/models/clients/alpaca_test.rb
+++ b/test/models/clients/alpaca_test.rb
@@ -145,6 +145,32 @@ class Clients::AlpacaTest < ActiveSupport::TestCase
     assert_predicate result, :success?
   end
 
+  # Alpaca pages bars at 1000 by default and answers with the OLDEST page plus a
+  # `next_page_token` this client does not read — so an unbounded request for a long history
+  # silently returns a window that ends years ago. The maximum page size fits every symbol
+  # Alpaca serves (its data begins in 2016) in one request.
+  test 'get_bars asks for the largest page Alpaca will serve' do
+    params = capture_bars_params { @client.get_bars(symbol: 'AAPL', timeframe: '1Day') }
+
+    assert_equal 10_000, params[:limit]
+  end
+
+  # Corporate actions are opt-in: the endpoint defaults to `raw`, and the as-traded paths
+  # (the bot chart's valuation grid, the tax boundary prices) depend on that default.
+  test 'get_bars leaves the adjustment unset by default' do
+    params = capture_bars_params { @client.get_bars(symbol: 'AAPL', timeframe: '1Day') }
+
+    assert_not params.key?(:adjustment)
+  end
+
+  test 'get_bars sends the adjustment it was asked for' do
+    params = capture_bars_params do
+      @client.get_bars(symbol: 'AAPL', timeframe: '1Day', adjustment: 'split')
+    end
+
+    assert_equal 'split', params[:adjustment]
+  end
+
   test 'get_crypto_latest_quote returns success result' do
     mock_response = stub(body: { 'quotes' => { 'AAVE/USD' => { 'bp' => 99.5, 'ap' => 100.5 } } })
     connection = stub
@@ -277,6 +303,17 @@ class Clients::AlpacaTest < ActiveSupport::TestCase
   end
 
   private
+
+  def capture_bars_params
+    captured = {}
+    req = stub_request('/v2/stocks/AAPL/bars')
+    req.stubs(:params=).with { |params| captured.replace(params) || true }
+    connection = stub
+    connection.expects(:get).yields(req).returns(stub(body: { 'bars' => [] }))
+    @client.stubs(:data_connection).returns(connection)
+    yield
+    captured
+  end
 
   def stub_request(_url)
     req = stub

--- a/test/models/exchange_test.rb
+++ b/test/models/exchange_test.rb
@@ -54,4 +54,19 @@ class ExchangeTest < ActiveSupport::TestCase
 
     assert_nil coinbase.raise_on_invalid_key!(Result::Success.new({}))
   end
+
+  # Corporate actions only exist on stock venues, so for a crypto exchange the indicator series
+  # IS the as-traded series — no signature and no behaviour of its own.
+  test 'get_indicator_candles falls through to get_candles where nothing restates history' do
+    binance = create(:binance_exchange)
+    ticker = create(:ticker, exchange: binance)
+    candles = [[Time.now.utc, 1.to_d, 2.to_d, 0.5.to_d, 1.5.to_d, 10.to_d]]
+    binance.expects(:get_candles).with(ticker: ticker, start_at: anything, timeframe: 1.day)
+           .returns(Result::Success.new(candles))
+
+    result = binance.get_indicator_candles(ticker: ticker, start_at: 1.day.ago, timeframe: 1.day)
+
+    assert_equal candles, result.data
+    assert_not binance.restated_candles?(ticker)
+  end
 end

--- a/test/models/exchanges/alpaca_test.rb
+++ b/test/models/exchanges/alpaca_test.rb
@@ -342,6 +342,52 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
     assert_equal 1, result.data.size
   end
 
+  # == corporate-action basis ==
+  #
+  # A stock split rewrites the whole price history. An indicator reading that history has nothing
+  # paired against it and wants it restated onto today's share basis; a series that will be
+  # multiplied by an as-traded ledger quantity wants the prices as they traded.
+
+  test 'get_indicator_candles asks for split-adjusted bars for a stock ticker' do
+    ticker = stock_ticker
+    Clients::Alpaca.any_instance.expects(:get_bars).with do |params|
+      params[:symbol] == 'AAPL' && params[:adjustment] == 'split'
+    end.returns(Result::Success.new({ 'bars' => [] }))
+
+    assert_predicate @exchange.get_indicator_candles(ticker: ticker, start_at: 1.day.ago, timeframe: 1.day),
+                     :success?
+  end
+
+  test 'get_candles leaves a stock ticker on the as-traded basis' do
+    ticker = stock_ticker
+    Clients::Alpaca.any_instance.expects(:get_bars).with do |params|
+      params[:symbol] == 'AAPL' && params[:adjustment].nil?
+    end.returns(Result::Success.new({ 'bars' => [] }))
+
+    assert_predicate @exchange.get_candles(ticker: ticker, start_at: 1.day.ago, timeframe: 1.day), :success?
+  end
+
+  test 'get_indicator_candles for a crypto ticker is the ordinary crypto fetch' do
+    aave = Asset.find_by(external_id: 'aave') || create(:asset, external_id: 'aave', symbol: 'AAVE', category: 'Cryptocurrency')
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    ticker = create(:ticker, exchange: @exchange, base_asset: aave, quote_asset: usd, ticker: 'AAVE/USD')
+    Clients::Alpaca.any_instance.expects(:get_bars).never
+    Clients::Alpaca.any_instance.stubs(:get_crypto_bars)
+                   .returns(Result::Success.new({ 'bars' => { 'AAVE/USD' => [] } }))
+
+    assert_predicate @exchange.get_indicator_candles(ticker: ticker, start_at: 1.day.ago, timeframe: 1.day),
+                     :success?
+  end
+
+  test 'restated_candles? separates stocks from crypto on the same venue' do
+    aave = Asset.find_by(external_id: 'aave') || create(:asset, external_id: 'aave', symbol: 'AAVE', category: 'Cryptocurrency')
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    crypto = create(:ticker, exchange: @exchange, base_asset: aave, quote_asset: usd, ticker: 'AAVE/USD')
+
+    assert @exchange.restated_candles?(stock_ticker)
+    assert_not @exchange.restated_candles?(crypto)
+  end
+
   # == get_tickers_prices (bulk metrics pricing — partitions stock vs. crypto symbols) ==
 
   test 'get_tickers_prices routes crypto pair symbols to the crypto endpoint and merges with stock snapshots' do
@@ -717,5 +763,14 @@ class Exchanges::AlpacaTest < ActiveSupport::TestCase
 
   test 'invalid_key_error? ignores a failure that is not about credentials' do
     assert_not @exchange.invalid_key_error?(['insufficient buying power'])
+  end
+
+  private
+
+  def stock_ticker
+    aapl = Asset.find_by(symbol: 'AAPL') || create(:asset, external_id: 'aapl', symbol: 'AAPL', category: 'Stock')
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    Ticker.find_by(exchange: @exchange, base: 'AAPL') ||
+      create(:ticker, exchange: @exchange, base_asset: aapl, quote_asset: usd, ticker: 'AAPL')
   end
 end

--- a/test/models/ticker/technically_analyzable_test.rb
+++ b/test/models/ticker/technically_analyzable_test.rb
@@ -21,7 +21,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
   test 'seeds ATH from a shorter window when the deep fetch comes back empty' do
     cutoff = 100.days.ago
     candle = normalized_candle(high: 120)
-    @ticker.define_singleton_method(:get_candles) do |**kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**kw|
       Result::Success.new(kw[:start_at] >= cutoff ? [candle] : [])
     end
 
@@ -36,7 +36,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
 
   test 'propagates a failure from the deep fetch without trying shorter windows' do
     calls = 0
-    @ticker.define_singleton_method(:get_candles) do |**_kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**_kw|
       calls += 1
       Result::Failure.new('boom')
     end
@@ -52,7 +52,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
   test 'propagates a failure that occurs during a fallback window and does not seed' do
     # The deep + long windows are empty; a shorter fallback window errors. That failure must
     # propagate (not be swallowed by continuing the walk).
-    @ticker.define_singleton_method(:get_candles) do |**kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**kw|
       if kw[:start_at] >= 200.days.ago
         Result::Failure.new('boom')
       else
@@ -72,7 +72,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
     @ticker.update_columns(ath: 200, ath_updated_at: nil)
     cutoff = 100.days.ago
     candle = normalized_candle(high: 150)
-    @ticker.define_singleton_method(:get_candles) do |**kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**kw|
       Result::Success.new(kw[:start_at] >= cutoff ? [candle] : [])
     end
 
@@ -88,7 +88,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
     @ticker.update!(ath: 200, ath_updated_at: 2.days.ago)
     seen = []
     candle = normalized_candle(high: 150, at: Time.now.utc - 1.hour)
-    @ticker.define_singleton_method(:get_candles) do |**kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**kw|
       seen << kw[:start_at]
       Result::Success.new([candle])
     end
@@ -104,7 +104,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
   test 'suppresses the seed walk on subsequent ticks when every window is empty' do
     Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
     calls = 0
-    @ticker.define_singleton_method(:get_candles) do |**_kw|
+    @ticker.define_singleton_method(:get_indicator_candles) do |**_kw|
       calls += 1
       Result::Success.new([])
     end
@@ -135,7 +135,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
 
   test 'get_low_of_last returns the minimum candle low over a finite window' do
     candles = [normalized_candle_low(low: 95), normalized_candle_low(low: 88), normalized_candle_low(low: 92)]
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Success.new(candles) }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new(candles) }
 
     result = @ticker.get_low_of_last(duration: 24.hours)
 
@@ -144,13 +144,13 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
   end
 
   test 'get_low_of_last propagates a candle fetch failure' do
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Failure.new('boom') }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Failure.new('boom') }
 
     assert_predicate @ticker.get_low_of_last(duration: 24.hours), :failure?
   end
 
   test 'get_low_of_last returns nil data when there are no candles' do
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Success.new([]) }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new([]) }
 
     result = @ticker.get_low_of_last(duration: 24.hours)
     assert_predicate result, :success?
@@ -182,7 +182,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
     # Newest candle is a fully-closed session (its close time is in the past), as for a stock over
     # a weekend. It must be included, not dropped, and not rejected as stale.
     candles = daily_candles(RSI_CLOSES, last_at: Time.now.utc - 2.days)
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Success.new(candles) }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new(candles) }
 
     result = @ticker.get_rsi_value(timeframe: 1.day, period: 14)
 
@@ -197,7 +197,7 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
     # Newest candle is the current, in-progress period (close time in the future). It must be
     # dropped so the RSI reflects only closed candles.
     candles = daily_candles(RSI_CLOSES, last_at: Time.now.utc)
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Success.new(candles) }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new(candles) }
 
     result = @ticker.get_rsi_value(timeframe: 1.day, period: 14)
 
@@ -210,11 +210,84 @@ class Ticker::TechnicallyAnalyzableTest < ActiveSupport::TestCase
 
   test 'get_moving_average_value keeps the latest closed candle when the market is closed' do
     candles = daily_candles(RSI_CLOSES, last_at: Time.now.utc - 2.days)
-    @ticker.define_singleton_method(:get_candles) { |**_kw| Result::Success.new(candles) }
+    @ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new(candles) }
 
     result = @ticker.get_sma_value(timeframe: 1.day, period: 9)
 
     assert_predicate result, :success?
     assert_not_nil result.data
+  end
+
+  # ---- restated histories (stock splits) ----
+  #
+  # `ath` is an incremental maximum, which is only sound while history is immutable. A split
+  # restates every bar downward, so the stored high is not a high any more — it is a number in
+  # units that no longer exist, and no future candle can ever beat it. On a venue that restates,
+  # the column has to be recomputed from the full history and REPLACED.
+
+  def alpaca_stock_ticker
+    exchange = create(:alpaca_exchange)
+    aapl = Asset.find_by(symbol: 'AAPL') || create(:asset, external_id: 'aapl', symbol: 'AAPL', category: 'Stock')
+    usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    create(:ticker, exchange: exchange, base_asset: aapl, quote_asset: usd, ticker: 'AAPL')
+  end
+
+  test 'a restated ticker replaces its ATH when a split rewrites the history downward' do
+    ticker = alpaca_stock_ticker
+    ticker.update!(ath: 2411.to_d, ath_updated_at: 2.days.ago)
+    seen = []
+    candle = normalized_candle(high: 254)
+    ticker.define_singleton_method(:get_indicator_candles) do |**kw|
+      seen << kw[:start_at]
+      Result::Success.new([candle])
+    end
+
+    result = ticker.get_high_of_last(duration: Float::INFINITY.seconds)
+
+    assert_predicate result, :success?
+    assert_equal 254.to_d, result.data, 'a 10:1 split must not leave the pre-split high standing'
+    assert_operator seen.first, :<, 10.years.ago, 'a restated ticker must re-walk the full history'
+    ticker.reload
+    assert_equal 254.to_d, ticker.ath
+  end
+
+  test 'an immutable history still carries its ATH forward' do
+    @ticker.update!(ath: 200, ath_updated_at: 2.days.ago)
+    @ticker.define_singleton_method(:get_indicator_candles) do |**_kw|
+      Result::Success.new([[Time.now.utc - 1.hour, 100.to_d, 150.to_d, 90.to_d, 110.to_d, 50.to_d]])
+    end
+
+    result = @ticker.get_high_of_last(duration: Float::INFINITY.seconds)
+
+    assert_equal 200.to_d, result.data, 'crypto has no corporate actions — the running max stands'
+  end
+
+  test 'a restated ticker keeps its ATH rather than downgrading to a fallback window' do
+    ticker = alpaca_stock_ticker
+    ticker.update!(ath: 2411.to_d, ath_updated_at: 2.days.ago)
+    cutoff = 100.days.ago
+    candle = normalized_candle(high: 150)
+    ticker.define_singleton_method(:get_indicator_candles) do |**kw|
+      Result::Success.new(kw[:start_at] >= cutoff ? [candle] : [])
+    end
+
+    result = ticker.get_high_of_last(duration: Float::INFINITY.seconds)
+
+    assert_equal 2411.to_d, result.data, 'only the full history may replace the stored value'
+    ticker.reload
+    assert_equal 2411.to_d, ticker.ath
+  end
+
+  test 'a restated ticker keeps its ATH when every window comes back empty' do
+    ticker = alpaca_stock_ticker
+    ticker.update!(ath: 2411.to_d, ath_updated_at: 2.days.ago)
+    ticker.define_singleton_method(:get_indicator_candles) { |**_kw| Result::Success.new([]) }
+
+    result = ticker.get_high_of_last(duration: Float::INFINITY.seconds)
+
+    assert_predicate result, :success?
+    assert_equal 2411.to_d, result.data, 'an empty answer is not evidence the high is gone'
+    ticker.reload
+    assert_equal 2411.to_d, ticker.ath
   end
 end


### PR DESCRIPTION
## What was wrong

Alpaca's `/v2/stocks/{symbol}/bars` defaults to `adjustment=raw`, and the client never sent
anything else. A corporate action therefore left a step in the middle of every stock candle
series. A 10:1 split drops the close from 2411.64 to 254.54 between two sessions:

```
raw:   06-10=2135.64  06-11=2411.64  06-12=254.54  06-15=256.42
split: 06-10=213.56   06-11=241.16   06-12=254.54  06-15=256.42
```

Everything reading that series as an indicator was reading across two different units:

- a moving average or RSI spanning the split averages 2400s with 250s;
- `tickers.ath` is an incremental maximum that never downgrades, so a high recorded before a
  split stands forever — no later candle can beat it. "% from ATH" then reads about −90%
  permanently, and a "% drop from high" rule stays satisfied.

The same request was also capped at Alpaca's default page of 1000 bars. The endpoint answers a
longer range with the **oldest** page plus a `next_page_token` the client does not read, so the
~20-year walk that seeds an all-time high returned a window ending years before the present:

```
no limit:      count=1000  first=2016-01-04  last=2019-12-20  next_page_token present
limit=10000:   count=2679  first=2016-01-04  last=2026-08-28  next_page_token nil
```

## What changed

**Two named seams instead of one.** `Exchange#get_candles` keeps its meaning — prices as they
traded — because every other caller multiplies a candle price by a ledger quantity, and every
ledger in the app is in as-traded units. `Exchange#get_indicator_candles` asks for the history
restated onto today's share basis and is what `Ticker::TechnicallyAnalyzable` uses for RSI, the
moving averages and the high/low readings. On the thirteen venues that have no corporate actions
it delegates straight to `get_candles`, so none of their signatures change.

**One page instead of a truncated one.** `Clients::Alpaca#get_bars` sends Alpaca's maximum page
size, which covers a full history for every symbol it serves (its data begins in 2016). It also
accepts an `adjustment`, left unset by default so the as-traded paths keep the endpoint's own
default.

**An all-time high that can be corrected.** `Exchange#restated_candles?(ticker)` names the one
property that matters: whether this venue rewrites this symbol's history behind us. Where it
does, `get_high_of_last` re-walks the full history and *replaces* the stored value rather than
taking a maximum with it — otherwise the next split welds a pre-split number in permanently,
since the restated tail is entirely below it. That re-walk costs the same single request as the
incremental window now that a whole history fits in one page. Replacement is limited to the full
walk, so a short fallback window can never downgrade a good deep value, and an empty (but
successful) answer leaves an existing high alone.

**A migration** clears the highs seeded on the old basis. Crypto tickers on the same venue keep
theirs — their history cannot be restated, and their stored maximum is still a maximum.

## Deliberately not in this PR

The bot chart still draws stock prices as traded, so a split is still visible as a step in the
price line. That is not a display setting: a bot's `transactions` table records orders only and
has no corporate-action rows, so its share counts are never restated, and the chart values them
by multiplying those counts by a candle price. Switching that grid to an adjusted basis without
restating the counts moves the error rather than removing it — a position opened and closed
before a split would start reading low by the split factor, and the fill prices spliced into the
same grid would sit above it.

Restating the bot ledger onto today's share basis is what actually fixes it. The same counts
feed order sizing, manual liquidation, rebalancing and redeploy, so that belongs in its own
change with order-sizing coverage.

## Tests

`bin/rails test` — 4885 runs, 18442 assertions, 0 failures. New coverage:

- `get_bars` sends the maximum page size, omits `adjustment` by default, and sends one when asked
- `get_indicator_candles` requests a split-adjusted stock series; `get_candles` does not
- `get_indicator_candles` on a crypto ticker and on a crypto exchange is the ordinary fetch
- a restated ticker whose history moves down replaces its high; an immutable one still carries
  its maximum forward
- a restated ticker keeps its high rather than downgrading to a fallback window, and keeps it
  when every window comes back empty
- the migration clears an Alpaca stock high and leaves crypto and other venues alone
