### PR TITLE
Draw the chart's price overlay on the venue's restated history

### DIFF
--- a/app/models/bot/chart_series.rb
+++ b/app/models/bot/chart_series.rb
@@ -83,8 +83,8 @@ module Bot::ChartSeries
 
   # The seam every candle fetch goes through. Overridable in tests, and the reason the index's
   # bounded-parallel fetch can be exercised without touching the cache.
-  def fetch_candle_series(ticker:, since:, timeframe:)
-    CandleSeriesCache.fetch(ticker: ticker, since: since, timeframe: timeframe)
+  def fetch_candle_series(ticker:, since:, timeframe:, restated: false)
+    CandleSeriesCache.fetch(ticker: ticker, since: since, timeframe: timeframe, restated: restated)
   end
 
   # A grid prices only the span it covers, and `chart_marked_at_market` drops a point outright when
@@ -180,7 +180,20 @@ module Bot::ChartSeries
   #             carries a per-symbol split (:assets) for the holdings tables to hover against.
   #             Omitted where the split would only duplicate the portfolio line — a single-asset
   #             bot's one holding IS the whole chart.
-  def chart_marked_at_market(chart, grids, holdings:, cash:, basis: nil)
+  # display_grids: - the grids the PRICE OVERLAY is read off, where they differ. Defaults to the
+  #             valuation grids, and on all but a restating venue that is what they are.
+  #
+  # Two grids because a split is the one place the two readings cannot be one. Values are
+  # as-traded — the walk counts the shares the bot bought, and they can only be multiplied by the
+  # prices the market quoted, since a bot that sold out before an effective date is never restated
+  # by the broker and no factor for it can be recovered. The overlay multiplies nothing and the
+  # browser rebases it against its own first point in view, so it reads as a return: the return of
+  # a raw series across a split is a 90% crash that never happened.
+  #
+  # Only `marked_prices` may read `display_grids`. The axis, the market values, the per-symbol
+  # split and everything hung off it stay on `grids`.
+  def chart_marked_at_market(chart, grids, holdings:, cash:, basis: nil, display_grids: nil)
+    display_grids ||= grids
     labels = chart[:labels]
     values = chart[:series][0]
     invested = chart[:series][1]
@@ -192,10 +205,9 @@ module Bot::ChartSeries
     marked_invested = []
     marked_split = []
     marked_basis = []
-    # One series per grid, parallel with the marked labels: the same readings the values above
-    # are marked with, kept so the chart can draw the price behind the curve without a second
-    # fetch and without a second ruler.
-    marked_prices = grids.keys.index_with { [] }
+    # One series per grid, parallel with the marked labels, kept so the chart can draw the price
+    # behind the curve without the browser fetching anything of its own.
+    marked_prices = display_grids.keys.index_with { [] }
     cursor = 0
 
     axis.each do |time|
@@ -231,7 +243,7 @@ module Bot::ChartSeries
       marked_invested << invested[cursor]
       # nil outside the grid's reach — the same points the values keep on their fill marks. The
       # curve skips them rather than being drawn through a price nobody quoted.
-      marked_prices.each { |symbol, serie| serie << chart_grid_price(grids[symbol], time) }
+      marked_prices.each { |symbol, serie| serie << chart_grid_price(display_grids[symbol], time) }
       next unless basis
 
       # nil where the point kept its fill mark: the portfolio total survives there, but no

--- a/app/models/bot/composition/measurable.rb
+++ b/app/models/bot/composition/measurable.rb
@@ -181,6 +181,7 @@ module Bot::Composition::Measurable
       priceable = tickers.map(&:base)
       metrics_data[:chart] = chart_marked_at_market(
         metrics_data[:chart], grids,
+        display_grids: chart_display_grids(metrics_data, grids),
         holdings: ->(i) { (metrics_data[:chart][:extra_series][i] || {}).slice(*priceable) },
         basis: ->(i) { ((metrics_data[:chart][:invested_series] || [])[i] || {}).slice(*priceable) },
         # Cash a rebalance sell realized but its buy has not spent yet — and, when a remainder ends
@@ -325,11 +326,46 @@ module Bot::Composition::Measurable
     return nil if symbols.empty?
 
     since, timeframe = chart_candle_window(metrics_data[:chart])
+    grids = chart_candle_grids(symbols, metrics_data, since: since, timeframe: timeframe)
+
+    # One member the candles do not cover would otherwise blank the interpolation for every member.
+    labels = metrics_data[:chart][:labels]
+    chart_split_pinned_grids(
+      chart_backfilled_grids(grids, symbols: symbols, from: labels.first, to: labels.last)
+    )
+  end
+
+  # The overlay's own grids: each restating symbol's history as its venue reads it TODAY, one
+  # basis end to end. No pins and no fill backfill — both exist to carry a VALUATION across a
+  # seam these grids do not have, and a fill price is as-traded, which on this basis it is not.
+  #
+  # Merged over the valuation grids per symbol, never wholesale: a basket can hold stocks beside
+  # crypto, and one ticker whose restated fetch failed must not take the other nineteen back with
+  # it. A symbol left behind keeps the raw line this chart has always drawn.
+  def chart_display_grids(metrics_data, grids)
+    restating = restating_symbols & metrics_data[:asset_breakdown].keys
+    return grids if restating.empty?
+
+    since, timeframe = chart_candle_window(metrics_data[:chart])
+    grids.merge(chart_candle_grids(restating, metrics_data, since: since, timeframe: timeframe,
+                                                            restated: true))
+  end
+
+  # Which members have a history their venue rewrites. One query for the categories rather than
+  # one per member: the question reaches `ticker.base_asset`, and a chart drawn from warm candle
+  # caches otherwise loads no asset row at all.
+  def restating_symbols
+    list = tickers
+    list = list.preload(:base_asset) if list.is_a?(ActiveRecord::Relation)
+    list.select(&:restated_candles?).map(&:base)
+  end
+
+  # Bounded parallel batches. A raise in one worker becomes a per-symbol failure (logged);
+  # failed symbols are skipped and retried on the next 5-minute metrics cycle.
+  def chart_candle_grids(symbols, metrics_data, since:, timeframe:, restated: false)
     ticker_by_symbol = tickers.index_by(&:base)
     grids = {}
 
-    # Bounded parallel batches. A raise in one worker becomes a per-symbol failure (logged);
-    # failed symbols are skipped and retried on the next 5-minute metrics cycle.
     symbols.each_slice(CANDLE_FETCH_THREADS) do |batch|
       threads = batch.filter_map do |symbol|
         ticker = ticker_by_symbol[symbol]
@@ -338,7 +374,8 @@ module Bot::Composition::Measurable
         Thread.new do
           result = begin
             Rails.application.executor.wrap do
-              fetch_candle_series(ticker: ticker, since: since, timeframe: timeframe)
+              fetch_candle_series(ticker: ticker, since: since, timeframe: timeframe,
+                                  restated: restated)
             end
           rescue StandardError => e
             Rails.logger.error("Candle fetch failed for #{symbol}: #{e.class}: #{e.message}")
@@ -360,15 +397,7 @@ module Bot::Composition::Measurable
       end
     end
 
-    # One member the candles do not cover would otherwise blank the interpolation for every member.
-    labels = metrics_data[:chart][:labels]
-    chart_split_pinned_grids(
-      chart_backfilled_grids(grids, symbols: symbols, from: labels.first, to: labels.last)
-    )
-  end
-
-  def fetch_candle_series(ticker:, since:, timeframe:)
-    CandleSeriesCache.fetch(ticker: ticker, since: since, timeframe: timeframe)
+    grids
   end
 
   def calculate_pnl(from, to)

--- a/app/models/bots/dca_single_asset/measurable.rb
+++ b/app/models/bots/dca_single_asset/measurable.rb
@@ -136,6 +136,7 @@ module Bots::DcaSingleAsset::Measurable
 
       metrics_data[:chart] = chart_marked_at_market(
         metrics_data[:chart], grids,
+        display_grids: chart_display_grids(metrics_data, grids),
         holdings: ->(i) { { ticker.base => metrics_data[:chart][:extra_series][0][i] } },
         # Realized proceeds are locked-in cash: they do not float with the price.
         cash: ->(i) { metrics_data[:chart][:extra_series][1][i] || 0 }
@@ -302,5 +303,31 @@ module Bots::DcaSingleAsset::Measurable
     marks = result.data.map { |candle| [candle[0], candle[1]] } +
             chart_live_marks(metrics_data, ticker.base)
     chart_split_pinned_grids(ticker.base => marks.sort_by(&:first))
+  end
+
+  # The overlay's own grid: the venue's history as it reads TODAY, restated across every split it
+  # has had. One basis end to end, so no pins and no fill backfill — both of those exist to carry
+  # a valuation across a seam this grid does not have.
+  #
+  # The valuation grid where the venue restates nothing, or where the restated fetch fails: a raw
+  # line with a step in it is what this chart has always drawn, and it beats no line at all.
+  def chart_display_grids(metrics_data, grids)
+    return grids unless ticker&.restated_candles?
+
+    since, timeframe = chart_candle_window(metrics_data[:chart])
+    # Rescued, unlike the valuation fetch beside it: this one is an improvement on a grid the
+    # chart already has, and a transient socket error on it must cost the overlay's basis, not
+    # the whole chart. Alpaca's client raises rather than returning a failed Result.
+    result = begin
+      fetch_candle_series(ticker: ticker, since: since, timeframe: timeframe, restated: true)
+    rescue StandardError => e
+      Rails.logger.error("Restated candle fetch failed for #{ticker.base}: #{e.class}: #{e.message}")
+      Result::Failure.new(e.message)
+    end
+    return grids if result.failure? || result.data.blank?
+
+    marks = result.data.map { |candle| [candle[0], candle[1]] } +
+            chart_live_marks(metrics_data, ticker.base)
+    { ticker.base => marks.sort_by(&:first) }
   end
 end

--- a/app/models/candle_series_cache.rb
+++ b/app/models/candle_series_cache.rb
@@ -7,20 +7,33 @@
 # the series is kept for 30 days and only the tail since the last cached candle is
 # fetched. A cache eviction degrades gracefully to one full fetch — the old behaviour.
 #
-# Tail fetches are filtered by open_time > last cached open_time, so exchanges with
-# inclusive or otherwise quirky start_at semantics can at worst return a few redundant
-# candles, never corrupt the series. The in-progress candle is never stored.
+# Immutable UNTIL a corporate action, which is not a new candle but a rewrite of every old one.
+# Appending a tail across a 10:1 split leaves the stored series half in one basis and half in
+# another, so the tail overlaps the last stored candle by one bar and that bar is compared —
+# see #restated_since?.
+#
+# `restated:` picks which of a venue's two histories this is: the prices as they were traded, or
+# the same prices restated onto today's share basis. They are different series and are stored
+# apart, on venues that have both.
 class CandleSeriesCache
   TTL = 30.days
 
-  def self.fetch(ticker:, since:, timeframe:)
-    new(ticker: ticker, since: since, timeframe: timeframe).fetch
+  # How far a re-read of a stored bar may move before it stops being rounding. Every real
+  # restatement is a whole small ratio away — 3:2 is the narrowest in common use, and that is 33%.
+  RESTATEMENT_TOLERANCE = 0.001
+
+  def self.fetch(ticker:, since:, timeframe:, restated: false)
+    new(ticker: ticker, since: since, timeframe: timeframe, restated: restated).fetch
   end
 
-  def initialize(ticker:, since:, timeframe:)
+  def initialize(ticker:, since:, timeframe:, restated: false)
     @ticker = ticker
     @since = since
     @timeframe = timeframe
+    # A venue that rewrites nothing has ONE history, so both callers share a key and the overlay
+    # costs a cache read rather than a second request. Asked once, here, so the key and the fetch
+    # can never disagree about which series this is.
+    @restated = restated && ticker.restated_candles?
   end
 
   # Result::Success with the closed-candle series ([open_time, o, h, l, c, v] rows),
@@ -31,6 +44,10 @@ class CandleSeriesCache
 
     # The next closed candle opens at last_open + timeframe and closes one timeframe
     # later; before that moment there is nothing new to fetch.
+    #
+    # ponytail: a restatement is therefore seen no sooner than the next candle is due — up to two
+    # days on a daily grid, during which the overlay carries the seam. Revalidating on every read
+    # would give up what this class is for; fetch the venue's corporate-action feed if it matters.
     last_open = cached.last[0]
     return Result::Success.new(cached) if Time.now.utc < last_open + (2 * @timeframe)
 
@@ -41,28 +58,81 @@ class CandleSeriesCache
 
   def refresh(existing: [])
     last_open = existing.last&.first
-    start_at = last_open ? last_open + 1.second : @since
-
-    result = @ticker.get_candles(start_at: start_at, timeframe: @timeframe)
+    # AT the last stored candle, not past it: the overlap bar is what tells a rewritten history
+    # from a continuing one, and one redundant candle is what it costs.
+    result = fetch_candles(start_at: last_open || @since)
     return result if result.failure?
 
-    # A candle is closed once its period has elapsed. Checking explicitly (rather than
-    # dropping the last returned candle) matters for closed markets: a weekend tail
-    # fetch returns Friday's fully-closed bar last, with no in-progress bar after it.
-    closed = result.data.select { |c| c[0] + @timeframe <= Time.now.utc }
-    fresh = last_open ? closed.select { |c| c[0] > last_open } : closed
-    # uniq+sort is cheap insurance against exchanges returning unordered/overlapping
-    # tails; concat of two sorted disjoint ranges is already the common case.
-    candles = (existing + fresh).uniq { |c| c[0] }.sort_by { |c| c[0] }
-    # Concurrent refreshes of the same series can interleave; the losing write is a
-    # valid (possibly slightly shorter) series and the next tail fetch repairs it, so
-    # no read-merge-write dance is warranted for a cache.
-    Rails.cache.write(cache_key, candles, expires_in: TTL) if candles.present?
+    closed = closed_candles(result.data)
+    return rebuild if last_open && restated_since?(existing.last, closed)
 
+    fresh = last_open ? closed.select { |candle| candle[0] > last_open } : closed
+    store(existing + fresh)
+  end
+
+  # The venue's own reading of a bar this cache already holds. A closed candle does not drift, so
+  # a disagreement is not noise — it is the history rewritten behind us, and every bar before the
+  # seam is on a basis the ones after it are not.
+  #
+  # A MISSING overlap says the same thing, but only where the venue restates: Alpaca documents its
+  # `start` as inclusive, so a bar it will not return from that instant is a bar it no longer has.
+  # Elsewhere a venue may simply read `start` exclusively, and rebuilding on that would refetch the
+  # whole history on every tail forever.
+  def restated_since?(last, closed)
+    overlap = closed.find { |candle| candle[0] == last[0] }
+    return @restated if overlap.nil?
+
+    before = last[1].to_d
+    after = overlap[1].to_d
+    return false if before.zero? || after.zero?
+
+    ((after - before) / before).abs > RESTATEMENT_TOLERANCE
+  end
+
+  # One full fetch, and never a second: a rebuild is already the expensive path, and a recursive
+  # one on a venue that keeps disagreeing with itself would be unbounded. A rebuild that fails or
+  # comes back empty leaves the stored series alone — a series on a stale basis still draws a
+  # chart, and dropping it on the way to fixing it draws none.
+  def rebuild
+    result = fetch_candles(start_at: @since)
+    return result if result.failure?
+
+    candles = closed_candles(result.data)
+    return Result::Success.new(candles) if candles.blank?
+
+    store(candles)
+  end
+
+  def fetch_candles(start_at:)
+    if @restated
+      @ticker.get_indicator_candles(start_at: start_at, timeframe: @timeframe)
+    else
+      @ticker.get_candles(start_at: start_at, timeframe: @timeframe)
+    end
+  end
+
+  # A candle is closed once its period has elapsed. Checking explicitly (rather than
+  # dropping the last returned candle) matters for closed markets: a weekend tail
+  # fetch returns Friday's fully-closed bar last, with no in-progress bar after it.
+  def closed_candles(candles)
+    candles.select { |candle| candle[0] + @timeframe <= Time.now.utc }
+  end
+
+  # uniq+sort is cheap insurance against exchanges returning unordered or overlapping rows, and it
+  # happens HERE so that every path into the cache gets it — `fetch` reads `candles.last` as the
+  # newest bar to decide both freshness and the next tail's start, so one unsorted write sends
+  # every read after it to the wrong place.
+  #
+  # Concurrent refreshes of the same series can interleave; the losing write is a valid (possibly
+  # slightly shorter) series and the next tail fetch repairs it, so no read-merge-write dance is
+  # warranted for a cache.
+  def store(candles)
+    candles = candles.uniq { |candle| candle[0] }.sort_by { |candle| candle[0] }
+    Rails.cache.write(cache_key, candles, expires_in: TTL) if candles.present?
     Result::Success.new(candles)
   end
 
   def cache_key
-    "ticker_#{@ticker.id}_candle_series_v1_#{@since.to_i}_#{@timeframe.to_i}"
+    "ticker_#{@ticker.id}_candle_series_v1#{'_restated' if @restated}_#{@since.to_i}_#{@timeframe.to_i}"
   end
 end

--- a/test/models/bots/chart_asset_series_test.rb
+++ b/test/models/bots/chart_asset_series_test.rb
@@ -35,7 +35,7 @@ class ChartAssetSeriesTest < ActiveSupport::TestCase
   end
 
   def ticker_stub(id:, base:, price:, from: T0 - 1.day)
-    ticker = stub(id: id, base: base, ticker: "#{base}USDT")
+    ticker = stub(id: id, base: base, ticker: "#{base}USDT", restated_candles?: false)
     ticker.stubs(:get_candles).returns(Result::Success.new(daily_candles(price, from: from)))
     ticker
   end

--- a/test/models/bots/chart_market_marking_test.rb
+++ b/test/models/bots/chart_market_marking_test.rb
@@ -39,7 +39,7 @@ class ChartMarketMarkingTest < ActiveSupport::TestCase
   end
 
   def ticker_stub(base:, symbol:, candles:, id: 1)
-    ticker = stub(id: id, base: base, ticker: symbol)
+    ticker = stub(id: id, base: base, ticker: symbol, restated_candles?: false)
     ticker.stubs(:get_candles).returns(Result::Success.new(candles))
     ticker
   end

--- a/test/models/bots/chart_price_overlay_basis_test.rb
+++ b/test/models/bots/chart_price_overlay_basis_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The chart carries two readings of one market, and a split is the only place they can disagree.
+#
+# VALUES are as-traded: the metrics walk counts the shares the bot actually bought, so they can
+# only be multiplied by the prices the market actually quoted. That pairing is not a preference —
+# a bot that bought before a split and sold out before its effective date is never restated by the
+# broker, so no ledger row exists and no factor can be recovered. Nothing may convert those counts.
+#
+# The OVERLAY multiplies nothing. The browser rebases each price line against its own first point
+# in view, so it reads as a return, and the return of a raw series across a split is a 90% crash
+# that never happened. It gets the venue's history as the venue reads it today.
+class ChartPriceOverlayBasisTest < ActiveSupport::TestCase
+  SPLIT_AT = Time.utc(2026, 6, 12, 13, 30)
+  T0 = SPLIT_AT - 8.days
+  NOW = SPLIT_AT + 4.days
+
+  setup do
+    travel_to NOW
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+    @user = create(:user)
+    @exchange = create(:alpaca_exchange)
+    @api_key = create(:api_key, user: @user, exchange: @exchange)
+    @usd = Asset.find_by(symbol: 'USD') || create(:asset, :usd)
+    @klac = create(:asset, external_id: 'klac', symbol: 'KLAC', category: 'Common Stock')
+  end
+
+  teardown { travel_back }
+
+  # As-traded: 1000 a share until the split, 100 after it.
+  def raw_candles
+    days.map { |day| [day, (day < SPLIT_AT ? 1000 : 100).to_d, 0, 0, 0, 1.to_d] }
+  end
+
+  # Restated: the same market, read on today's basis. 100 throughout — the pre-split bars are the
+  # 1000 the market quoted, divided by the ten shares each of them became.
+  def restated_candles
+    days.map { |day| [day, 100.to_d, 0, 0, 0, 1.to_d] }
+  end
+
+  def days
+    (-9..4).map { |d| SPLIT_AT + d.days }
+  end
+
+  def split!
+    create(:account_transaction, user: @user, api_key: @api_key, exchange: @exchange,
+                                 entry_type: :adjustment, base_currency: 'KLAC', base_amount: 18,
+                                 quote_currency: nil, quote_amount: nil, transacted_at: SPLIT_AT,
+                                 raw_data: { 'corporate_action' => 'split', 'split_ratio' => '10:1' })
+  end
+
+  # Two shares at 1000, held from before the split all the way through it.
+  def buy!(bot)
+    create(:transaction, bot: bot, exchange: @exchange, base: 'KLAC', quote: 'USD',
+                         side: :buy, amount: 2, amount_exec: 2, price: 1000,
+                         quote_amount: 2000, quote_amount_exec: 2000, created_at: T0)
+  end
+
+  def stub_live(price = 100.to_d)
+    Exchanges::Alpaca.any_instance.stubs(:get_last_price).returns(Result::Success.new(price))
+    Exchanges::Alpaca.any_instance.stubs(:get_tickers_prices)
+                     .returns(Result::Success.new('KLACUSD' => price))
+  end
+
+  # Both series answer from the same seam, told apart by `restated:` — the one thing this change
+  # adds to the fetch path.
+  def stub_candles(bot, raw: raw_candles, restated: restated_candles)
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
+      Result::Success.new(restated ? restated_series : raw_series)
+    end
+    bot.define_singleton_method(:raw_series) { raw }
+    bot.define_singleton_method(:restated_series) { restated }
+    bot
+  end
+
+  def single_asset_bot
+    bot = create(:dca_single_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                    base_asset: @klac, quote_asset: @usd)
+    buy!(bot)
+    bot
+  end
+
+  # A basket holding a stock beside a coin — the case the overlay grids have to merge per symbol
+  # rather than wholesale. Only KLAC is ever bought, so only KLAC is ever priced.
+  def composition_bot
+    btc = create(:asset, external_id: 'btc', symbol: 'BTC', category: 'Cryptocurrency')
+    bot = create(:dca_multi_asset, user: @user, exchange: @exchange, with_api_key: false,
+                                   base_assets: [@klac, btc], quote_asset: @usd)
+    buy!(bot)
+    bot
+  end
+
+  def chart_for(bot)
+    bot.metrics_with_current_prices_and_candles(force: true)[:chart]
+  end
+
+  # == the two rulers ==
+
+  test 'a single-asset bot values as-traded and draws the overlay restated' do
+    split!
+    stub_live
+    data = chart_for(stub_candles(single_asset_bot))
+
+    # Two shares at 1000, then twenty at 100: 2000 throughout, on either side of the split.
+    data[:series][0].each { |value| assert_in_delta 2000.to_d, value.to_d, 1.to_d }
+    # And one basis in the line the reader sees — no step, in either direction.
+    assert_equal [100.to_d], data[:prices]['KLAC'].compact.uniq
+  end
+
+  test 'a multi-asset bot values as-traded and draws the overlay restated' do
+    split!
+    stub_live
+    data = chart_for(stub_candles(composition_bot))
+
+    data[:series][0].each { |value| assert_in_delta 2000.to_d, value.to_d, 1.to_d }
+    assert_equal [100.to_d], data[:prices]['KLAC'].compact.uniq
+  end
+
+  test 'without the overlay grid the price line is the raw series it always was' do
+    # The guard on the whole change: a venue that does not restate history gets one grid, one
+    # fetch, and byte-for-byte what it got before.
+    @klac.update!(category: 'Cryptocurrency')
+    stub_live
+    data = chart_for(stub_candles(single_asset_bot))
+
+    assert_equal [1000.to_d, 100.to_d], data[:prices]['KLAC'].compact.uniq
+  end
+
+  test 'a crypto ticker is never asked for a second series' do
+    @klac.update!(category: 'Cryptocurrency')
+    stub_live
+    bot = single_asset_bot
+    calls = []
+    bars = [[SPLIT_AT, 100.to_d, 0, 0, 0, 1.to_d]]
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
+      calls << restated
+      Result::Success.new(bars)
+    end
+
+    bot.metrics_with_current_prices_and_candles(force: true)
+
+    assert_equal [false], calls.uniq, 'a venue with no corporate actions has one series, not two'
+  end
+
+  # == the fallback ==
+
+  test 'a symbol whose restated fetch fails keeps the price line it has' do
+    split!
+    stub_live
+    bot = single_asset_bot
+    raw = raw_candles
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
+      restated ? Result::Failure.new('boom') : Result::Success.new(raw)
+    end
+
+    data = chart_for(bot)
+
+    # Degraded to today's behaviour — a raw line with the step in it — rather than no line at all.
+    assert_equal [1000.to_d, 100.to_d], data[:prices]['KLAC'].compact.uniq
+    data[:series][0].each { |value| assert_in_delta 2000.to_d, value.to_d, 1.to_d }
+  end
+
+  test 'the value series never reads the restated grid, even where the two disagree' do
+    split!
+    stub_live
+    # A restated series at a WRONG basis would move the values if anything valued against it.
+    data = chart_for(stub_candles(single_asset_bot,
+                                  restated: days.map { |d| [d, 7.to_d, 0, 0, 0, 1.to_d] }))
+
+    data[:series][0].each { |value| assert_in_delta 2000.to_d, value.to_d, 1.to_d }
+    assert_equal [7.to_d], data[:prices]['KLAC'].compact.uniq
+  end
+end

--- a/test/models/bots/chart_price_series_test.rb
+++ b/test/models/bots/chart_price_series_test.rb
@@ -5,10 +5,11 @@ require 'test_helper'
 # The chart carries the PRICE of every asset it can price, alongside the value curves — the
 # overlay behind "Show prices".
 #
-# Read off the SAME grid, at the SAME labels, with the same interpolation the values are marked
-# with: a price point and a value point on one label are two readings of one number, so a curve
-# and the price under it can never disagree about what the market did. Nothing is fetched for
-# this — the grids are already in hand from marking the chart at market.
+# Read at the SAME labels, with the same interpolation the values are marked with, so a curve and
+# the price under it are two readings of one market. On a venue with no corporate actions they are
+# also literally one grid, already in hand from marking the chart at market, and nothing is
+# fetched for this. A venue that restates its history is the one exception — see
+# ChartPriceOverlayBasisTest for why the overlay is allowed its own basis there, and only there.
 #
 # A label the grid does not cover carries nil rather than a nearest guess: that is exactly the
 # point the portfolio kept on its fill mark, and a price invented there would be the second
@@ -36,7 +37,7 @@ class ChartPriceSeriesTest < ActiveSupport::TestCase
   end
 
   def ticker_stub(id:, base:, price:, from: T0 - 1.day)
-    ticker = stub(id: id, base: base, ticker: "#{base}USDT")
+    ticker = stub(id: id, base: base, ticker: "#{base}USDT", restated_candles?: false)
     ticker.stubs(:get_candles).returns(Result::Success.new(daily_candles(price, from: from)))
     ticker
   end

--- a/test/models/bots/extended_chart_candle_price_test.rb
+++ b/test/models/bots/extended_chart_candle_price_test.rb
@@ -31,7 +31,7 @@ class ExtendedChartCandlePriceTest < ActiveSupport::TestCase
   end
 
   def ticker_stub(id:, base: 'BTC', scale: 1)
-    ticker = stub(id: id, base: base)
+    ticker = stub(id: id, base: base, restated_candles?: false)
     ticker.stubs(:get_candles).returns(Result::Success.new(candles(scale: scale)))
     ticker
   end

--- a/test/models/bots/extended_chart_candle_source_test.rb
+++ b/test/models/bots/extended_chart_candle_source_test.rb
@@ -14,7 +14,7 @@ class ExtendedChartCandleSourceTest < ActiveSupport::TestCase
   # Installs a plain-Ruby (thread-safe) fetch_candle_series override returning
   # per-symbol Results from a frozen hash.
   def stub_candle_series(bot, results_by_base)
-    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:| # rubocop:disable Lint/UnusedBlockArgument
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
       results_by_base.fetch(ticker.base)
     end
   end
@@ -64,7 +64,7 @@ class ExtendedChartCandleSourceTest < ActiveSupport::TestCase
     live = 0
     peak = 0
     candles = [[t + 1.hour, 5.0, 5.0, 5.0, 5.0, 1.0]]
-    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:| # rubocop:disable Lint/UnusedBlockArgument
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
       mutex.synchronize do
         live += 1
         peak = [peak, live].max
@@ -85,7 +85,7 @@ class ExtendedChartCandleSourceTest < ActiveSupport::TestCase
     bot = index_bot_with_symbols({ 'AAA' => 1.0, 'BAD' => 1.0 }, at: t)
 
     candles = [[t + 1.hour, 5.0, 5.0, 5.0, 5.0, 1.0]]
-    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:| # rubocop:disable Lint/UnusedBlockArgument
+    bot.define_singleton_method(:fetch_candle_series) do |ticker:, since:, timeframe:, restated: false| # rubocop:disable Lint/UnusedBlockArgument
       raise 'unexpected explosion' if ticker.base == 'BAD'
 
       Result::Success.new(candles)

--- a/test/models/candle_series_cache_test.rb
+++ b/test/models/candle_series_cache_test.rb
@@ -2,9 +2,11 @@
 
 require 'test_helper'
 
-# Closed candles never change. CandleSeriesCache stores them durably and only fetches
-# the tail since the last cached candle, instead of refetching full history every time
-# the old expire-at-candle-close cache rolled over.
+# Closed candles never change — until a corporate action rewrites the series behind them.
+# CandleSeriesCache stores them durably and only fetches the tail since the last cached candle,
+# instead of refetching full history every time the old expire-at-candle-close cache rolled over.
+# That makes it the one place that has to notice when the history it holds is no longer the
+# venue's: append across a 10:1 split and the stored series is half in one basis, half in another.
 class CandleSeriesCacheTest < ActiveSupport::TestCase
   setup do
     @store = ActiveSupport::Cache::MemoryStore.new
@@ -48,11 +50,11 @@ class CandleSeriesCacheTest < ActiveSupport::TestCase
     CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
 
     travel_to Time.utc(2026, 1, 1, 8, 30) # candles 6 and 7 have closed since
-    # Exchange returns one overlapping already-cached candle (inclusive start_at quirk)
-    # plus the two new closed candles plus the in-progress one.
+    # The tail starts AT the last cached candle, so the venue's own reading of a bar already
+    # stored comes back with it — plus the two new closed candles and the in-progress one.
     tail = [candle(5), candle(6), candle(7), candle(8)]
     @ticker.expects(:get_candles)
-           .with { |**kw| kw[:start_at] > @since + 5.hours && kw[:timeframe] == @timeframe }
+           .with { |**kw| kw[:start_at] == @since + 5.hours && kw[:timeframe] == @timeframe }
            .returns(Result::Success.new(tail))
 
     result = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
@@ -61,6 +63,131 @@ class CandleSeriesCacheTest < ActiveSupport::TestCase
     assert_equal 8, result.data.length                       # 0..7, no duplicate of candle(5)
     assert_equal @since + 7.hours, result.data.last[0]       # candle(8) in progress — dropped
     assert_equal result.data, result.data.uniq { |c| c[0] } # rubocop:disable Lint/AmbiguousBlockAssociation
+  end
+
+  # == a series the venue has rewritten ==
+
+  test 'a restated overlap bar discards the series and refetches the whole window' do
+    stub_full_fetch
+    CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    travel_to Time.utc(2026, 1, 1, 8, 30)
+    # The venue now reads a bar this cache already holds at a tenth of the price. A closed candle
+    # does not drift; that is a 10:1 split, and everything before the seam has moved with it.
+    seq = sequence('restatement')
+    @ticker.expects(:get_candles).with(start_at: @since + 5.hours, timeframe: @timeframe)
+           .returns(Result::Success.new([candle(5, 10.0), candle(6, 10.0), candle(7, 10.0)]))
+           .in_sequence(seq)
+    @ticker.expects(:get_candles).with(start_at: @since, timeframe: @timeframe)
+           .returns(Result::Success.new((0..7).map { |h| candle(h, 10.0) }))
+           .in_sequence(seq)
+
+    result = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    assert_predicate result, :success?
+    assert_equal 8, result.data.length
+    assert_equal [10.0], result.data.map { |c| c[1] }.uniq, 'a mixed-basis series survived'
+  end
+
+  test 'an overlap bar agreeing within rounding is not a restatement' do
+    stub_full_fetch
+    CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    travel_to Time.utc(2026, 1, 1, 8, 30)
+    @ticker.expects(:get_candles).once
+           .returns(Result::Success.new([candle(5, 100.01), candle(6), candle(7)]))
+
+    result = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    assert_equal 8, result.data.length
+    assert_equal 100.0, result.data[5][1], 'the stored bar is kept, not overwritten by the reread'
+  end
+
+  test 'a rebuild stores a normalized series, whatever order the venue answers in' do
+    stub_full_fetch
+    CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    travel_to Time.utc(2026, 1, 1, 8, 30)
+    seq = sequence('unordered rebuild')
+    @ticker.expects(:get_candles).returns(Result::Success.new([candle(5, 10.0)])).in_sequence(seq)
+    @ticker.expects(:get_candles)
+           .returns(Result::Success.new([candle(2, 10.0), candle(0, 10.0), candle(1, 10.0),
+                                         candle(2, 10.0)]))
+           .in_sequence(seq)
+
+    result = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    # `fetch` reads the LAST row as the newest bar to decide both freshness and the next tail's
+    # start, so an unsorted write sends every read after it to the wrong place.
+    assert_equal [@since, @since + 1.hour, @since + 2.hours], result.data.map(&:first)
+  end
+
+  test 'a rebuild that fails leaves the stored series where it was' do
+    stub_full_fetch
+    CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    travel_to Time.utc(2026, 1, 1, 8, 30)
+    seq = sequence('failed rebuild')
+    @ticker.expects(:get_candles).returns(Result::Success.new([candle(5, 10.0)])).in_sequence(seq)
+    @ticker.expects(:get_candles).returns(Result::Failure.new('boom')).in_sequence(seq)
+
+    assert_predicate CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe),
+                     :failure?
+
+    travel_to Time.utc(2026, 1, 1, 6, 31)
+    @ticker.expects(:get_candles).never
+    assert_equal 6, CandleSeriesCache.fetch(ticker: @ticker, since: @since,
+                                            timeframe: @timeframe).data.length
+  end
+
+  # == the restated series is a series of its own ==
+
+  test 'a restated fetch reads the venue restated history and keys it apart from the raw one' do
+    @ticker.stubs(:restated_candles?).returns(true)
+    @ticker.expects(:get_indicator_candles).with(start_at: @since, timeframe: @timeframe)
+           .returns(Result::Success.new([candle(0, 10.0), candle(1, 10.0), candle(2, 10.0)]))
+    @ticker.expects(:get_candles).with(start_at: @since, timeframe: @timeframe)
+           .returns(Result::Success.new([candle(0), candle(1), candle(2)]))
+
+    restated = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe,
+                                       restated: true)
+    raw = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    assert_equal [10.0], restated.data.map { |c| c[1] }.uniq
+    assert_equal [100.0], raw.data.map { |c| c[1] }.uniq
+  end
+
+  test 'a venue that restates nothing serves one series for both, and fetches once' do
+    @ticker.stubs(:restated_candles?).returns(false)
+    @ticker.expects(:get_candles).once
+           .returns(Result::Success.new((0..5).map { |h| candle(h) }))
+    @ticker.expects(:get_indicator_candles).never
+
+    restated = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe,
+                                       restated: true)
+    raw = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe)
+
+    assert_equal raw.data, restated.data
+  end
+
+  test 'a restated series missing its overlap bar rebuilds; a raw one appends' do
+    @ticker.stubs(:restated_candles?).returns(true)
+    @ticker.stubs(:get_indicator_candles).returns(Result::Success.new((0..5).map { |h| candle(h) }))
+    CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe, restated: true)
+
+    travel_to Time.utc(2026, 1, 1, 8, 30)
+    # A bar the venue no longer returns from a start it treats as inclusive is a bar it no longer
+    # has, which is the same news as one whose price moved.
+    seq = sequence('missing overlap')
+    @ticker.expects(:get_indicator_candles).with(start_at: @since + 5.hours, timeframe: @timeframe)
+           .returns(Result::Success.new([candle(6, 10.0), candle(7, 10.0)])).in_sequence(seq)
+    @ticker.expects(:get_indicator_candles).with(start_at: @since, timeframe: @timeframe)
+           .returns(Result::Success.new((0..7).map { |h| candle(h, 10.0) })).in_sequence(seq)
+
+    result = CandleSeriesCache.fetch(ticker: @ticker, since: @since, timeframe: @timeframe,
+                                     restated: true)
+
+    assert_equal [10.0], result.data.map { |c| c[1] }.uniq
   end
 
   test 'exchange failure: returns the failure and leaves the cache untouched' do


### PR DESCRIPTION
A stock split rewrites a symbol's whole price history. The chart's price overlay was reading the as-traded series, so a 10-for-1 split drew as a 90% overnight crash — and because each price line is rebased against its own first point in view, the line spent the rest of the chart pinned to the floor of the plot.

Measured on a symbol that split 10-for-1 on 12 June:

```
get_candles            06-11  2213.37  ->  06-12  237.60     the overlay today
get_indicator_candles  06-11   221.34  ->  06-12  237.60     the same market, restated
```

Split-adjusted bars already existed — `get_indicator_candles`, added for RSI, moving averages and the all-time high. The chart was never switched over.

## Why the value curve keeps the raw series

It is drawn from share counts as they were traded, so it can only be multiplied by the prices the market actually quoted.

Converting those counts would need the split factors, and the only record of a split in this app is the broker's `adjustment` ledger row — which exists only for accounts the restatement actually touched. A bot that bought before a split and **sold out before its effective date** is never restated, books no row, and yields no factor, while the adjusted candle series is restated regardless. Its whole pre-split segment would read a tenth of the truth with nothing available to correct it.

So valuation is untouched, pins and all. Only the overlay moves. It multiplies nothing and the browser rebases it anyway, so it does not have to share the valuation ruler.

## What changed

**A second grid, for display only.** `chart[:prices]` reads it; the axis, the market values and the per-asset hover series all keep reading the valuation grid. Taken only where `Ticker#restated_candles?` is true — everywhere else both names point at the same object, one fetch, byte-for-byte the same chart. A restated fetch that fails or raises leaves that symbol on the grid it already had, per symbol rather than wholesale, so one ticker cannot take a basket back with it.

**`CandleSeriesCache` learned that a closed candle is not always immutable.** It keeps a series for 30 days and only ever appended a tail, so a restatement left the stored history half in one basis and half in another — a state that would have outlived this fix by a month and returned with every future split. The tail is now fetched from the last stored bar inclusive and that bar is compared against the stored one; a disagreement beyond rounding means the venue rewrote its history, and the window is rebuilt once. On a venue that restates, a bar it will no longer return from an inclusive start means the same thing. Raw and restated series are stored under separate keys.

Known ceiling, left as it is: the cache answers without a request while `now < last_open + 2 x timeframe`, so on a daily grid a restatement is noticed up to two days late and the overlay can carry the seam until then. Revalidating on every read would give up what the cache is for.

## Tests

`ChartPriceOverlayBasisTest` — single-asset and multi-asset bots both value as-traded while drawing the overlay restated; a deliberately wrong restated series moves the overlay and leaves the values alone; a failed restated fetch degrades to the raw line rather than to no line; a ticker whose venue restates nothing is never asked for a second series.

`CandleSeriesCacheTest` — a restated overlap bar discards the series and rebuilds; agreement within rounding does not; a rebuild normalizes whatever order the venue answers in; a failed rebuild leaves the stored series where it was; the two bases cache apart, and a venue with one history serves it to both callers.

4888 tests green.
