### PR TITLE
Keep the progress bar off menu visits only; ignore repeat clicks

### DIFF
--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -11,8 +11,9 @@ body
 dialog
   display: block // override default display: none, used if js is disabled
 
-// A page changes like a native view: the menu's highlight moving is the only sign of a visit.
-.turbo-progress-bar
+// On a menu-tile visit the highlight moving is the sign of the visit, so Turbo's bar stays out
+// of it. Everywhere else the bar is the only sign there is — see menu_controller.js.
+html[data-menu-visit] .turbo-progress-bar
   display: none !important
 ol, ul
     padding-left: 3.5rem

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -23,6 +23,33 @@ Turbo.StreamActions.remove_class = function () {
   this.targetElements.forEach((element) => element.classList.remove(className));
 };
 
+// A repeat click on the link whose visit is already in flight would abort that request and start
+// the render over — and the server still renders the abandoned one, ahead of the new one. Only the
+// identical URL is ignored; a different link still cancels the visit and moves on. Both events are
+// cancelled: a turbo:click left unfollowed falls through to the browser as a full navigation.
+document.addEventListener("turbo:click", (event) => {
+  const visit = Turbo.navigator.currentVisit;
+  if (visit?.state !== "started" || visit.location.href !== event.detail.url) return;
+  // Only a navigation duplicating a navigation: a Back/Forward restoration or a page refresh in
+  // flight is not what the click asked for, and a frame-targeted link is its own navigation even
+  // at the same URL.
+  if (visit.action === "restore" || visit.isPageRefresh) return;
+  if (event.target.closest("turbo-frame") || event.target.hasAttribute("data-turbo-frame")) return;
+
+  event.preventDefault();
+  event.detail.originalEvent.preventDefault();
+});
+
+// The menu controller stamps data-menu-visit on <html> for a menu-tile visit, which hides Turbo's
+// progress bar for that visit alone. turbo:visit fires only when a visit STARTS, and a form
+// submission emits none while its request runs — and starting one cancels the visit in flight
+// without a load or an error of its own — so the stamp has to come off when the visit ends or is
+// cut short. Here, rather than in the controller, because the page the visit lands on may not
+// carry the menu at all (a session that expired mid-visit lands on the sign-in layout).
+["turbo:load", "turbo:fetch-request-error", "turbo:submit-start"].forEach((name) =>
+  document.addEventListener(name, () => document.documentElement.removeAttribute("data-menu-visit"))
+);
+
 // Turbo keeps a snapshot of every page visited and restores it, without a request, when the user
 // goes Back. Turning "Hide balances" on therefore leaves the balances one Back press away: the
 // snapshot was taken while they were still on screen, and a broadcast refresh reaches the live

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -24,18 +24,33 @@ export default class extends Controller {
 
   connect() {
     document.addEventListener("turbo:before-render", this.beforeRender);
+    document.addEventListener("turbo:visit", this.visit);
   }
 
   disconnect() {
     document.removeEventListener("turbo:before-render", this.beforeRender);
+    document.removeEventListener("turbo:visit", this.visit);
   }
 
   // No preventDefault: the link navigates. A MODIFIED click opens a new tab and leaves this page
   // as it was, so the chip stays put — the same rule the segmented control has.
   select(event) {
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button > 0) return;
+    // Turbo starts the visit inside this same click, so the latch is consumed before the
+    // microtask clears it — and a click Turbo does not follow leaves nothing behind.
+    this.clicked = true;
+    queueMicrotask(() => (this.clicked = false));
     this.#slide(event.currentTarget);
   }
+
+  // Turbo's progress bar is the sign of a visit still in flight. On a menu-tile visit the chip
+  // already is that sign, so the bar stays hidden — and ONLY there: a first visit to a bot page
+  // paints nothing until the response, and with no bar it reads as a dead click. Stamped on
+  // <html>, which survives the body swap and is never part of a snapshot; application.js takes
+  // it off when the visit ends, and the next visit restamps it either way.
+  visit = () => {
+    document.documentElement.toggleAttribute("data-menu-visit", this.clicked === true);
+  };
 
   // Back/forward and redirects carry no click: the incoming body says which tile is active and
   // the chip slides there before the swap. Then the hold, for a slide from either path.


### PR DESCRIPTION
Follow-up to #315. Two small fixes for a first visit to a bot page appearing to ignore clicks.

## What was happening

A page visited before paints its cached copy instantly; a first visit shows nothing until the response — and #315 hid Turbo's progress bar everywhere, so that first click looked dead and got clicked again. Each repeat click makes Turbo abort the in-flight request and start over, while the server still renders the abandoned one; with a single Puma thread those abandoned renders queue ahead of the one the browser is actually waiting for, so a few impatient clicks turned into seconds of nothing.

## Changes

- **The progress bar is hidden only for menu-tile visits**, where the sliding chip is already the sign of the visit. `select()` latches the click, the `turbo:visit` that Turbo starts inside that same click stamps `data-menu-visit` on `<html>` (never part of a snapshot, survives the body swap), and the CSS rule is scoped to it. `turbo:load` / `turbo:fetch-request-error` / `turbo:submit-start` take the stamp off when the visit ends or is cut short — a form submission emits no `turbo:visit` while its request runs (and starting one cancels the visit in flight), so a lingering stamp would have hidden its bar too. Everywhere else — bot pages, forms, mobile — Turbo's bar behaves as it did before #315.
- **A repeat click on the link whose visit is already in flight is ignored.** A `turbo:click` guard compares the URL with `Turbo.navigator.currentVisit`; only the identical URL is dropped — and not during a Back/Forward restoration or a page refresh, nor for a frame-targeted link — so clicking a different link still cancels and moves on. Both the Turbo event and the native click are cancelled — an unfollowed `turbo:click` would otherwise fall through to the browser as a full navigation.

Verified in the browser: three clicks on one link produce one visit, the second and third are cancelled at both levels, and a different link during the in-flight visit starts its own.
