### PR TITLE
Restate a bot's holdings through a corporate action

### DIFF
--- a/app/jobs/bot/expire_restated_metrics_job.rb
+++ b/app/jobs/bot/expire_restated_metrics_job.rb
@@ -1,0 +1,13 @@
+# A corporate action dated ahead of today is imported once and becomes effective later. The import
+# moves the affected bots' cache generation, but the walk correctly declines to apply an action
+# that has not happened — so what gets cached under the new key is the pre-split position, and no
+# later sync bumps again because the row is by then a duplicate.
+#
+# So the bump is repeated at the moment the action takes effect.
+class Bot::ExpireRestatedMetricsJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform(user, exchange, symbol)
+    AccountTransactionSync.expire_restated_bots(user: user, exchange: exchange, symbol: symbol)
+  end
+end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -13,6 +13,7 @@ class Bot < ApplicationRecord
   include ExchangeUser
   include ActivityLoggable
   include ChartSeries # chart marked at market (candle grid), shared by every measurable
+  include Restatable # corporate actions, folded into every measurable's walk
 
   belongs_to :user
   has_many :transactions, dependent: :destroy

--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -122,6 +122,37 @@ module Bot::ChartSeries
                 .transform_values { |rows| rows.map { |time, _base, price| [time, price] } }
   end
 
+  # Two marks pinned either side of every restatement: the last observed pre-split price at one
+  # second before the effective instant, and the first observed post-split price at the instant
+  # itself.
+  #
+  # Without them `chart_grid_price` draws a straight line from the mark before a split to the mark
+  # after it, and those two are in different units — 2411 the day before a ten-for-one, 254 the day
+  # after. A point landing between them is priced at neither, and multiplied by a holding that IS
+  # restated, which is a spike exactly where the chart is supposed to have stopped having one.
+  #
+  # Both pins are observed prices moved to the boundary, not invented ones. Interpolation then
+  # happens within one basis on each side, and the only interval spanning the two is a second wide,
+  # which no point can land inside. A symbol whose grid does not reach both sides is left alone —
+  # there is nothing to pin it to.
+  def chart_split_pinned_grids(grids)
+    events = split_events
+    return grids if events.empty? || grids.blank?
+
+    events.each do |at, symbol, _factor|
+      marks = grids[symbol]
+      next if marks.blank?
+
+      before = marks.select { |time, _price| time < at }.last
+      after = marks.find { |time, _price| time >= at }
+      next if before.nil? || after.nil?
+
+      grids[symbol] = (marks + [[at - 1.second, before[1]], [at, after[1]]])
+                      .uniq { |time, _price| time }.sort_by(&:first)
+    end
+    grids
+  end
+
   # Candles are fetched from one timeframe BEFORE the first transaction so that the first buy
   # has a mark below it; without that it is permanently uncovered. The earlier candle is
   # interpolation support only — `chart_marked_at_market` never lets it become a point, or the

--- a/app/models/bot/composition/measurable.rb
+++ b/app/models/bot/composition/measurable.rb
@@ -29,8 +29,15 @@ module Bot::Composition::Measurable
       ledger = Hash.new { |hash, key| hash[key] = { amount: 0, invested: 0 } }
       books = new_rebalance_books
       asset_prices = {} # Track last known price for each asset
+      # Corporate actions are events in this walk like any fill. A pending queue rather than a
+      # merge, because they are rare and this loop runs over every order the bot ever placed.
+      pending_splits = split_events
 
       transactions_array.each do |created_at, price, amount_exec, quote_amount_exec, amount, base, side, external_status, transaction_type|
+        # Before the order, not after: the restatement is a property of the position the order then
+        # acts on, so a split sharing an order's timestamp is applied first.
+        pending_splits = apply_due_splits(pending_splits, created_at, ledger, asset_prices, data, books)
+
         amount_exec, quote_amount_exec =
           confirmed_exec_amounts(external_status, price, amount, amount_exec, quote_amount_exec)
         next if price.blank? || quote_amount_exec.blank? || amount_exec.blank?
@@ -59,6 +66,9 @@ module Bot::Composition::Measurable
         end
       end
 
+      # The ordinary case: a split lands and the bot has not traded since.
+      apply_due_splits(pending_splits, nil, ledger, asset_prices, data, books)
+
       data[:total_quote_amount_invested] = invested_total(books)
       # Cash realized by a sell whose buy has not landed yet — or by a liquidation the bot has not
       # re-spent — is still the user's money.
@@ -86,6 +96,10 @@ module Bot::Composition::Measurable
                       force: force) do
       metrics_data = metrics.deep_dup
       return metrics_data if metrics_data[:chart][:labels].empty?
+
+      # A restatement the market has not priced yet: the venue's latest trade is still the old
+      # basis, and this walk's holdings are already the new one.
+      return stale(metrics_data) if restated_prices_untrusted?(metrics_data)
 
       result = exchange.get_tickers_prices(symbols: tickers.map(&:ticker))
       return stale(metrics_data) if result.failure?
@@ -224,20 +238,21 @@ module Bot::Composition::Measurable
   # _v3: realised P/L and the contributed/ledger split. _v4: a per-symbol cost-basis snapshot per
   # transaction, so the chart can draw one holding on its own. _v5: realised_cash split out of
   # rebalance_cash, which the redeploy offer reads — without the bump an existing bot serves a hash
-  # with no such key for up to 30 days and the prompt never appears.
+  # with no such key for up to 30 days and the prompt never appears. _v6: holdings are restated
+  # through corporate actions, so every count, value and chart point in here can differ.
   # The cached shape lives up to 30 days, so this has to move with it or every existing bot serves
   # the old numbers after a deploy.
   # A method, not a literal: the tests that seed this cache were reading the string off the source.
   def metrics_cache_key
-    "bot_#{id}_metrics_v5"
+    "bot_#{id}_metrics_v6_#{restatement_generation}"
   end
 
   def metrics_with_current_prices_cache_key
-    "bot_#{id}_metrics_with_current_prices_v5"
+    "bot_#{id}_metrics_with_current_prices_v6_#{restatement_generation}"
   end
 
   def metrics_with_current_prices_and_candles_cache_key
-    "bot_#{id}_metrics_with_current_prices_and_candles_v5"
+    "bot_#{id}_metrics_with_current_prices_and_candles_v6_#{restatement_generation}"
   end
 
   def optimal_candles_timeframe_for_duration(duration)
@@ -255,6 +270,48 @@ module Bot::Composition::Measurable
     else
       1.day
     end
+  end
+
+  # Folds in every restatement due at or before `until_time` (all of them when nil), and returns
+  # what is left. A split multiplies the position and moves no money, so `invested` — and with it
+  # the cost basis, the realised P/L and the rebalance books — is untouched.
+  #
+  # The last-known price is divided by the same factor. This walk values the portfolio at the price
+  # each asset last traded at, and that price is pre-split; without restating it the value jumps by
+  # the factor and stays there until the asset next trades, which is exactly the fallback headline
+  # a bot shows when the live read fails.
+  #
+  # A chart point is emitted, as a fill would. `chart_marked_at_market` interpolates between the
+  # snapshots stored here, so with no snapshot at the split every candle point between it and the
+  # next order would price a pre-split count. Because both sides move together the point's value
+  # equals the one before it — the curve gains a vertex, not a step.
+  def apply_due_splits(pending, until_time, ledger, asset_prices, data, books)
+    # The overwhelming majority of bots have no corporate actions at all, and this runs once per
+    # fill over histories that reach into the millions of them.
+    return pending if pending.empty?
+
+    due, rest = pending.partition { |at, _symbol, _factor| until_time.nil? || at <= until_time }
+    due.each do |at, symbol, factor|
+      # `key?`, not `[]`: the ledger's default proc would CREATE a zero entry for a symbol the bot
+      # never actually held, and every one of those becomes a row in `asset_breakdown`.
+      next unless ledger.key?(symbol)
+
+      entry = ledger[symbol]
+      next if entry[:amount].to_d.zero?
+
+      entry[:amount] = entry[:amount].to_d * factor
+      asset_prices[symbol] /= factor if asset_prices[symbol].present?
+      # Only a restatement that MOVED something puts the live prices out of trust.
+      data[:restated_at] = [data[:restated_at], at].compact.max
+
+      data[:chart][:labels] << at
+      data[:chart][:series][0] << portfolio_value(ledger_value(ledger, asset_prices), books)
+      data[:chart][:series][1] << invested_total(books)
+      data[:chart][:extra_series] << ledger.transform_values { |values| values[:amount] }
+      data[:chart][:invested_series] << ledger.transform_values { |values| values[:invested] }
+      (data[:chart][:cash_series] ||= []) << uninvested_cash(books)
+    end
+    rest
   end
 
   # The price grid every held symbol is marked on: its candle opens plus its live price.
@@ -305,7 +362,9 @@ module Bot::Composition::Measurable
 
     # One member the candles do not cover would otherwise blank the interpolation for every member.
     labels = metrics_data[:chart][:labels]
-    chart_backfilled_grids(grids, symbols: symbols, from: labels.first, to: labels.last)
+    chart_split_pinned_grids(
+      chart_backfilled_grids(grids, symbols: symbols, from: labels.first, to: labels.last)
+    )
   end
 
   def fetch_candle_series(ticker:, since:, timeframe:)

--- a/app/models/bot/rebalanceable.rb
+++ b/app/models/bot/rebalanceable.rb
@@ -72,6 +72,14 @@ module Bot::Rebalanceable
           log_activity('dca_skipped_redeploy_pending', level: :info)
           return Result::Success.new
         end
+        # A corporate action the market has not priced yet. The holdings are already restated and
+        # the venue's latest trade is not, so the weights this leg sizes against are the factor's
+        # worth of imaginary drift — it would pour a contribution into whichever member the
+        # mismatch made look cheap. The money is not lost: missed_quote_amount carries it.
+        if restated_prices_untrusted?(metrics)
+          log_activity('dca_skipped_restatement', level: :info)
+          return Result::Success.new
+        end
 
         super
       end

--- a/app/models/bot/restatable.rb
+++ b/app/models/bot/restatable.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# What a bot knows about its own share counts being restated.
+#
+# A bot's `transactions` table records orders and nothing else, so a corporate action is invisible
+# to it: after a 10-for-1 split it goes on believing it owns the number of shares it bought. The
+# only account of the event is the broker's, and it is already stored — the account sync books it
+# as an `adjustment` ledger row marked `corporate_action`, the same rows `Tracker::Ledger` and
+# `Tax::Methods::Fifo` already restate against.
+#
+# This turns those rows into the events the metrics walks fold in.
+module Bot::Restatable
+  extend ActiveSupport::Concern
+
+  # How long a live price stays out of trust after a restatement.
+  #
+  # A venue's "latest trade" is the last trade that actually happened, and a corporate action is
+  # effective before the market opens — so between booking one and the first trade on the new
+  # basis, the live mark is still the OLD price. Multiplied by a count this code has just
+  # restated, that is the factor's worth of imaginary money, and a rebalancer reading it sees an
+  # asset wildly overweight and sells real shares to correct a move that never happened.
+  #
+  # ponytail: a blunt window, because the shared `get_tickers_prices` returns prices and no
+  # timestamps. Alpaca's snapshot carries `latestTrade.t` right beside the price it does return;
+  # plumb that through and this becomes the exact question — is the mark newer than the action —
+  # instead of a wait. Two days so a session always intervenes, weekend or holiday.
+  SPLIT_PRICE_QUARANTINE = 2.days
+
+  # `[[at, symbol, factor], ...]`, oldest first: what the position is multiplied by, and when.
+  #
+  # ponytail: read per walk, and each walk memoizes it. A bot with enough corporate actions for
+  # that lookup to show up belongs in the metrics cache with the rest of them.
+  def split_events
+    grouped_split_rows.filter_map { |(symbol, date), group| split_event(symbol, date, group) }
+                      .select { |at, _symbol, _factor| at <= Time.current }
+                      .sort_by { |at, symbol, _factor| [at, symbol] }
+  end
+
+  # Whether a live price can be multiplied by this bot's holdings at all.
+  #
+  # Two ways it cannot. A restatement newer than the market's last chance to reprice the security:
+  # the count has moved and the venue's last trade has not, so the walk's own last-known prices —
+  # restated alongside the position — are the honest reading and the live ones are not. Or a split
+  # this bot can see but cannot size, where the holdings can NEVER be brought onto the same basis
+  # as the price; that one does not expire.
+  #
+  # `metrics_data` carries `:restated_at`, the last restatement that actually moved a position. A
+  # split before the bot's first fill, or after it sold out, moves nothing and is no reason to
+  # stand a bot down.
+  #
+  # ponytail: the unresolved case is deliberately not narrowed to the symbols still held. It should
+  # not happen at all, and while it does, over-broad means safe.
+  def restated_prices_untrusted?(metrics_data = nil)
+    return true if unresolved_split?
+
+    restated_at = metrics_data.is_a?(Hash) ? metrics_data[:restated_at] : nil
+    restated_at.present? && restated_at > SPLIT_PRICE_QUARANTINE.ago
+  end
+
+  # A split this bot can see and cannot size — one leg with no counterpart, or two sources naming
+  # different factors. Its position stays on the old basis while the market moves to the new one,
+  # which no amount of waiting fixes.
+  def unresolved_split?
+    effective_split_rows.any? { |(_symbol, date), group| date.nil? || resolved_factor(group).nil? }
+  end
+
+  # Everything a bot has cached is computed from a position a corporate action moves, so when one
+  # lands they all go. Order sizing forces its own recompute and would be right regardless, but
+  # `Bot::Rebalancer#rebalance_targets` reads `metrics_with_current_prices` UNFORCED — a stale hash
+  # there is a sell sized against a tenth of a position.
+  #
+  # The generation moves FIRST, and it is what actually makes this safe. Deleting alone loses a
+  # race: a walk that read the ledger just before the split was stored can finish just after and
+  # write its pre-split answer back into the hole, where nothing downstream can tell it apart from
+  # a fresh one. Past the bump that writer is computing an old key and can only write there. The
+  # deletes then just reclaim the entries nothing will read again.
+  def expire_restated_metrics!
+    stale_keys = restated_metrics_cache_keys
+    increment!(:restatement_generation)
+    stale_keys.each { |key| Rails.cache.delete(key) }
+  end
+
+  def restated_metrics_cache_keys
+    %i[metrics_cache_key metrics_with_current_prices_cache_key
+       metrics_with_current_prices_and_candles_cache_key]
+      .filter_map { |name| send(name) if respond_to?(name, true) }
+  end
+
+  private
+
+  # The marked split rows this bot is eligible for, grouped by the action they describe.
+  #
+  # A corporate action is an event of the SECURITY on an effective date, so that is the key: two
+  # venues reporting one restatement must apply it once, and they need not agree on the hour.
+  # The actions already in effect. A broker can store a pending one dated ahead of today, and a
+  # position restated before its split is simply wrong — as is standing a bot's automation down
+  # for an event that has not happened.
+  def effective_split_rows
+    grouped_split_rows.reject do |_key, group|
+      group.map(&:transacted_at).compact.min.try(:>, Time.current)
+    end
+  end
+
+  def grouped_split_rows
+    pairs = traded_pairs
+    return {} if pairs.empty?
+
+    AccountTransaction.where(user_id: user_id, entry_type: :adjustment)
+                      .where(exchange_id: pairs.map(&:first).uniq,
+                             base_currency: pairs.map(&:last).uniq)
+                      .select { |row| pairs.include?([row.exchange_id, row.base_currency]) && split_row?(row) }
+                      .group_by { |row| [row.base_currency, effective_date(row)] }
+  end
+
+  def split_row?(row)
+    row.raw_data.is_a?(Hash) && row.raw_data['corporate_action'] == 'split'
+  end
+
+  # The (venue, symbol) pairs this bot actually traded — its eligibility, and deliberately not its
+  # current venue. A bot can be moved between brokers and its orders keep the one they were placed
+  # on, so reading the present venue would both miss the restatement that moved its position and
+  # apply one that never touched it.
+  #
+  # `submitted` rather than executed: an order that never filled bought nothing, so a pair it alone
+  # contributes can only apply a factor to a position of zero.
+  def traded_pairs
+    transactions.submitted.distinct.pluck(:exchange_id, :base)
+                .filter_map { |exchange_id, base| [exchange_id, base] if exchange_id && base.present? }
+                .uniq
+  end
+
+  def effective_date(row)
+    row.transacted_at&.utc&.to_date
+  end
+
+  # One event, or none. Sources that disagree about the factor restate nothing: a share count is
+  # not something to guess at, and a wrong factor is a wrong position in every order this bot sizes.
+  #
+  # Timed at the EARLIEST instant the group reports, not at the key's date boundary. The date is a
+  # de-duplication key and nothing more: `transacted_at` is written by parsing the venue's date
+  # string in `Time.zone`, so reconstructing an instant from a UTC date would move the event by a
+  # day for every zone ahead of UTC — and `Time.zone` is per-request here. The row's own instant is
+  # zone-independent and already says when the venue booked it.
+  def split_event(symbol, date, group)
+    return nil if date.nil?
+
+    factor = resolved_factor(group)
+    return nil unless factor
+
+    [group.map(&:transacted_at).min, symbol, factor]
+  end
+
+  # One factor, or none. A row that names no factor is silent, not dissenting: Alpaca can ship the
+  # add leg alone and the merged pair a sync later, and the sync keeps both on purpose — the first
+  # says a split happened without saying by how much, the second says both. Treating that pair as a
+  # conflict would leave the position un-restated forever, which is the failure this exists to end.
+  # Two rows naming DIFFERENT factors resolve to nothing: a share count is not something to guess
+  # at, and a wrong factor is a wrong position in every order this bot sizes.
+  def resolved_factor(group)
+    factors = group.filter_map { |row| split_factor(row) }.uniq
+    factors.size == 1 ? factors.first : nil
+  end
+
+  # "10:1" -> 10. Fails closed on anything else — a blank, a single number, a zero or negative
+  # side, words, or extra parts. Nothing is restated on a factor that could not be read.
+  def split_factor(row)
+    parts = row.raw_data['split_ratio'].to_s.split(':')
+    return nil unless parts.size == 2 && parts.all? { |part| part.match?(/\A\d+(\.\d+)?\z/) }
+
+    new_count, old_count = parts.map(&:to_d)
+    return nil unless new_count.positive? && old_count.positive?
+
+    new_count / old_count
+  end
+end

--- a/app/models/bots/dca_single_asset/measurable.rb
+++ b/app/models/bots/dca_single_asset/measurable.rb
@@ -9,11 +9,12 @@ module Bots::DcaSingleAsset::Measurable
   # total_quote_amount_invested is now the TOTAL COST BASIS (real buys + phantom buys at sale price),
   # not just real cash invested — a pure liquidation reads invested ≈ proceeds and neutral
   # liquidations dilute PnL% while the $ profit comes only from the bot's real buys.
-  METRICS_CACHE_VERSION = 'v4'.freeze
+  # v5: holdings, the average buy price and the running value are restated through corporate
+  # actions, so every figure in here can differ for a bot that held through one.
+  METRICS_CACHE_VERSION = 'v5'.freeze
 
   def metrics(force: false)
-    cache_key = "bot_#{id}_metrics_#{METRICS_CACHE_VERSION}"
-    Rails.cache.fetch(cache_key, expires_in: 30.days, force: force) do
+    Rails.cache.fetch(metrics_cache_key, expires_in: 30.days, force: force) do
       data = initialize_metrics_data
       transactions_array = transactions.submitted.order(created_at: :asc).pluck(:created_at,
                                                                                 :price,
@@ -25,7 +26,15 @@ module Bots::DcaSingleAsset::Measurable
       return data if transactions_array.empty?
 
       totals = initialize_totals_data
+      # Corporate actions are events in this walk like any fill. A pending queue rather than a
+      # merge, because they are rare and this loop runs over every order the bot ever placed.
+      pending_splits = split_events
+
       transactions_array.each do |created_at, price, amount_exec, quote_amount_exec, amount, side, external_status|
+        # Before the order, not after: the restatement is a property of the position the order then
+        # acts on, so a split sharing an order's timestamp is applied first.
+        pending_splits = apply_due_splits(pending_splits, created_at, totals, data)
+
         # The "null exec == filled for the requested amount" fallback (legacy rows never backfilled
         # exec amounts) is only valid for CONFIRMED rows. An accepted-but-unfilled order (open/unknown)
         # or a cancelled one must not be assumed filled, or its requested amount would be realized
@@ -58,11 +67,15 @@ module Bots::DcaSingleAsset::Measurable
         end
 
         data[:chart][:series][1] << totals[:total_quote_amount_invested]
+        totals[:last_price] = price
         totals[:current_value_in_quote] = totals[:realized_proceeds] + (totals[:net_base] * price)
         data[:chart][:series][0] << totals[:current_value_in_quote]
         data[:chart][:extra_series][0] << totals[:net_base]
         data[:chart][:extra_series][1] << totals[:realized_proceeds]
       end
+
+      # The ordinary case: a split lands and the bot has not traded since.
+      apply_due_splits(pending_splits, nil, totals, data)
 
       data[:total_base_amount] = totals[:net_base]
       data[:total_quote_amount_invested] = totals[:total_quote_amount_invested]
@@ -84,6 +97,9 @@ module Bots::DcaSingleAsset::Measurable
       return metrics_data if metrics_data[:chart][:labels].empty? || ticker.nil?
 
       result = exchange.get_tickers_prices(symbols: [ticker.ticker])
+      # A restatement the market has not priced yet: the venue's latest trade is still the old
+      # basis, and this walk's holdings are already the new one.
+      return stale(metrics_data) if restated_prices_untrusted?(metrics_data)
       return stale(metrics_data) if result.failure?
 
       price = result.data[ticker.ticker]
@@ -155,12 +171,66 @@ module Bots::DcaSingleAsset::Measurable
 
   private
 
+  # Folds in every restatement due at or before `until_time` (all of them when nil), and returns
+  # what is left. A split multiplies the position and moves no money.
+  #
+  # The accumulated buy prices are divided by the same factor and the accumulated amounts
+  # multiplied by it, because `average_buy_price` is a weighted average over them: left alone, a
+  # split spanning two buys would average two different units and the figure would be shown against
+  # a price in neither. The money paid is preserved, which is what makes the restated average the
+  # cost per share the position actually has today.
+  #
+  # The last traded price is restated too — the running value is `proceeds + base * that price`,
+  # and without it a split with no trade after it multiplies the value by the factor.
+  #
+  # A chart point is emitted, as a fill would: `chart_marked_at_market` interpolates between the
+  # snapshots stored here, and with no snapshot at the split every candle point between it and the
+  # next order would price a pre-split count. Both sides move together, so the point's value equals
+  # the one before it.
+  def apply_due_splits(pending, until_time, totals, data)
+    # The overwhelming majority of bots have no corporate actions at all, and this runs once per
+    # fill over histories that reach into the millions of them.
+    return pending if pending.empty?
+
+    due, rest = pending.partition { |at, _symbol, _factor| until_time.nil? || at <= until_time }
+    due.each do |at, _symbol, factor|
+      held = totals[:net_base].to_d
+      # The accumulators are restated whether or not anything is held right now: they cover every
+      # buy the bot has ever made, and a bot that sold out before the split and bought again after
+      # it would otherwise average two different units into one price.
+      totals[:net_base] = held * factor
+      totals[:amounts] = totals[:amounts].map { |amount| amount.to_d * factor }
+      totals[:prices] = totals[:prices].map { |price| price.to_d / factor }
+      totals[:last_price] = totals[:last_price].to_d / factor if totals[:last_price].present?
+      next if held.zero?
+
+      # Only a restatement that MOVED something puts the live prices out of trust.
+      data[:restated_at] = [data[:restated_at], at].compact.max
+
+      totals[:current_value_in_quote] =
+        totals[:realized_proceeds] + (totals[:net_base] * totals[:last_price].to_d)
+
+      data[:chart][:labels] << at
+      data[:chart][:series][1] << totals[:total_quote_amount_invested]
+      data[:chart][:series][0] << totals[:current_value_in_quote]
+      data[:chart][:extra_series][0] << totals[:net_base]
+      data[:chart][:extra_series][1] << totals[:realized_proceeds]
+    end
+    rest
+  end
+
+  # A method, not a literal, for the same reason the composition concern has one: the caches are
+  # seeded by name in tests, and dropped by name when a corporate action arrives.
+  def metrics_cache_key
+    "bot_#{id}_metrics_#{METRICS_CACHE_VERSION}_#{restatement_generation}"
+  end
+
   def metrics_with_current_prices_cache_key
-    "bot_#{id}_metrics_with_current_prices_#{METRICS_CACHE_VERSION}"
+    "bot_#{id}_metrics_with_current_prices_#{METRICS_CACHE_VERSION}_#{restatement_generation}"
   end
 
   def metrics_with_current_prices_and_candles_cache_key
-    "bot_#{id}_metrics_with_current_prices_and_candles_#{METRICS_CACHE_VERSION}"
+    "bot_#{id}_metrics_with_current_prices_and_candles_#{METRICS_CACHE_VERSION}_#{restatement_generation}"
   end
 
   def calculate_pnl(from, to)
@@ -231,6 +301,6 @@ module Bots::DcaSingleAsset::Measurable
 
     marks = result.data.map { |candle| [candle[0], candle[1]] } +
             chart_live_marks(metrics_data, ticker.base)
-    { ticker.base => marks.sort_by(&:first) }
+    chart_split_pinned_grids(ticker.base => marks.sort_by(&:first))
   end
 end

--- a/app/services/account_transaction_sync.rb
+++ b/app/services/account_transaction_sync.rb
@@ -117,6 +117,24 @@ class AccountTransactionSync
     { imported: imported, duplicates: duplicates, skipped: skipped, min_skipped: min_skipped }
   end
 
+  # Every bot whose walk would fold this event in — that is, one that traded the symbol on this
+  # venue. Deliberately NOT `bots_holding`: that filters to a non-flat position, which is a rule
+  # about who should be told, not about whose numbers move.
+  def self.expire_restated_bots(user:, exchange:, symbol:)
+    return if symbol.blank?
+
+    Bot.where(id: Transaction.submitted.where(base: symbol, exchange: exchange)
+                             .where(bot_id: Bot.where(user: user).select(:id))
+                             .select(:bot_id))
+       .find_each do |bot|
+      bot.expire_restated_metrics!
+      # Dropping the caches fixes the next render; a page already open would go on showing the
+      # pre-split position until someone reloaded it. Enqueued rather than rendered here — the
+      # partial reads live prices, and a ledger sync is not the place to make that call.
+      Bot::BroadcastMetricsUpdateJob.perform_later(bot)
+    end
+  end
+
   # One info line per bot that was holding the symbol when it was restated. Also called from the
   # migration that backfills the splits already on record, which is why it takes plain arguments
   # and no sync state.
@@ -223,9 +241,30 @@ class AccountTransactionSync
   def log_split(at)
     return unless at.adjustment? && at.raw_data.is_a?(Hash) && at.raw_data['corporate_action'] == 'split'
 
+    # The ledger first, and unconditionally: `announce_split` returns early for a split older than
+    # the feed keeps, and whether a bot should be TOLD about a restatement is a different question
+    # from whether its numbers changed.
+    AccountTransactionSync.expire_restated_bots(
+      user: @api_key.user, exchange: @exchange, symbol: at.base_currency
+    )
+    # An action dated ahead of today is imported now and takes effect later; the walk rightly
+    # declines to apply it until then, so the bump has to happen again at that moment or the
+    # pre-split position stays cached. No later sync will do it — by then the row is a duplicate.
+    if at.transacted_at&.>(Time.current)
+      Bot::ExpireRestatedMetricsJob.set(wait_until: at.transacted_at)
+                                   .perform_later(@api_key.user, @exchange, at.base_currency)
+    end
     AccountTransactionSync.announce_split(
       user: @api_key.user, exchange: @exchange, symbol: at.base_currency,
       at: at.transacted_at, ratio: at.raw_data['split_ratio']
+    )
+  rescue StandardError => e
+    # The row is already stored, and a later sync will read it as a duplicate and never come back
+    # here — so this must not abort the batch, and it must be loud. A bot left on a stale cache key
+    # is a position read at the wrong basis, which is what the fleet's log scan is for.
+    Rails.logger.error(
+      "[#{@exchange.name_id}] Split side effects failed for #{at.base_currency} " \
+      "tx_id=#{at.tx_id.inspect}: #{e.class}: #{e.message}"
     )
   end
 

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -632,6 +632,7 @@ bg:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Вноската е пропусната — сплит, който пазарът още не е оценил"
             asset_split: "%{base} сплит %{ratio} — брокерът преизчисли броя на акциите"
             asset_split_unknown_ratio: "%{base} беше сплитнат — брокерът преизчисли броя на акциите"
             rebalance_sell_placed: 'Ребалансиране — продажба на надтегления актив'

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -640,6 +640,7 @@ cs:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Příspěvek přeskočen — split, který trh ještě neocenil"
             asset_split: "%{base} split %{ratio} — broker přepočítal počet akcií"
             asset_split_unknown_ratio: "%{base} prošel splitem — broker přepočítal počet akcií"
             rebalance_sell_placed: 'Rebalancování — prodej nadváženého aktiva'

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -632,6 +632,7 @@ da:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Bidrag sprunget over — en aktiesplit markedet endnu ikke har prissat"
             asset_split: "%{base} aktiesplit %{ratio} — mægleren har omregnet antallet af aktier"
             asset_split_unknown_ratio: "%{base} blev aktiesplittet — mægleren har omregnet antallet af aktier"
             rebalance_sell_placed: 'Rebalancering — sælger det overvægtede aktiv'

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -621,6 +621,7 @@ de:
         other: 'Sonstige'
     bot_activity:
         events:
+            dca_skipped_restatement: "Beitrag übersprungen — ein Aktiensplit, den der Markt noch nicht bepreist hat"
             asset_split: "%{base} Aktiensplit %{ratio} — der Broker hat die Stückzahl angepasst"
             asset_split_unknown_ratio: "%{base} wurde gesplittet — der Broker hat die Stückzahl angepasst"
             rebalance_sell_placed: 'Rebalancing — Verkauf des übergewichteten Werts'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -632,6 +632,7 @@ el:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Η εισφορά παραλείφθηκε — split που η αγορά δεν έχει ακόμη αποτιμήσει"
             asset_split: "%{base} split %{ratio} — ο χρηματιστής αναπροσάρμοσε τον αριθμό των μετοχών"
             asset_split_unknown_ratio: "%{base} έγινε split — ο χρηματιστής αναπροσάρμοσε τον αριθμό των μετοχών"
             rebalance_sell_placed: 'Επανεξισορρόπηση — πώληση του υπερεκπροσωπούμενου στοιχείου'

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -631,6 +631,7 @@ en:
         other: 'Other'
     bot_activity:
         events:
+            dca_skipped_restatement: "Contribution skipped — a split the market has not priced yet"
             asset_split: "%{base} split %{ratio} — the broker restated the share count"
             asset_split_unknown_ratio: "%{base} was split — the broker restated the share count"
             rebalance_sell_placed: 'Rebalancing — selling the overweight asset'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -621,6 +621,7 @@ es:
         other: 'Otros'
     bot_activity:
         events:
+            dca_skipped_restatement: "Aportación omitida — un split que el mercado aún no ha valorado"
             asset_split: "%{base} split %{ratio} — el bróker recalculó el número de acciones"
             asset_split_unknown_ratio: "%{base} tuvo un split — el bróker recalculó el número de acciones"
             rebalance_sell_placed: 'Reequilibrio — vendiendo el activo sobreponderado'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -621,6 +621,7 @@ fr:
         other: 'Autres'
     bot_activity:
         events:
+            dca_skipped_restatement: "Versement ignoré — un split que le marché n'a pas encore valorisé"
             asset_split: "%{base} split %{ratio} — le courtier a réajusté le nombre d'actions"
             asset_split_unknown_ratio: "%{base} a fait l'objet d'un split — le courtier a réajusté le nombre d'actions"
             rebalance_sell_placed: 'Rééquilibrage — vente de l’actif surpondéré'

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -620,6 +620,7 @@ it:
         other: 'Altri'
     bot_activity:
         events:
+            dca_skipped_restatement: "Versamento saltato — uno split che il mercato non ha ancora prezzato"
             asset_split: "%{base} split %{ratio} — il broker ha ricalcolato il numero di azioni"
             asset_split_unknown_ratio: "%{base} ha subito uno split — il broker ha ricalcolato il numero di azioni"
             rebalance_sell_placed: 'Ribilanciamento — vendita dell’asset sovrappesato'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -620,6 +620,7 @@ nl:
         other: 'Overige'
     bot_activity:
         events:
+            dca_skipped_restatement: "Inleg overgeslagen — een aandelensplitsing die de markt nog niet heeft verwerkt"
             asset_split: "%{base} aandelensplitsing %{ratio} — de broker heeft het aantal aandelen herberekend"
             asset_split_unknown_ratio: "%{base} is gesplitst — de broker heeft het aantal aandelen herberekend"
             rebalance_sell_placed: 'Herbalanceren — de overwogen asset verkopen'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -624,6 +624,7 @@ pl:
         other: 'Inne'
     bot_activity:
         events:
+            dca_skipped_restatement: "Wpłata pominięta — podział akcji, którego rynek jeszcze nie wycenił"
             asset_split: "%{base} podział akcji %{ratio} — broker przeliczył liczbę akcji"
             asset_split_unknown_ratio: "%{base} przeszedł podział akcji — broker przeliczył liczbę akcji"
             rebalance_sell_placed: 'Rebalansowanie — sprzedaż nadreprezentowanego aktywa'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -619,8 +619,9 @@ pt:
         other: 'Outros'
     bot_activity:
         events:
-            asset_split: "%{base} desdobramento %{ratio} — a corretora recalculou o número de ações"
-            asset_split_unknown_ratio: "%{base} sofreu um desdobramento — a corretora recalculou o número de ações"
+            dca_skipped_restatement: "Contribuição ignorada — um split que o mercado ainda não avaliou"
+            asset_split: "%{base} split %{ratio} — a corretora ajustou o número de ações"
+            asset_split_unknown_ratio: "%{base} sofreu um split — a corretora ajustou o número de ações"
             rebalance_sell_placed: 'Reequilíbrio — a vender o ativo sobreponderado'
             rebalance_buy_placed: 'Reequilíbrio — a recomprar o ativo subponderado'
             rebalance_dust: 'Sobra pouco para reequilibrar — fica como numerário'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -624,6 +624,7 @@ ru:
         other: 'Прочие'
     bot_activity:
         events:
+            dca_skipped_restatement: "Взнос пропущен — сплит, который рынок ещё не оценил"
             asset_split: "%{base} сплит %{ratio} — брокер пересчитал количество акций"
             asset_split_unknown_ratio: "%{base} прошёл сплит — брокер пересчитал количество акций"
             rebalance_sell_placed: 'Ребалансировка — продажа перевешенного актива'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -640,6 +640,7 @@ sk:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Príspevok preskočený — split, ktorý trh ešte neocenil"
             asset_split: "%{base} split %{ratio} — broker prepočítal počet akcií"
             asset_split_unknown_ratio: "%{base} prešiel splitom — broker prepočítal počet akcií"
             rebalance_sell_placed: 'Rebalansovanie — predaj nadváženého aktíva'

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -632,6 +632,7 @@ sv:
     # TODO: translate bot_activity events (English placeholders)
     bot_activity:
         events:
+            dca_skipped_restatement: "Insättning hoppades över — en aktiesplit marknaden ännu inte prissatt"
             asset_split: "%{base} aktiesplit %{ratio} — mäklaren har räknat om antalet aktier"
             asset_split_unknown_ratio: "%{base} aktiesplittades — mäklaren har räknat om antalet aktier"
             rebalance_sell_placed: 'Rebalansering — säljer den överviktade tillgången'

--- a/db/migrate/20260830230000_add_restatement_generation_to_bots.rb
+++ b/db/migrate/20260830230000_add_restatement_generation_to_bots.rb
@@ -1,0 +1,13 @@
+# A bot's metrics are cached for 30 days and computed from a position a corporate action moves.
+# Deleting those keys when one lands is not enough on its own: a walk that read the ledger just
+# BEFORE the split was stored can finish just after, and write its pre-split answer back over the
+# hole. That hash carries no restatement, so nothing downstream knows to distrust it.
+#
+# The generation makes the old and new answers live at different keys. A writer that read the old
+# ledger computed the old key and can only ever write there; the key everything reads next is one
+# nothing pre-split can reach.
+class AddRestatementGenerationToBots < ActiveRecord::Migration[8.1]
+  def change
+    add_column :bots, :restatement_generation, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_230000) do
   create_table "account_balances", force: :cascade do |t|
     t.integer "asset_id", null: false
     t.datetime "created_at", null: false
@@ -235,6 +235,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_210000) do
     t.integer "position", default: 0, null: false
     t.decimal "redeploy_declined_offset", default: "0.0", null: false
     t.integer "restarts", default: 0, null: false
+    t.integer "restatement_generation", default: 0, null: false
     t.json "settings", default: {}, null: false
     t.datetime "settings_changed_at", precision: nil
     t.datetime "started_at", precision: nil

--- a/test/models/bot/asset_split_locales_test.rb
+++ b/test/models/bot/asset_split_locales_test.rb
@@ -24,6 +24,8 @@ class Bot::AssetSplitLocalesTest < ActiveSupport::TestCase
                       "base.#{locale}.yml asset_split_unknown_ratio drops the symbol"
       assert_not_includes without_ratio, '%{ratio}',
                           "base.#{locale}.yml asset_split_unknown_ratio has no ratio to name"
+      assert events['dca_skipped_restatement'].present?,
+             "base.#{locale}.yml is missing bot_activity.events.dca_skipped_restatement"
       # rubocop:enable Style/FormatStringToken
     end
   end

--- a/test/models/bot/chart_split_boundary_test.rb
+++ b/test/models/bot/chart_split_boundary_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+
+# `chart_grid_price` draws a straight line between the two candle marks around a time. The marks
+# either side of a split are in different units — 2411 the day before, 254 the day after — so a
+# point landing between them would be priced at something like 1300 and multiplied by a restated
+# holding. That is a spike, and it is the artefact the restatement exists to remove.
+class Bot::ChartSplitBoundaryTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC')
+    @bot = create(:dca_single_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                     base_asset: @klac, quote_asset: @usd)
+    @split_at = 5.days.ago.change(usec: 0)
+    # The bot has to have traded the symbol on this venue for a restatement to be its business.
+    @buy = create(:transaction, bot: @bot, exchange: @exchange, base: 'KLAC', quote: 'USD',
+                                side: :buy, amount: 2, amount_exec: 2, price: 1000,
+                                quote_amount: 2000, quote_amount_exec: 2000,
+                                created_at: @split_at - 8.days)
+  end
+
+  # A daily grid across the split: 1000 a day before, 100 a day after — one restatement, no drift.
+  def daily_grid
+    marks = (-8..-6).map { |d| [@split_at + d.days, 1000.to_d] } +
+            (0..4).map { |d| [@split_at + d.days, 100.to_d] }
+    { 'KLAC' => marks }
+  end
+
+  def split!(ratio: '10:1')
+    create(:account_transaction, user: @user, api_key: @api_key, exchange: @exchange,
+                                 entry_type: :adjustment, base_currency: 'KLAC', base_amount: 90,
+                                 quote_currency: nil, quote_amount: nil, transacted_at: @split_at,
+                                 raw_data: { 'corporate_action' => 'split', 'split_ratio' => ratio })
+  end
+
+  test 'the grid gains a mark on each side of the boundary, in its own units' do
+    split!
+
+    pinned = @bot.chart_split_pinned_grids(daily_grid)['KLAC']
+
+    assert_equal 1000.to_d, pinned.find { |at, _price| at == @split_at - 1.second }&.last
+    assert_equal 100.to_d, pinned.find { |at, _price| at == @split_at }&.last
+  end
+
+  test 'a price read between the two bases lands in one of them, not between' do
+    split!
+    # Half a day before the split: strictly between the last pre-split mark and the first
+    # post-split one, which is exactly where a straight line between them is meaningless.
+    midway = @split_at - 12.hours
+
+    unpinned = @bot.send(:chart_grid_price, daily_grid['KLAC'], midway)
+    pinned = @bot.send(:chart_grid_price, @bot.chart_split_pinned_grids(daily_grid)['KLAC'], midway)
+
+    assert_operator unpinned, :<, 1000.to_d
+    assert_operator unpinned, :>, 100.to_d, 'without the pins it reads a price nobody quoted'
+    assert_equal 1000.to_d, pinned, 'still on the pre-split basis, where the holding also is'
+  end
+
+  test 'a price read at the boundary itself is the post-split one' do
+    split!
+
+    pinned = @bot.chart_split_pinned_grids(daily_grid)['KLAC']
+
+    assert_equal 100.to_d, @bot.send(:chart_grid_price, pinned, @split_at)
+    assert_equal 1000.to_d, @bot.send(:chart_grid_price, pinned, @split_at - 1.second)
+  end
+
+  test 'a grid that does not reach both sides of the split is left alone' do
+    split!
+    one_sided = { 'KLAC' => (0..4).map { |d| [@split_at + d.days, 100.to_d] } }
+
+    assert_equal one_sided, @bot.chart_split_pinned_grids(one_sided)
+  end
+
+  test 'a bot with no restatement gets its grid back untouched' do
+    assert_equal daily_grid, @bot.chart_split_pinned_grids(daily_grid)
+  end
+
+  test 'the marked value series has neither spike nor step across the split' do
+    split!
+    grid = daily_grid
+    @bot.define_singleton_method(:chart_price_grids) { |_metrics_data| grid }
+    Exchanges::Alpaca.any_instance.stubs(:get_last_price).returns(Result::Success.new(100.to_d))
+    Exchanges::Alpaca.any_instance.stubs(:get_tickers_prices)
+                     .returns(Result::Success.new('KLACUSD' => 100.to_d))
+
+    series = @bot.metrics_with_current_prices_and_candles(force: true)[:chart][:series][0]
+
+    # Two shares at 1000, then twenty at 100: 2000 throughout, at every point on the grid.
+    assert_operator series.size, :>=, 4
+    series.each { |value| assert_in_delta 2000.to_d, value.to_d, 1.to_d, "series: #{series.inspect}" }
+  end
+end

--- a/test/models/bot/composition/restated_holdings_test.rb
+++ b/test/models/bot/composition/restated_holdings_test.rb
@@ -1,0 +1,164 @@
+require 'test_helper'
+
+# A split multiplies a share count with nothing bought or sold. The bot's own ledger records orders
+# only, so unless the walk folds the broker's restatement in, every number downstream of it — the
+# headline, the chart, the weights an order is sized against, the amount a liquidation offers — is
+# wrong by the factor, permanently.
+class Bot::Composition::RestatedHoldingsTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC')
+    @aapl = create(:asset, external_id: 'aapl', symbol: 'AAPL')
+    @bot = create(:dca_multi_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                    base_assets: [@klac, @aapl], quote_asset: @usd)
+  end
+
+  def buy(symbol, amount:, price:, at:)
+    create(:transaction, bot: @bot, exchange: @exchange, base: symbol, quote: 'USD', side: :buy,
+                         amount: amount, amount_exec: amount, price: price,
+                         quote_amount: amount * price, quote_amount_exec: amount * price,
+                         created_at: at)
+  end
+
+  def split(symbol: 'KLAC', ratio: '10:1', at: 5.days.ago, **overrides)
+    create(:account_transaction, { user: @user, api_key: @api_key, exchange: @exchange,
+                                   entry_type: :adjustment, base_currency: symbol, base_amount: 90,
+                                   quote_currency: nil, quote_amount: nil, transacted_at: at,
+                                   raw_data: { 'corporate_action' => 'split',
+                                               'split_ratio' => ratio }.compact }.merge(overrides))
+  end
+
+  def held(symbol, bot = @bot)
+    bot.metrics(force: true).dig(:asset_breakdown, symbol, :amount).to_d
+  end
+
+  def invested(symbol, bot = @bot)
+    bot.metrics(force: true).dig(:asset_breakdown, symbol, :quote_invested).to_d
+  end
+
+  # ---- the case every bot in the fleet is in ----
+
+  test 'a bot with no restatement is untouched' do
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+    buy('AAPL', amount: 1, price: 50, at: 7.days.ago)
+    before = @bot.metrics(force: true)
+
+    after = @bot.metrics(force: true)
+
+    assert_equal before, after
+    assert_equal 2.to_d, held('KLAC')
+  end
+
+  # ---- the fold ----
+
+  test 'a split between two buys multiplies the position and leaves the money alone' do
+    buy('KLAC', amount: 2, price: 1000, at: 8.days.ago)
+    split(at: 5.days.ago)
+    buy('KLAC', amount: 3, price: 100, at: 2.days.ago)
+
+    assert_equal (2 * 10) + 3, held('KLAC')
+    assert_equal 2000 + 300, invested('KLAC'), 'a split moves no money'
+  end
+
+  test 'a split after the last order still restates the position' do
+    buy('KLAC', amount: 2, price: 1000, at: 8.days.ago)
+    split(at: 2.days.ago)
+
+    assert_equal 20.to_d, held('KLAC')
+  end
+
+  test 'a split before the first order restates nothing' do
+    split(at: 9.days.ago)
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+
+    assert_equal 2.to_d, held('KLAC')
+  end
+
+  test 'a split of another symbol leaves this one alone' do
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+    buy('AAPL', amount: 4, price: 50, at: 8.days.ago)
+    split(symbol: 'AAPL', at: 5.days.ago)
+
+    assert_equal 2.to_d, held('KLAC')
+    assert_equal 40.to_d, held('AAPL')
+  end
+
+  test 'two restatements compound' do
+    buy('KLAC', amount: 2, price: 1000, at: 9.days.ago)
+    split(at: 6.days.ago, ratio: '2:1', tx_id: 'first')
+    split(at: 3.days.ago, ratio: '5:1', tx_id: 'second')
+
+    assert_equal 20.to_d, held('KLAC')
+  end
+
+  test 'a reverse split divides' do
+    buy('KLAC', amount: 80, price: 1, at: 8.days.ago)
+    split(at: 5.days.ago, ratio: '1:8')
+
+    assert_equal 10.to_d, held('KLAC')
+  end
+
+  test 'a split at an order timestamp is applied before that order' do
+    at = 5.days.ago.change(usec: 0)
+    buy('KLAC', amount: 2, price: 1000, at: 8.days.ago)
+    split(at: at)
+    buy('KLAC', amount: 1, price: 100, at: at)
+
+    assert_equal 21.to_d, held('KLAC'), 'the order acts on the position the split left'
+  end
+
+  # ---- the value it is all read through ----
+
+  test 'the portfolio value does not jump when a split arrives with no trade after it' do
+    buy('KLAC', amount: 2, price: 1000, at: 8.days.ago)
+    before = @bot.metrics(force: true)[:total_amount_value_in_quote]
+
+    split(at: 5.days.ago)
+
+    assert_equal before, @bot.metrics(force: true)[:total_amount_value_in_quote],
+                 'the count went up ten-fold and the last price it traded at went down ten-fold'
+  end
+
+  test 'the split takes a chart point of its own, and the curve does not step' do
+    buy('KLAC', amount: 2, price: 1000, at: 8.days.ago)
+    points_before = @bot.metrics(force: true)[:chart][:labels].size
+
+    split(at: 5.days.ago)
+    chart = @bot.metrics(force: true)[:chart]
+
+    assert_equal points_before + 1, chart[:labels].size
+    assert_equal chart[:series][0][-2], chart[:series][0][-1], 'value is continuous across it'
+    assert_equal 20.to_d, chart[:extra_series].last['KLAC']
+  end
+
+  # ---- sourcing ----
+
+  test 'an adjustment with no provenance restates nothing' do
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+    split(at: 5.days.ago, raw_data: { 'activity_type' => 'JNLC' })
+
+    assert_equal 2.to_d, held('KLAC')
+  end
+
+  test 'a split with no readable factor restates nothing' do
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+    split(at: 5.days.ago, ratio: nil)
+
+    assert_equal 2.to_d, held('KLAC')
+  end
+
+  test 'a symbol with no position is not conjured into the breakdown by its own split' do
+    # The order never executed, so there is no ledger entry — but the symbol is still one the bot
+    # traded, so its split is still loaded.
+    create(:transaction, bot: @bot, exchange: @exchange, base: 'AAPL', quote: 'USD', side: :buy,
+                         status: :skipped, amount: nil, amount_exec: nil, price: nil,
+                         created_at: 8.days.ago)
+    buy('KLAC', amount: 2, price: 100, at: 8.days.ago)
+    split(symbol: 'AAPL', at: 5.days.ago)
+
+    assert_equal ['KLAC'], @bot.metrics(force: true)[:asset_breakdown].keys
+  end
+end

--- a/test/models/bot/composition/restated_sizing_test.rb
+++ b/test/models/bot/composition/restated_sizing_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+# The ledger this restates is not a display: it is what every order the bot places is sized
+# against. A bot reading a tenth of its position buys as if it were 90% underweight, and sells a
+# tenth of what it means to.
+class Bot::Composition::RestatedSizingTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC')
+    @aapl = create(:asset, external_id: 'aapl', symbol: 'AAPL')
+    @bot = create(:dca_multi_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                    base_assets: [@klac, @aapl], quote_asset: @usd)
+    # Equal money into each: 2000 of KLAC at 1000 (2 shares), 2000 of AAPL at 100 (20 shares).
+    buy('KLAC', amount: 2, price: 1000)
+    buy('AAPL', amount: 20, price: 100)
+    Ticker.any_instance.stubs(:get_ask_price).returns(Result::Success.new(100.to_d))
+    Ticker.any_instance.stubs(:get_last_price).returns(Result::Success.new(100.to_d))
+  end
+
+  def buy(symbol, amount:, price:)
+    create(:transaction, bot: @bot, exchange: @exchange, base: symbol, quote: 'USD', side: :buy,
+                         amount: amount, amount_exec: amount, price: price,
+                         quote_amount: amount * price, quote_amount_exec: amount * price,
+                         created_at: 8.days.ago)
+  end
+
+  def split!(symbol: 'KLAC', ratio: '10:1')
+    create(:account_transaction, user: @user, api_key: @api_key, exchange: @exchange,
+                                 entry_type: :adjustment, base_currency: symbol, base_amount: 18,
+                                 quote_currency: nil, quote_amount: nil, transacted_at: 5.days.ago,
+                                 raw_data: { 'corporate_action' => 'split', 'split_ratio' => ratio })
+  end
+
+  def contribution_split
+    result = @bot.send(:get_orders_data, 200)
+    assert_predicate result, :success?
+    result.data.to_h { |order| [order[:ticker].base, order[:quote_amount].to_d] }
+  end
+
+  test 'without the restatement the bot pours a contribution into the split asset' do
+    orders = contribution_split
+
+    # KLAC reads as 2 shares x 100 = 200 against AAPL's 2000: badly underweight, and it is not.
+    assert_operator orders['KLAC'].to_d, :>, (orders['AAPL'] || 0).to_d
+  end
+
+  test 'a restated position is sized as the balanced portfolio it is' do
+    split!
+
+    orders = contribution_split
+
+    assert_in_delta 100.to_d, orders['KLAC'].to_d, 1.to_d
+    assert_in_delta 100.to_d, orders['AAPL'].to_d, 1.to_d
+  end
+
+  test 'a liquidation offers the restated amount, still capped by what is on the exchange' do
+    split!
+    holding = { symbol: 'KLAC', ticker: @bot.tickers.find { |t| t.base == 'KLAC' } }
+    @bot.stubs(:side_price).returns(100.to_d)
+
+    @bot.stubs(:live_free_balance).returns(1_000.to_d)
+    assert_equal 20.to_d, @bot.send(:liquidation_order_data, holding, @bot.metrics(force: true))[:amount]
+
+    @bot.stubs(:live_free_balance).returns(6.to_d)
+    assert_equal 6.to_d, @bot.send(:liquidation_order_data, holding, @bot.metrics(force: true))[:amount],
+                 'shares the user moved out are still not sellable'
+  end
+end

--- a/test/models/bot/restatable_test.rb
+++ b/test/models/bot/restatable_test.rb
@@ -1,0 +1,180 @@
+require 'test_helper'
+
+# Where a bot learns that its share count was restated. Its own `transactions` table records orders
+# and nothing else, so the only account of a corporate action is the broker's, in the ledger the
+# account sync stores.
+class Bot::RestatableTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @alpaca = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @alpaca)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+  end
+
+  def asset_for(symbol)
+    Asset.find_by(symbol: symbol) || create(:asset, external_id: symbol.downcase, symbol: symbol)
+  end
+
+  def bot_trading(symbol, exchange: @alpaca)
+    bot = create(:dca_single_asset, user: @user, exchange: exchange,
+                                    base_asset: asset_for(symbol), quote_asset: @usd, with_api_key: false)
+    trade(bot, symbol, exchange)
+    bot
+  end
+
+  def trade(bot, symbol, exchange)
+    base = asset_for(symbol)
+    unless Ticker.exists?(exchange: exchange, base_asset: base, quote_asset: @usd)
+      create(:ticker, exchange: exchange, base_asset: base, quote_asset: @usd)
+    end
+    create(:transaction, bot: bot, exchange: exchange, base: symbol, quote: 'USD')
+  end
+
+  def split_row(symbol: 'KLAC', ratio: '10:1', at: 3.days.ago, exchange: @alpaca, user: @user, **overrides)
+    raw = { 'corporate_action' => 'split', 'split_ratio' => ratio }.compact
+    api_key = user == @user ? @api_key : create(:api_key, user: user, exchange: exchange)
+    create(:account_transaction, { user: user, api_key: api_key, exchange: exchange, entry_type: :adjustment,
+                                   base_currency: symbol, base_amount: 90, quote_currency: nil,
+                                   quote_amount: nil, transacted_at: at,
+                                   raw_data: raw }.merge(overrides))
+  end
+
+  test 'a split of a symbol the bot traded on that venue becomes an event' do
+    bot = bot_trading('KLAC')
+    at = 3.days.ago
+    split_row(at: at)
+
+    assert_equal [[at, 'KLAC', 10.to_d]], bot.split_events
+  end
+
+  # The date is a de-duplication key, not the event time: `transacted_at` is written by parsing the
+  # venue's date in `Time.zone`, which is per-request here, so rebuilding an instant from a UTC date
+  # would move the split by a day for every zone ahead of UTC.
+  test 'the event keeps the instant the venue booked, and the earliest when two report it' do
+    bot = bot_trading('KLAC')
+    early = Time.utc(2026, 6, 12, 4, 0, 0)
+    split_row(at: Time.utc(2026, 6, 12, 21, 0, 0), tx_id: 'late')
+    split_row(at: early, tx_id: 'early')
+
+    assert_equal early, bot.split_events.sole.first
+  end
+
+  test 'a reverse split is a factor below one' do
+    bot = bot_trading('KLAC')
+    split_row(ratio: '1:8')
+
+    assert_equal (1.to_d / 8), bot.split_events.sole.last
+  end
+
+  test 'a symbol the bot never traded is not its business' do
+    bot = bot_trading('KLAC')
+    split_row(symbol: 'AAPL')
+
+    assert_empty bot.split_events
+  end
+
+  test 'a venue the bot never traded that symbol on is not its business' do
+    kraken = create(:kraken_exchange)
+    bot = bot_trading('KLAC')
+    # The bot also traded something else on Kraken, so the venue is in its history — but not for
+    # this symbol, and a cross-product would wrongly pull this in.
+    trade(bot, 'BTC', kraken)
+    split_row(symbol: 'KLAC', exchange: kraken)
+
+    assert_empty bot.split_events
+  end
+
+  test 'a bot moved to another venue keeps the split of the venue it traded on' do
+    bot = bot_trading('KLAC')
+    split_row
+    bot.update_columns(exchange_id: create(:kraken_exchange).id)
+
+    assert_equal 1, bot.split_events.size
+  end
+
+  test "another user's restatement is not applied" do
+    bot = bot_trading('KLAC')
+    other = create(:user)
+    split_row(user: other)
+
+    assert_empty bot.split_events
+  end
+
+  test 'one action reported twice on the same date is one event' do
+    bot = bot_trading('KLAC')
+    split_row(at: Time.utc(2026, 6, 12, 4, 0, 0), tx_id: 'a')
+    split_row(at: Time.utc(2026, 6, 12, 21, 0, 0), tx_id: 'b')
+
+    assert_equal 1, bot.split_events.size
+  end
+
+  # Alpaca can ship the add leg alone and the merged pair a sync later; the sync keeps both on
+  # purpose. The first says a split happened without saying by how much.
+  test 'a row that names no factor does not veto one that does' do
+    bot = bot_trading('KLAC')
+    split_row(at: Time.utc(2026, 6, 12, 4, 0, 0), ratio: nil, tx_id: 'standalone')
+    split_row(at: Time.utc(2026, 6, 12, 21, 0, 0), ratio: '10:1', tx_id: 'merged')
+
+    assert_equal 10.to_d, bot.split_events.sole.last
+  end
+
+  test 'sources that disagree about the factor restate nothing' do
+    bot = bot_trading('KLAC')
+    split_row(at: Time.utc(2026, 6, 12, 4, 0, 0), ratio: '10:1', tx_id: 'a')
+    split_row(at: Time.utc(2026, 6, 12, 21, 0, 0), ratio: '4:1', tx_id: 'b')
+
+    assert_empty bot.split_events, 'a factor the sources disagree about must move no position'
+  end
+
+  test 'an adjustment with no provenance is not a split' do
+    bot = bot_trading('KLAC')
+    split_row(raw_data: { 'activity_type' => 'JNLC' })
+
+    assert_empty bot.split_events
+  end
+
+  test 'a ratio that cannot be read fails closed' do
+    bot = bot_trading('KLAC')
+    ['', '10', '10:0', '0:10', '-10:1', 'ten:one', '10:1:2', nil].each_with_index do |ratio, i|
+      split_row(ratio: ratio, at: (10 + i).days.ago, tx_id: "bad-#{i}")
+    end
+
+    assert_empty bot.split_events, 'nothing is restated on a factor that could not be parsed'
+  end
+
+  test 'events arrive oldest first' do
+    bot = bot_trading('KLAC')
+    split_row(at: 2.days.ago, tx_id: 'later')
+    split_row(at: 9.days.ago, ratio: '2:1', tx_id: 'earlier')
+
+    assert_equal [2.to_d, 10.to_d], bot.split_events.map(&:last)
+  end
+
+  test 'an action dated ahead of today has not happened yet' do
+    bot = bot_trading('KLAC')
+    split_row(at: 3.days.from_now)
+
+    assert_empty bot.split_events
+    assert_not bot.unresolved_split?, 'and it cannot stand the bot down either'
+  end
+
+  # Deleting the cache keys alone loses a race: a walk that read the ledger just before the split
+  # was stored can finish just after and write its pre-split answer into the hole. Past the bump it
+  # is computing an old key and can only ever write there.
+  test 'expiring moves the keys somewhere a pre-split writer cannot reach' do
+    bot = bot_trading('KLAC')
+    before = bot.send(:metrics_cache_key)
+
+    bot.expire_restated_metrics!
+
+    assert_equal 1, bot.reload.restatement_generation
+    assert_not_equal before, bot.send(:metrics_cache_key)
+  end
+
+  test 'a bot that has never been restated keeps one stable key' do
+    bot = bot_trading('KLAC')
+
+    assert_equal bot.send(:metrics_cache_key), bot.reload.send(:metrics_cache_key)
+    assert_equal 0, bot.restatement_generation
+  end
+end

--- a/test/models/bot/restated_price_quarantine_test.rb
+++ b/test/models/bot/restated_price_quarantine_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+# The one place a restated count can still meet an un-restated price. A venue's "latest trade" is
+# the last trade that actually happened, and a split is effective before the market opens — so
+# between booking one and the first trade on the new basis, the live mark is the OLD price. Ten
+# times the shares at ten times the price is ten times the money, and a rebalancer reading that
+# sees an asset wildly overweight and sells it.
+class Bot::RestatedPriceQuarantineTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC')
+    @aapl = create(:asset, external_id: 'aapl', symbol: 'AAPL')
+    @bot = create(:dca_multi_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                    base_assets: [@klac, @aapl], quote_asset: @usd)
+    create(:transaction, bot: @bot, exchange: @exchange, base: 'KLAC', quote: 'USD', side: :buy,
+                         amount: 2, amount_exec: 2, price: 1000, quote_amount: 2000,
+                         quote_amount_exec: 2000, created_at: 20.days.ago)
+    Exchanges::Alpaca.any_instance.stubs(:get_tickers_prices)
+                     .returns(Result::Success.new('KLACUSD' => 1000.to_d))
+  end
+
+  def split!(at:)
+    create(:account_transaction, user: @user, api_key: @api_key, exchange: @exchange,
+                                 entry_type: :adjustment, base_currency: 'KLAC', base_amount: 18,
+                                 quote_currency: nil, quote_amount: nil, transacted_at: at,
+                                 raw_data: { 'corporate_action' => 'split', 'split_ratio' => '10:1' })
+  end
+
+  test 'a fresh restatement puts the live prices out of trust' do
+    split!(at: 2.hours.ago)
+
+    assert @bot.restated_prices_untrusted?(@bot.metrics(force: true))
+    assert @bot.metrics_with_current_prices(force: true)[:prices_stale]
+  end
+
+  test 'and the rebalancer will not size anything against them' do
+    split!(at: 2.hours.ago)
+
+    assert_nil @bot.send(:rebalance_targets)
+  end
+
+  test 'a restatement the market has long since priced is trusted again' do
+    split!(at: 30.days.ago)
+
+    assert_not @bot.restated_prices_untrusted?(@bot.metrics(force: true))
+    assert_not @bot.metrics_with_current_prices(force: true)[:prices_stale]
+  end
+
+  test 'a bot with no restatement at all is never quarantined' do
+    assert_not @bot.restated_prices_untrusted?(@bot.metrics(force: true))
+    assert_not @bot.metrics_with_current_prices(force: true)[:prices_stale]
+  end
+
+  test 'the value shown during the quarantine is the restated one, not a tenfold one' do
+    split!(at: 2.hours.ago)
+
+    # The walk's own last-known price was restated with the position, so this holds 20 shares at
+    # 100 rather than 20 at the 1000 the venue still reports.
+    assert_equal 2000.to_d, @bot.metrics(force: true)[:total_amount_value_in_quote]
+  end
+
+  test 'a restatement that moved nothing is no reason to stand a bot down' do
+    # Effective before the bot's first fill: the walk changes no holding, so the count and the
+    # price were never on different bases.
+    split!(at: 21.days.ago)
+
+    assert_not @bot.restated_prices_untrusted?(@bot.metrics(force: true))
+  end
+
+  # A split this bot can see and cannot size never comes onto the same basis as the price, so this
+  # one does not expire on a clock.
+  test 'a split with no resolvable factor stands the bot down for as long as it stays unresolved' do
+    split!(at: 60.days.ago)
+    AccountTransaction.last.update!(raw_data: { 'corporate_action' => 'split' })
+
+    assert_predicate @bot, :unresolved_split?
+    assert @bot.restated_prices_untrusted?(@bot.metrics(force: true))
+    assert_nil @bot.send(:rebalance_targets)
+  end
+
+  test 'the DCA leg stands down rather than sizing against the mismatch' do
+    split!(at: 2.hours.ago)
+    @bot.expects(:set_orders).never
+
+    assert_predicate @bot.execute_action, :success?
+    assert_equal 'dca_skipped_restatement', @bot.bot_activity_logs.last&.event
+  end
+end

--- a/test/models/bots/dca_single_asset/restated_holdings_test.rb
+++ b/test/models/bots/dca_single_asset/restated_holdings_test.rb
@@ -1,0 +1,121 @@
+require 'test_helper'
+
+# The single-asset walk keeps a running base amount and a running weighted average of what was paid
+# for it. A split multiplies the first and divides the second; without folding it in, the bot shows
+# a tenth of its position at ten times the price it paid.
+class Bots::DcaSingleAsset::RestatedHoldingsTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC')
+    @bot = create(:dca_single_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                     base_asset: @klac, quote_asset: @usd)
+  end
+
+  def buy(amount:, price:, at:, side: :buy)
+    create(:transaction, bot: @bot, exchange: @exchange, base: 'KLAC', quote: 'USD', side: side,
+                         amount: amount, amount_exec: amount, price: price,
+                         quote_amount: amount * price, quote_amount_exec: amount * price,
+                         created_at: at)
+  end
+
+  def split(ratio: '10:1', at: 5.days.ago, **overrides)
+    create(:account_transaction, { user: @user, api_key: @api_key, exchange: @exchange,
+                                   entry_type: :adjustment, base_currency: 'KLAC', base_amount: 90,
+                                   quote_currency: nil, quote_amount: nil, transacted_at: at,
+                                   raw_data: { 'corporate_action' => 'split',
+                                               'split_ratio' => ratio }.compact }.merge(overrides))
+  end
+
+  def metrics = @bot.metrics(force: true)
+
+  test 'a bot with no restatement is untouched' do
+    buy(amount: 2, price: 100, at: 8.days.ago)
+
+    assert_equal 2.to_d, metrics[:total_base_amount]
+    assert_equal 100.to_d, metrics[:average_buy_price]
+  end
+
+  test 'the position is multiplied and the money is not' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)
+    split(at: 5.days.ago)
+
+    assert_equal 20.to_d, metrics[:total_base_amount]
+    assert_equal 2000.to_d, metrics[:total_quote_amount_invested]
+  end
+
+  test 'the average buy price is restated with the position' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)
+    split(at: 5.days.ago)
+
+    assert_equal 100.to_d, metrics[:average_buy_price], '2000 paid over 20 shares'
+  end
+
+  test 'buys either side of a split average in one unit' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)  # 2000 for what is now 20 shares
+    split(at: 5.days.ago)
+    buy(amount: 30, price: 100, at: 2.days.ago)  # 3000 for 30 shares
+
+    assert_equal 50.to_d, metrics[:total_base_amount]
+    assert_equal 100.to_d, metrics[:average_buy_price], '5000 paid over 50 shares'
+  end
+
+  test 'a reverse split divides the position and lifts the average' do
+    buy(amount: 80, price: 10, at: 8.days.ago)
+    split(at: 5.days.ago, ratio: '1:8')
+
+    assert_equal 10.to_d, metrics[:total_base_amount]
+    assert_equal 80.to_d, metrics[:average_buy_price]
+  end
+
+  test 'the value does not jump when a split arrives with no trade after it' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)
+    before = metrics[:total_amount_value_in_quote]
+
+    split(at: 5.days.ago)
+
+    assert_equal before, metrics[:total_amount_value_in_quote]
+  end
+
+  test 'the split takes a chart point of its own and the curve does not step' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)
+    points_before = metrics[:chart][:labels].size
+
+    split(at: 5.days.ago)
+    chart = metrics[:chart]
+
+    assert_equal points_before + 1, chart[:labels].size
+    assert_equal chart[:series][0][-2], chart[:series][0][-1]
+    assert_equal 20.to_d, chart[:extra_series][0].last
+  end
+
+  test 'a sale after the split is measured against the restated position' do
+    buy(amount: 2, price: 1000, at: 9.days.ago)
+    split(at: 6.days.ago)
+    buy(amount: 20, price: 120, at: 3.days.ago, side: :sell)
+
+    assert_equal 0.to_d, metrics[:total_base_amount], 'twenty shares is the whole position'
+    assert_equal 2400.to_d, metrics[:total_realized_proceeds]
+  end
+
+  test 'a split with no readable factor restates nothing' do
+    buy(amount: 2, price: 1000, at: 8.days.ago)
+    split(at: 5.days.ago, ratio: '')
+
+    assert_equal 2.to_d, metrics[:total_base_amount]
+  end
+
+  # The accumulators behind `average_buy_price` cover every buy the bot ever made, not just the
+  # ones still held — so they have to be restated even when the position is momentarily flat.
+  test 'a position closed before the split and reopened after it averages in one unit' do
+    buy(amount: 1, price: 100, at: 9.days.ago)
+    buy(amount: 1, price: 110, at: 8.days.ago, side: :sell)
+    split(at: 6.days.ago)
+    buy(amount: 10, price: 10, at: 3.days.ago)
+
+    assert_equal 10.to_d, metrics[:average_buy_price], 'ten paid for one share, then ten for ten'
+    assert_equal 10.to_d, metrics[:total_base_amount]
+  end
+end

--- a/test/services/account_transaction_sync_test.rb
+++ b/test/services/account_transaction_sync_test.rb
@@ -843,4 +843,125 @@ class AccountTransactionSyncTest < ActiveSupport::TestCase
 
     assert_empty bot.bot_activity_logs
   end
+
+  # ---- the ledger the split changes ----
+  #
+  # The activity line is a courtesy; the restatement is not. Every cached metrics hash a bot has is
+  # computed from a position this event moves, and `Bot::Rebalancer` reads one of them WITHOUT
+  # forcing — so a stale hash is a sell sized off a tenth of a position.
+
+  def cached_metrics_keys(bot)
+    [bot.send(:metrics_cache_key),
+     bot.send(:metrics_with_current_prices_cache_key),
+     bot.send(:metrics_with_current_prices_and_candles_cache_key)]
+  end
+
+  # The test environment runs a null store, which would make every assertion here vacuous.
+  # Returns the keys it seeded: a restatement moves them, so they have to be captured first.
+  def seed_caches(bot)
+    Rails.stubs(:cache).returns(@memory_cache ||= ActiveSupport::Cache::MemoryStore.new)
+    cached_metrics_keys(bot).each do |key|
+      Rails.cache.write(key, { stale: true })
+      assert_equal({ stale: true }, Rails.cache.read(key))
+    end
+    cached_metrics_keys(bot)
+  end
+
+  test 'a split drops every cached metrics hash of a bot that traded the symbol' do
+    bot = holder
+    stale_keys = seed_caches(bot)
+
+    sync_split!
+
+    stale_keys.each { |key| assert_nil Rails.cache.read(key), "#{key} survived" }
+  end
+
+  test 'and moves the keys past anything a pre-split walk could still write' do
+    bot = holder
+    stale_keys = seed_caches(bot)
+
+    sync_split!
+
+    assert_equal 1, bot.reload.restatement_generation
+    assert_empty (stale_keys & cached_metrics_keys(bot)), 'a pre-split writer can only reach the old keys'
+  end
+
+  test 'a page already open is told to redraw' do
+    bot = holder
+    Bot::BroadcastMetricsUpdateJob.expects(:perform_later).with(bot)
+
+    sync_split!
+  end
+
+  test 'it drops them for a split too old for the feed to keep, which says nothing' do
+    bot = holder(at: 2.years.ago)
+    seed_caches(bot)
+
+    stale = cached_metrics_keys(bot).first
+    sync_split!(split_entry.merge(transacted_at: 1.year.ago))
+
+    assert_empty bot.bot_activity_logs
+    assert_nil Rails.cache.read(stale)
+  end
+
+  test 'it drops them for a bot whose position reads flat, which is told nothing' do
+    bot = holder
+    create(:transaction, bot: bot, exchange: @exchange, base: 'KLAC', quote: 'USD',
+                         side: :sell, created_at: split_at - 2.hours)
+    seed_caches(bot)
+
+    stale = cached_metrics_keys(bot).first
+    sync_split!
+
+    assert_empty bot.bot_activity_logs
+    assert_nil Rails.cache.read(stale)
+  end
+
+  test 'it leaves a bot that traded the symbol on another venue alone' do
+    elsewhere = holder(exchange: create(:kraken_exchange))
+    seed_caches(elsewhere)
+
+    sync_split!
+
+    assert_equal({ stale: true }, Rails.cache.read(cached_metrics_keys(elsewhere).first))
+  end
+
+  test 'an ordinary ledger row drops nothing' do
+    bot = holder
+    seed_caches(bot)
+
+    @exchange.stubs(:get_ledger).returns(Result::Success.new(@ledger_entries))
+    AccountTransactionSync.new(@api_key).sync!
+
+    assert_equal({ stale: true }, Rails.cache.read(cached_metrics_keys(bot).first))
+  end
+
+  # A corporate action dated ahead of today is imported once and takes effect later. No sync comes
+  # back to it — by then the row is a duplicate — so the bump has to be booked for that moment.
+  test 'an action that has not happened yet books its own second bump' do
+    holder
+    effective = 3.days.from_now.change(usec: 0)
+    Bot::ExpireRestatedMetricsJob.expects(:set).with(wait_until: effective)
+                                 .returns(stub(perform_later: true))
+
+    sync_split!(split_entry.merge(transacted_at: effective))
+  end
+
+  test 'an action already in effect books nothing' do
+    holder
+    Bot::ExpireRestatedMetricsJob.expects(:set).never
+
+    sync_split!
+  end
+
+  # The row is stored by the time these run, and a later sync reads it as a duplicate and never
+  # returns — so a failure here must not take the rest of the batch down with it.
+  test 'a failure in the split side effects is logged, not raised' do
+    holder
+    AccountTransactionSync.stubs(:expire_restated_bots).raises(StandardError, 'boom')
+    Rails.logger.expects(:error).with(regexp_matches(/Split side effects failed for KLAC/))
+
+    assert_predicate sync_split!, :success?
+    assert_equal 1, AccountTransaction.where(entry_type: :adjustment).count, 'the row still landed'
+  end
 end


### PR DESCRIPTION
## The gap

A bot's `transactions` table records orders and nothing else. So when a stock splits, the bot never
learns: after a ten-for-one it goes on believing it owns the number of shares it bought.

That ledger is not a display. It is what every order the bot places is sized against:

| Reader | What it does with the count |
|---|---|
| `Bot::Composition::Measurable#metrics` → `asset_breakdown` | the headline value, the P/L, the chart's value curve |
| `Bots::DcaSingleAsset::Measurable#metrics` → `net_base` | the same, plus `average_buy_price` |
| `Bot::Composition::OrderSetter#get_orders_data` | sizes every contribution against the target weights |
| `Bot::Composition::Liquidatable` | sells the ledger amount, capped by the live balance — so it silently under-sells |
| `Bot::Rebalancer` | sizes sells from those values |
| `Bot::Composition::Redeployable` | the same order-sizing path |

The tracker and the tax engines have always handled this — `Tracker::Ledger#quantity_moves`,
`PortfolioSnapshot::BackfillJob` and `Tax::Methods::Fifo#apply_split` all apply the broker's signed
net delta. Only the bot ledger was left out.

## The model: at the moment it happened, not onto today's basis

Holdings are multiplied by the factor **when the split occurred**, which is how the tax engine
already works.

That keeps one ruler across the app. At any past instant the count is the count that was held then,
which is what pairs with an as-traded price — which is what the candle grids, the stored fill prices
and `Tax::PriceService` already are. Nothing about the candle basis, `CandleSeriesCache` or the
fill-price backfill changes. It also keeps the buy marks honest: `chart_buy_marks` shows what an
order actually bought, and restating onto today's basis would leave the curve beneath it counting
different units than the mark above it.

Today's holdings come out fully restated, which is what makes the live headline and every sizing
decision correct.

## Where the factor comes from

The `adjustment` ledger rows the account sync already stores, marked and carrying a `split_ratio`.
`Bot::Restatable#split_events` is the one place that reads them, shared by both metrics walks:

- Sourced against the **`(exchange_id, symbol)` pairs the bot actually traded**, from its own
  orders. Not its current venue — a bot can be moved between brokers and its orders keep the one
  they were placed on — and not a cross-product of the two, which would pull in a split from a venue
  where it never held that symbol.
- Keyed by `(symbol, effective UTC date)`, because a split is an event of the security on a date and
  two sources need not timestamp it identically. The event keeps the earliest instant the group
  reports: `transacted_at` is written by parsing the venue's date in `Time.zone`, which is
  per-request here, so rebuilding an instant from a UTC date would move the split by a day for every
  zone ahead of UTC.
- A row that names **no** factor is silent, not dissenting. A venue can ship the add leg alone and
  the merged pair a sync later, and the sync keeps both on purpose; treating that as a conflict
  would leave the position un-restated forever. Two rows naming **different** factors do suppress
  the event — a share count is not something to guess at.
- The ratio is parsed strictly and fails closed: anything that is not two positive numbers around a
  colon produces no event, and no position moves on a factor that could not be read.

## The fold

One event in two existing chronological walks. At a split of symbol S by factor `f`:

1. `amount *= f`.
2. `invested` untouched — money is basis-invariant, which is what keeps cost basis, realised P/L and
   the rebalance books correct without touching any of them.
3. **The last-known price `/= f`.** Both walks value the portfolio at the price each asset last
   traded at, and that price is pre-split. Without this the value jumps by the factor and stays
   there until the asset next trades — which is the fallback headline a bot shows whenever the live
   read fails.
4. **A chart point is emitted**, as a fill does. `chart_marked_at_market` interpolates between the
   snapshots the walk stores, so with no snapshot at the split every candle point between it and the
   next order would price a pre-split count. Because both sides move together the point's value
   equals the one before it: the curve gains a vertex, not a step.
5. **The single-asset average buy price is restated with it** — accumulated prices `/= f`, amounts
   `*= f`. It is a weighted average over every buy the bot ever made, so it is restated even while
   the position is momentarily flat; otherwise a bot that sold out before a split and bought again
   after it averages two different units into one price.

Splits after the last order are applied after the loop — the ordinary case, since a split lands and
the bot has not traded since.

## The grid must not interpolate across the boundary either

Emitting the point is not enough. `chart_grid_price` draws a straight line between the two candle
marks around a time, and the marks either side of a split are in different units — 2411 the day
before, 254 the day after. A point landing between them is priced at neither and multiplied by a
holding that *is* restated, which is a spike exactly where the chart was supposed to stop having
one.

So each symbol's grid gets two marks pinned at the boundary: the last observed pre-split price one
second before the effective instant, the first observed post-split price at the instant itself. Both
are real observed prices moved to the boundary. Interpolation then stays within one basis on each
side, and the only interval spanning the two is a second wide, which no point can land inside. A
symbol whose grid does not reach both sides is left alone.

## A live price is not trusted while it may still be on the old basis

The one place a restated count can still meet an un-restated price. A venue's "latest trade" is the
last trade that actually happened, and a split is effective before the market opens — so between
booking one and the first trade on the new basis, the live mark is the old price. Ten times the
shares at ten times the price is ten times the money, and a rebalancer reading that sees an asset
wildly overweight and sells real shares to correct a move that never happened.

So while a split is newer than the market's last chance to reprice the security, both automated paths
stand down: the rebalancer through the existing `prices_stale` valve, and the DCA leg through the
same guard the rebalance/liquidation/redeploy skips already use (the contribution is not lost —
`missed_quote_amount` carries it). Gating only `metrics_with_current_prices` would have left
contribution sizing exposed, since `get_orders_data` reads restated holdings and fetches its own
prices.

A split that can be seen and **not sized** — one leg with no counterpart, or two sources naming
different factors — does not expire on a clock: those holdings can never be brought onto the price's
basis, so the stand-down lasts until the factor resolves.

Only a split that actually moved a position counts. One before the bot's first fill, or after it
sold out, changes no holding and is no reason to stand anything down.

## Caches

All three composition keys go to `v6` and `METRICS_CACHE_VERSION` to `v5` (the single-asset concern
derives its three from that constant) — they hold 30 days, so without the bump an existing bot would
serve un-restated numbers for a month.

Every key also carries a **restatement generation**, a new integer column on bots. Deleting keys
alone loses a race: a walk that read the ledger just before the split was stored can finish just
after and write its pre-split answer into the hole, where nothing downstream can tell it apart from
a fresh one — and that hash carries no restatement, so it bypasses the price guard too. Past the bump
that writer is computing an old key and can only ever write there.

When a split lands, `AccountTransactionSync` bumps the generation of every bot the loader would apply
it to, drops the old keys, and enqueues the existing `Bot::BroadcastMetricsUpdateJob` so a page
already open redraws. That runs **before** the activity line's retention guard: whether a bot should
be *told* about a split is a different question from whether its numbers changed. It also uses its
own eligibility rather than the "was holding" filter, which is a rule about who to tell.

The side-effect block is wrapped: the ledger row is already stored by then and a later sync reads it
as a duplicate, so a failure must not take the rest of the batch down, and it is logged at `:error`.

## Compatibility

Inert until a split occurs. With no `adjustment` row carrying a ratio there is no event to fold, and
every existing ledger, cached figure and order size is unchanged. The behaviour begins the first time
a held stock splits.

## Tests

`bin/rails test` — 4871 runs, 18635 assertions, 0 failures.

- a bot with no split produces identical metrics, for both walks — the regression that guards every
  existing bot
- the fold: between two orders, after the last one, before the first, another symbol, two
  compounding, a reverse split, and a split sharing an order's timestamp
- the value does not jump and the chart gains a vertex rather than a step, for both walks
- `average_buy_price` after a forward split, a reverse split, buys either side of one, and a
  position closed before it and reopened after
- sourcing: venue eligibility, a moved bot, another user, one split reported twice, a silent row
  beside a speaking one, sources that disagree, and eight malformed ratios
- a symbol with no position is not conjured into `asset_breakdown` by its own split
- sizing: a contribution splits evenly across a restated portfolio instead of pouring into the asset
  that reads underweight, and a liquidation offers the restated amount still capped by the live
  balance
- the marked value series has neither spike nor step across a real candle grid spanning a split
- the price guard: a fresh split stops both the rebalancer and the DCA leg; one the market has long
  since priced does not; one that moved nothing does not; an unresolved factor stands the bot down
  without a clock; the value shown meanwhile is the restated one
- a split dated ahead of today is not applied and does not stand anything down
- invalidation: all three caches dropped and the keys moved past anything a pre-split walk could
  write, including for a split too old to announce and a bot whose position reads flat; untouched
  for another venue and for an ordinary ledger row; the redraw is enqueued; a failure is logged
  rather than raised
