### PR TITLE
Slide the menu highlight between tiles

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -10,6 +10,10 @@ body
     font-weight: 450
 dialog
   display: block // override default display: none, used if js is disabled
+
+// A page changes like a native view: the menu's highlight moving is the only sign of a visit.
+.turbo-progress-bar
+  display: none !important
 ol, ul
     padding-left: 3.5rem
     display: flex

--- a/app/assets/stylesheets/new/_navbar.sass
+++ b/app/assets/stylesheets/new/_navbar.sass
@@ -82,15 +82,17 @@
       background: var(--washed) !important
       box-shadow: var(--shadow-basic)
       cursor: default
+      // Not !important: the ink is animated between tiles (menu_controller.js), and an important
+      // declaration would outrank the animation. Specificity already beats .fill--icon.
       svg *
-        fill: var(--link) !important
+        fill: var(--link)
       // The tracker's ring is drawn in strokes, and the rule above would fill its arcs into solid
       // wedges. On its own page it wears the portfolio's colours, so only the empty ring — the one
       // with nothing to divide — takes the active ink.
       .icon-24--allocation *
-        fill: none !important
+        fill: none
       .stroke--icon
-        stroke: var(--link) !important
+        stroke: var(--link)
 
   // The highlight is ONE chip that slides between the tiles, the way the .segmented thumb does.
   // CSS places it on the active tile — no measurement, so it is right in a restored snapshot and

--- a/app/assets/stylesheets/new/_navbar.sass
+++ b/app/assets/stylesheets/new/_navbar.sass
@@ -66,19 +66,7 @@
     align-items: center
     position: relative
     border-radius: 2rem
-    .tooltip
-      left: 6rem
-      white-space: nowrap
-      text-align: center
-      padding: 0.5rem 1.25rem
-      line-height: 3rem
-      &::before
-          display: none
-      &__counter
-        opacity: 0.5
-    &.show-tooltip
-      .tooltip
-        left: 7rem
+    transition: all 0.1s ease-in
     svg
       width: 3rem
       height: 3rem
@@ -103,6 +91,38 @@
         fill: none !important
       .stroke--icon
         stroke: var(--link) !important
+
+  // The highlight is ONE chip that slides between the tiles, the way the .segmented thumb does.
+  // CSS places it on the active tile — no measurement, so it is right in a restored snapshot and
+  // after a resize alike; the menu controller only animates the trip between two placements.
+  // Last in the section, so it paints over a tile's hover background: the tile it is arriving
+  // under is the one the cursor is on. Its icon is raised above it below.
+  &__chip
+    display: none
+    position: absolute
+    left: 0
+    width: 6rem
+    height: 6rem
+    border-radius: 2rem
+    background: var(--washed)
+    box-shadow: var(--shadow-basic)
+    pointer-events: none
+  &__section--main-menu
+    // One tile = the 6rem item + the section's 1rem gap, both set above. nth-of-type counts the
+    // <a> tiles only; the chip is a div.
+    @for $i from 1 through 3
+      .menu__item--active:nth-of-type(#{$i}) ~ .menu__chip
+        display: block
+        top: #{($i - 1) * 7rem}
+    .menu__item svg
+      position: relative
+      z-index: 1
+    // The chip draws the pill here. Scoped: the settings trigger below reuses --active as its open
+    // state and keeps the pill of its own. Without this the tile the chip is LEAVING would still
+    // show one until the new page lands.
+    .menu__item--active
+      background: transparent !important
+      box-shadow: none
 
   &__button
     background: none

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -115,6 +115,9 @@ application.register("index-filter", IndexFilterController)
 import MarqueeController from "./marquee_controller"
 application.register("marquee", MarqueeController)
 
+import MenuController from "./menu_controller"
+application.register("menu", MenuController)
+
 import MenuMobileController from "./menu_mobile_controller"
 application.register("menu-mobile", MenuMobileController)
 

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -16,6 +16,9 @@ import { Controller } from "@hotwired/stimulus";
 // until the second response lands and its own controller slides on from there — what a slightly
 // slower hand would have seen. Non-destructive; not worth a render-skipping hack, which would
 // leave the live page with clones of its turbo-permanent elements.
+const ACTIVE = "menu__item--active";
+const TIMING = { duration: 180, easing: "cubic-bezier(0.22, 0.61, 0.36, 1)", fill: "forwards" };
+
 export default class extends Controller {
   static targets = ["chip", "tile"];
 
@@ -64,10 +67,37 @@ export default class extends Controller {
     const target = tile.getBoundingClientRect().top;
     if (visual === target) return;
 
+    this.#ink(tile);
     this.tile = tile;
     this.animation = this.chipTarget.animate(
       [{ transform: `translateY(${visual - base}px)` }, { transform: `translateY(${target - base}px)` }],
-      { duration: 180, easing: "cubic-bezier(0.22, 0.61, 0.36, 1)", fill: "forwards" }
+      TIMING
+    );
+  }
+
+  // The icon ink travels with the chip: the tile it leaves fades to the menu's gray and the tile
+  // it reaches lights up, over the same trip. The colours are the cascade's own — the active class
+  // is moved onto the target, every shape's computed fill and stroke read, and the class put back,
+  // all inside one task: nothing is painted in between and nothing reaches Turbo's snapshot, which
+  // clones the body on a later tick. Reading rather than knowing keeps the tracker's ring honest:
+  // its arcs light up in the portfolio's colours, one each, and only the empty ring takes the ink.
+  #ink(tile) {
+    const current = this.tileTargets.find((candidate) => candidate.classList.contains(ACTIVE));
+    // The previous target too, when a second click lands mid-slide: its half-lit shapes fade back
+    // instead of snapping.
+    const shapes = [...new Set([current, tile, this.tile].filter(Boolean))].flatMap((t) => [...t.querySelectorAll("svg *")]);
+    const read = () => shapes.map((shape) => (({ fill, stroke }) => ({ fill, stroke }))(getComputedStyle(shape)));
+
+    const from = read(); // mid-animation colours, if a slide is in flight
+    this.inks?.forEach((animation) => animation.cancel());
+    current.classList.remove(ACTIVE);
+    tile.classList.add(ACTIVE);
+    const to = read();
+    tile.classList.remove(ACTIVE);
+    current.classList.add(ACTIVE);
+
+    this.inks = shapes.flatMap((shape, i) =>
+      from[i].fill === to[i].fill && from[i].stroke === to[i].stroke ? [] : [shape.animate([from[i], to[i]], TIMING)]
     );
   }
 }

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus";
+
+// The main menu's highlight: one chip that slides between the tiles, the way the .segmented thumb
+// does. Turbo replaces the body on every visit, so the slide has to run on the OUTGOING page — the
+// chip sets off the moment a tile is clicked and, if the new page lands mid-slide, its render is
+// held until the chip has settled (turbo:before-render is cancelable and resumable). The new body
+// arrives with its chip already on the tile, placed by CSS from the server's active class.
+//
+// Nothing here touches the DOM. The chip's real place is CSS state and the slide is a Web
+// Animation: Turbo clones the outgoing body into its snapshot cache a tick after the click, and a
+// class or an inline style flipped here would be cloned with it — Back would then restore the bots
+// page with the tracker tile lit. An Animation is not part of the clone.
+//
+// Known: a second tile clicked while the first response is being held cancels that slide, which
+// resumes the held render (Turbo has no cancellation past that point), so the first page shows
+// until the second response lands and its own controller slides on from there — what a slightly
+// slower hand would have seen. Non-destructive; not worth a render-skipping hack, which would
+// leave the live page with clones of its turbo-permanent elements.
+export default class extends Controller {
+  static targets = ["chip", "tile"];
+
+  connect() {
+    document.addEventListener("turbo:before-render", this.beforeRender);
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-render", this.beforeRender);
+  }
+
+  // No preventDefault: the link navigates. A MODIFIED click opens a new tab and leaves this page
+  // as it was, so the chip stays put — the same rule the segmented control has.
+  select(event) {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button > 0) return;
+    this.#slide(event.currentTarget);
+  }
+
+  // Back/forward and redirects carry no click: the incoming body says which tile is active and
+  // the chip slides there before the swap. Then the hold, for a slide from either path.
+  beforeRender = (event) => {
+    const key = event.detail.newBody.querySelector(".menu__section--main-menu .menu__item--active")?.dataset.tile;
+    const tile = this.tileTargets.find((candidate) => candidate.dataset.tile === key);
+    if (tile) this.#slide(tile);
+    // A hidden document gets no rendering opportunities, so a running animation never reports
+    // finished there — a visit a broadcast started in a background tab would be held until the tab
+    // was looked at. Nobody sees the slide either way: swap, and let CSS place the chip.
+    if (document.hidden || this.animation?.playState !== "running") return;
+
+    event.preventDefault();
+    this.animation.finished.then(event.detail.resume, event.detail.resume);
+  };
+
+  #slide(tile) {
+    // The swap places it; nothing to slide. The reset zeroes CSS transitions under reduced
+    // motion, but a Web Animation has to be told.
+    if (matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    // Chip or whole menu display: none — the mobile breakpoint, or a page with no tile of its own.
+    if (!this.chipTarget.offsetParent) return;
+    // The response landed mid-slide, on its way to this very tile: restarting would hitch the easing.
+    if (this.animation?.playState === "running" && this.tile === tile) return;
+
+    const visual = this.chipTarget.getBoundingClientRect().top; // where the eye has it, mid-slide or not
+    this.animation?.cancel();
+    const base = this.chipTarget.getBoundingClientRect().top; // where CSS has it
+    const target = tile.getBoundingClientRect().top;
+    if (visual === target) return;
+
+    this.tile = tile;
+    this.animation = this.chipTarget.animate(
+      [{ transform: `translateY(${visual - base}px)` }, { transform: `translateY(${target - base}px)` }],
+      { duration: 180, easing: "cubic-bezier(0.22, 0.61, 0.36, 1)", fill: "forwards" }
+    );
+  }
+}

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -8,6 +8,11 @@ export default class extends Controller {
 
   connect() {
     this.showTooltipTimeout = null;
+    document.addEventListener("turbo:before-cache", this.hideTooltip);
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-cache", this.hideTooltip);
   }
 
   // A click is deliberate: no delay, and positioned before it is revealed, like a hover.
@@ -30,7 +35,10 @@ export default class extends Controller {
     this.#setTooltipTimeout();
   }
 
-  hideTooltip() {
+  // Also on turbo:before-cache: Turbo clones the body into its snapshot cache at the moment a
+  // link is clicked — with the clicked element's tooltip open. Left there, the preview render
+  // on the way back to this page would paint that tooltip under a cursor that is somewhere else.
+  hideTooltip = () => {
     this.#clearTimeouts();
     this.element.classList.remove("show-tooltip");
 

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -8,22 +8,22 @@
 .menu-mobile{ data: { controller: 'menu-mobile', action: 'click->menu-mobile#close' } }
   - if single_bot_mode?
     - single_bot_path = bot_path(current_user.bots.not_deleted.first)
-    = link_to single_bot_path, class: "menu-mobile__item menu-mobile__item--bots #{'menu-mobile__item--active' if current_page?(single_bot_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+    = link_to single_bot_path, class: "menu-mobile__item menu-mobile__item--bots #{'menu-mobile__item--active' if current_page?(single_bot_path)}" do
       = t('links.bot')
   - else
-    = link_to bots_path, class: "menu-mobile__item menu-mobile__item--bots #{'menu-mobile__item--active' if current_page?(bots_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+    = link_to bots_path, class: "menu-mobile__item menu-mobile__item--bots #{'menu-mobile__item--active' if current_page?(bots_path)}" do
       = t('links.bots')
 
-  = link_to tracker_path, class: "menu-mobile__item menu-mobile__item--tracker #{'menu-mobile__item--active' if current_page?(tracker_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+  = link_to tracker_path, class: "menu-mobile__item menu-mobile__item--tracker #{'menu-mobile__item--active' if current_page?(tracker_path)}" do
     = t('links.tracker')
 
-  = link_to rules_path, class: "menu-mobile__item menu-mobile__item--rules #{'menu-mobile__item--active' if current_page?(rules_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+  = link_to rules_path, class: "menu-mobile__item menu-mobile__item--rules #{'menu-mobile__item--active' if current_page?(rules_path)}" do
     = t('links.rules')
 
-  = link_to settings_connect_path, class: "menu-mobile__item menu-mobile__item--connections #{'menu-mobile__item--active' if current_page?(settings_connect_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+  = link_to settings_connect_path, class: "menu-mobile__item menu-mobile__item--connections #{'menu-mobile__item--active' if current_page?(settings_connect_path)}" do
     = t('links.connections')
 
-  = link_to settings_account_path, class: "menu-mobile__item menu-mobile__item--account #{'menu-mobile__item--active' if current_page?(settings_account_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+  = link_to settings_account_path, class: "menu-mobile__item menu-mobile__item--account #{'menu-mobile__item--active' if current_page?(settings_account_path)}" do
     = t('links.account')
 
   = render 'layouts/navbar/hide_balances_toggle', item_class: 'menu-mobile__item'
@@ -38,29 +38,25 @@
     = link_to (single_bot_mode? ? bot_path(current_user.bots.not_deleted.first) : bots_path), class: 'menu__logo', 'aria-label': 'Deltabadger' do
       = render 'svg/40x30_logo'
 
-  .menu__section.menu__section--top.menu__section--main-menu
+  .menu__section.menu__section--top.menu__section--main-menu{ data: { controller: 'menu' } }
 
     - if single_bot_mode?
       - single_bot_path = bot_path(current_user.bots.not_deleted.first)
-      = link_to single_bot_path, class: "menu__item menu__item--bots #{'menu__item--active' if current_page?(single_bot_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+      = link_to single_bot_path, class: "menu__item menu__item--bots #{'menu__item--active' if current_page?(single_bot_path)}", 'aria-label': t('links.bot'), data: { action: 'click->menu#select', menu_target: 'tile', tile: 'bots' } do
         = render 'svg/24x24_bot_count', count: bot_menu_count(current_user)
-        .tooltip
-          = t('links.bot')
     - else
-      = link_to bots_path, class: "menu__item menu__item--bots #{'menu__item--active' if current_page?(bots_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+      = link_to bots_path, class: "menu__item menu__item--bots #{'menu__item--active' if current_page?(bots_path)}", 'aria-label': t('links.bots'), data: { action: 'click->menu#select', menu_target: 'tile', tile: 'bots' } do
         = render 'svg/24x24_bot_count', count: bot_menu_count(current_user)
-        .tooltip
-          = t('links.bots')
 
-    = link_to tracker_path, class: "menu__item menu__item--tracker #{'menu__item--active' if current_page?(tracker_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+    = link_to tracker_path, class: "menu__item menu__item--tracker #{'menu__item--active' if current_page?(tracker_path)}", 'aria-label': t('links.tracker'), data: { action: 'click->menu#select', menu_target: 'tile', tile: 'tracker' } do
       = render 'svg/24x24_allocation', arcs: allocation_icon_arcs(current_user)
-      .tooltip
-        = t('links.tracker')
 
-    = link_to rules_path, class: "menu__item menu__item--rules #{'menu__item--active' if current_page?(rules_path)}", data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip' } do
+    = link_to rules_path, class: "menu__item menu__item--rules #{'menu__item--active' if current_page?(rules_path)}", 'aria-label': t('links.rules'), data: { action: 'click->menu#select', menu_target: 'tile', tile: 'rules' } do
       = render 'svg/24x24_withdrawal'
-      .tooltip
-        = t('links.rules')
+
+    -# The highlight. Placed by CSS on whichever tile is active (see _navbar.sass) and slid between
+      tiles by the menu controller; last, so it paints over the tiles' hover backgrounds.
+    .menu__chip{ data: { menu_target: 'chip' } }
 
   .menu__section.menu__section--bottom
     -# Permanent: flipping the switch inside re-renders the page, and a menu that vanished mid-flip
@@ -68,10 +64,8 @@
       visit, so it stays open and stays on the state the user just set. Nothing in it is page-
       dependent, so keeping the old node costs nothing.
     .dropdown-wrapper.dropdown-wrapper--bottom-left#settings-menu{ data: { turbo_permanent: true, controller: "dropdown", action: "click->dropdown#toggle", dropdown_target: "wrapper", dropdown_active_class: "menu__item--active" } }
-      .menu__item.menu__button{ data: { controller: 'tooltip', action: 'mouseenter->tooltip#showTooltip mouseleave->tooltip#hideTooltip', dropdown_target: "trigger" } }
+      .menu__item.menu__button{ data: { dropdown_target: "trigger" } }
         = render 'svg/24x24_sliders'
-        .tooltip
-          = t('links.settings')
       .dropdown
         = link_to t('links.connections'), settings_connect_path, class: "dropdown__item"
         = link_to t('links.account'), settings_account_path, class: "dropdown__item"

--- a/test/controllers/menu_chip_test.rb
+++ b/test/controllers/menu_chip_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The desktop menu's highlight is one chip that slides between the tiles. The slide is done in the
+# browser, but it matches the incoming page's active tile by `data-tile`, and the chip is placed by
+# CSS from that same class — so every signed-in page has to render the section the controller
+# expects: the chip, and at most ONE active tile, each tile named.
+class MenuChipTest < ActionDispatch::IntegrationTest
+  MENU = '.menu__section--main-menu[data-controller=menu]'
+
+  setup do
+    create(:user, admin: true) # satisfies the onboarding gate (an admin must exist)
+    @user = create(:user)
+    sign_in @user
+  end
+
+  { bots: :bots_path, tracker: :tracker_path, rules: :rules_path }.each do |tile, route|
+    test "the #{tile} page lights the #{tile} tile alone" do
+      get send(route)
+
+      assert_menu_with_active tile
+    end
+  end
+
+  test 'a single-bot account lights the bots tile on that bot' do
+    bot = create(:dca_single_asset, user: @user)
+
+    get bot_path(id: bot.id)
+
+    assert_menu_with_active :bots
+  end
+
+  test 'a page with no tile of its own still renders the chip, unlit' do
+    get settings_account_path
+
+    assert_select MENU do
+      assert_select '.menu__chip[data-menu-target=chip]', 1
+      assert_select '.menu__item--active', 0
+    end
+  end
+
+  private
+
+  def assert_menu_with_active(tile)
+    assert_select MENU do
+      assert_select '.menu__chip[data-menu-target=chip]', 1
+      assert_select '.menu__item[data-menu-target=tile][data-tile]', 3
+      assert_select '.menu__item--active', 1
+      assert_select ".menu__item--active[data-tile=#{tile}]", 1
+    end
+  end
+end


### PR DESCRIPTION
The desktop menu's highlight is now one chip that slides to the clicked tile, like the segmented control's thumb. Pages still swap instantly — no view transitions — and Turbo's progress bar is hidden, so the chip moving is the only sign of a visit.

## How it works

- **Placement is CSS.** `.menu__item--active:nth-of-type(n) ~ .menu__chip` sets the chip's `top` from the server's own active class. No measurement, so a restored snapshot, a resize, or a page with no tile of its own (settings) is always right.
- **The slide is a Web Animation, never a DOM change.** Turbo clones the outgoing body into its snapshot cache a tick after the click; a class or inline style flipped on click would be cloned with it and Back would restore the page with the wrong tile lit. An animation is not part of the clone.
- **The render waits for the chip.** `turbo:before-render` is held (`preventDefault` / `resume`) until the animation settles — at most 180ms — then the new body lands with its chip already placed. Skipped in a hidden document, where an animation never reports finished.
- **The icon ink travels with the chip.** The tile being left fades to the menu's gray and the tile being reached lights up over the same 180ms, as Web Animations on every shape. The colours are read from the cascade (active class moved, computed `fill`/`stroke` read, class put back, all in one task), so the tracker ring's arcs light up in their own portfolio colours. The active ink rules drop their `!important`, which an animation can't outrank.
- **Back/forward slide too**, from the incoming body's active tile, and modified clicks (new tab) leave the chip put.
- The chip paints over a tile's hover background (it arrives under the cursor) with the icon raised above it; main-menu active tiles draw no pill of their own, so the tile being left never shows a second highlight.

## Also

- Menu icons lose their tooltips; the tiles carry `aria-label`s instead.
- The tooltip controller closes on `turbo:before-cache`: a tooltip open at the moment of a click used to freeze into the snapshot and reappear on the cached preview under a cursor that had moved on.

## Known

Clicking a second tile while the first response is being held renders the first page until the second response lands, then slides on from there — what a slightly slower hand would have seen. Turbo has no render cancellation past that point; skipping the render would strand its permanent elements as clones.

Tests cover the markup the controller relies on: one named active tile per page, the chip present, single-bot mode, and a page with no tile.

