### PR TITLE
Retry transient mail failures and collapse forked limit-check chains

### DIFF
--- a/app/jobs/application_mail_delivery_job.rb
+++ b/app/jobs/application_mail_delivery_job.rb
@@ -1,0 +1,26 @@
+# Rails' stock ActionMailer::MailDeliveryJob declares no retry policy, and because it subclasses
+# ActiveJob::Base rather than ApplicationJob it inherits none either. A single transport failure
+# therefore destroys the message on its first attempt, leaving only a dead-letter row — which for
+# a bot alert means the user is never told something their bot needed them to know.
+#
+# Only CONNECT-phase failures are retried. That distinction is the whole safety argument: these
+# errors all occur before a TCP session exists, so no SMTP dialogue happened and no message can
+# have been accepted — redelivering cannot duplicate mail.
+#
+# Read-phase errors are deliberately NOT here. Net::ReadTimeout and Errno::ECONNRESET happen on an
+# established connection and can land after the server accepted DATA but before its final 250
+# reached us, or during QUIT after acceptance. Retrying those would send the message twice, so
+# they keep the old behaviour and surface instead: losing one alert beats silently mailing someone
+# the same thing twice.
+#
+# Errors meaning the message WAS handled (Net::SMTPFatalError, a rejected recipient) and
+# template/argument bugs also still surface — retrying them changes nothing and hides the fault.
+class ApplicationMailDeliveryJob < ActionMailer::MailDeliveryJob
+  retry_on Net::OpenTimeout,
+           Errno::ECONNREFUSED,
+           Errno::EHOSTUNREACH,
+           Errno::ENETUNREACH,
+           SocketError,
+           wait: :polynomially_longer,
+           attempts: 5
+end

--- a/app/jobs/bot/limit_check_job_base.rb
+++ b/app/jobs/bot/limit_check_job_base.rb
@@ -18,7 +18,7 @@ class Bot::LimitCheckJobBase < ApplicationJob
       bot.update!(status: :scheduled)
       Bot::ActionJob.perform_later(bot)
     else
-      self.class.set(wait_until: next_check_at(bot)).perform_later(bot)
+      enqueue_next_poll(bot, next_check_at(bot))
     end
   rescue Client::TransientNetworkError, Client::RateLimitedError => e
     # A live-price read raised a transient (network blip / rate limit) instead of returning a
@@ -34,7 +34,25 @@ class Bot::LimitCheckJobBase < ApplicationJob
 
   def reschedule_after_transient(bot, reason)
     Rails.logger.warn("#{self.class.name.demodulize} for bot #{bot.id} failed: #{reason}. Retrying in 1 minute.")
-    self.class.set(wait_until: 1.minute.from_now).perform_later(bot)
+    enqueue_next_poll(bot, 1.minute.from_now)
+  end
+
+  # Arm the next poll, then collapse any duplicate chain while we are here.
+  #
+  # The chain is one-in-one-out so it cannot fork itself, but nothing healed a fork either: a bot
+  # that ends up with two chains polls twice a minute indefinitely, doubling its exchange reads and
+  # every log line it produces. Several paths can start a chain (recovery, resume, a manual
+  # rescue), so rather than guard each of them, the poll every chain must pass through restores the
+  # invariant — whatever forks it, the next tick collapses it.
+  #
+  # Enqueue FIRST, then prune. The reverse order is tempting (never two chains) but its failure
+  # mode is a bot with NO chain, which never polls again; this way the worst case is a duplicate
+  # that the next tick removes. The prune keeps the newest live job rather than sparing "the one I
+  # just enqueued" — see Automation::Schedulable#prune_duplicate_solid_queue_jobs — so two chains
+  # racing here converge on one instead of destroying each other's successor.
+  def enqueue_next_poll(bot, wait_until)
+    self.class.set(wait_until:).perform_later(bot)
+    bot.prune_duplicate_limit_check_jobs(self.class)
   end
 
   def condition_result(bot)

--- a/app/models/automation/schedulable.rb
+++ b/app/models/automation/schedulable.rb
@@ -156,6 +156,40 @@ module Automation::Schedulable
     end
   end
 
+  # Collapse duplicate live jobs of one class for one record down to a single survivor, keeping the
+  # NEWEST and destroying the rest.
+  #
+  # "Keep one" rather than "delete all but the one I just enqueued" is what makes this safe under
+  # concurrency. Two chains running at once would both enqueue a successor and then both prune; an
+  # exclusion list has each prune spare its OWN successor and destroy the other's, which can end
+  # with zero jobs and a bot that never polls again. Keeping whichever is newest is idempotent and
+  # order-independent: every interleaving converges on exactly one, and it can never reach zero.
+  #
+  # Claimed executions are deliberately not candidates — that is the job currently running.
+  def prune_duplicate_solid_queue_jobs(job_class:, record:)
+    return unless defined?(SolidQueue)
+
+    global_id = record.to_global_id.to_s
+    jobs = [SolidQueue::ScheduledExecution, SolidQueue::ReadyExecution,
+            SolidQueue::BlockedExecution].flat_map do |execution_model|
+      live_executions_for(execution_model, job_class, global_id).map(&:job)
+    end
+
+    return if jobs.size <= 1
+
+    # Re-check for a claimed execution immediately before destroying. A ready job can be picked up
+    # by a worker between the select above and here, and destroying it would cascade to the claimed
+    # execution and abort a running poll. Skipping it is free: it is a duplicate, so the survivor
+    # already keeps the chain alive, and the next tick collapses it once it is no longer claimed.
+    # This narrows the race rather than closing it — the alternative, locking the queue tables on
+    # every poll, costs more than the mid-flight abort of a redundant poll it would prevent.
+    jobs.sort_by(&:id)[0..-2].each do |job|
+      next if SolidQueue::ClaimedExecution.exists?(job_id: job.id)
+
+      job.destroy
+    end
+  end
+
   def find_next_scheduled_job_at(job_class:, record:)
     return nil unless defined?(SolidQueue)
 
@@ -184,6 +218,28 @@ module Automation::Schedulable
                      .where(solid_queue_jobs: { class_name: job_class.to_s })
                      .any? { |execution| job_matches_record?(execution.job, global_id) }
     end
+  end
+
+  # Executions of job_class belonging to record, narrowed in SQL before the exact Ruby check.
+  #
+  # The LIKE is a pure prefilter: the serialized arguments embed the GlobalID verbatim (either as
+  # "_aj_globalid" or as a bare string), so it can only exclude rows job_matches_record? would
+  # reject anyway. Without it every caller loads EVERY live job of that class and filters in Ruby
+  # — fine for a one-off cancel, but the limit-check prune runs once per waiting bot per minute,
+  # which made it scale with the square of the waiting-bot count.
+  #
+  # ponytail: the leading wildcard means this cannot use an index, so it still SCANS every
+  # class-matching row — it only avoids instantiating and JSON-parsing them. The cost is bounded by
+  # the number of waiting limit bots in ONE installation, which is small in practice: a few dozen
+  # bots costs a few hundred row-scans a minute. If an installation ever runs a few hundred waiting
+  # limit bots, index it properly — a generated column over the GlobalID, or give the limit-check
+  # jobs a per-bot concurrency_key, which is already indexed.
+  def live_executions_for(execution_model, job_class, global_id)
+    execution_model.joins(:job)
+                   .where(solid_queue_jobs: { class_name: job_class.to_s })
+                   .where('solid_queue_jobs.arguments LIKE ?', "%#{global_id}%")
+                   .includes(:job)
+                   .select { |execution| job_matches_record?(execution.job, global_id) }
   end
 
   def job_matches_record?(job, global_id)

--- a/app/models/bot/limit_checkable.rb
+++ b/app/models/bot/limit_checkable.rb
@@ -69,6 +69,15 @@ module Bot::LimitCheckable
     active_job?(job_class: klass.name, record: self)
   end
 
+  # Collapse a forked poll chain for one check-job class down to a single live job.
+  # See Bot::LimitCheckJobBase#enqueue_next_poll for why this exists and why it keeps the newest.
+  # Deliberately takes the class rather than reading live_limit_check_type: a running job knows
+  # which chain it belongs to, while live_limit_check_type reports the type the bot is paused on
+  # NOW, which can differ mid-transition and would prune the wrong chain.
+  def prune_duplicate_limit_check_jobs(job_class)
+    prune_duplicate_solid_queue_jobs(job_class: job_class.name, record: self)
+  end
+
   # Re-enqueue the live check job at its type-specific next check time. No-op if no paused type.
   def enqueue_limit_check_job
     type = live_limit_check_type

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,1 +1,12 @@
 Rails.application.config.active_job.queue_adapter = :solid_queue
+
+# Route mail through ApplicationMailDeliveryJob so a transport blip retries instead of destroying
+# the message.
+#
+# Set here rather than via `config.action_mailer.delivery_job = "..."`: ActionMailer's railtie
+# constantizes that option while the framework initializers run, before the autoloaders can
+# resolve an app/ constant, so the string form raises `uninitialized constant` on a production
+# boot. `to_prepare` is the supported hook for referencing an autoloaded constant.
+Rails.application.config.to_prepare do
+  ActionMailer::Base.delivery_job = ApplicationMailDeliveryJob
+end

--- a/test/jobs/bot/limit_check_chain_dedup_test.rb
+++ b/test/jobs/bot/limit_check_chain_dedup_test.rb
@@ -1,0 +1,123 @@
+require 'test_helper'
+
+# A :waiting limit bot is polled by a single self-rescheduling chain: each run of the check job
+# enqueues exactly one successor. The chain is one-in-one-out, so it cannot fork itself — but it
+# also cannot heal a fork, and any path that STARTS a second chain (recovery, resume, a manual
+# rescue) leaves the bot polling twice a minute forever.
+#
+# A forked chain is silent: the bot keeps working, it just polls two, three or four times a minute
+# forever, multiplying its exchange price reads and every log line it emits. Because no single
+# enqueue path can be shown to be the culprit, the poll itself is made self-healing instead:
+# whatever creates a duplicate, the next tick collapses it.
+class Bot::LimitCheckChainDedupTest < ActiveSupport::TestCase
+  setup do
+    @bot = create(:dca_single_asset, :started)
+    @bot.update!(status: :waiting)
+    @bot.stubs(:get_price_drop_limit_condition_met?).returns(Result::Success.new(false))
+  end
+
+  def live_job_ids_for(bot)
+    global_id = bot.to_global_id.to_s
+    [SolidQueue::ScheduledExecution, SolidQueue::ReadyExecution, SolidQueue::BlockedExecution]
+      .flat_map do |model|
+        model.joins(:job)
+             .where(solid_queue_jobs: { class_name: 'Bot::PriceDropLimitCheckJob' })
+             .select { |e| e.job.arguments.to_s.include?(global_id) }
+             .map(&:job_id)
+      end
+  end
+
+  def chains_for(bot)
+    live_job_ids_for(bot).size
+  end
+
+  test 'a forked chain collapses to one on the next poll' do
+    2.times { Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot) }
+    assert_equal 2, chains_for(@bot), 'setup should model a forked chain'
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot)
+  end
+
+  test 'a four-way fork collapses to one, not to two' do
+    4.times { Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot) }
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot)
+  end
+
+  # The prune keeps the NEWEST live job rather than sparing the one this run enqueued. That is what
+  # makes it safe when two chains race: each would otherwise spare its own successor and destroy
+  # the other's, leaving the bot with none. Keeping the newest is order-independent, so every
+  # interleaving converges on one and none can reach zero.
+  test 'the surviving chain is the newest job' do
+    2.times { Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot) }
+    before = live_job_ids_for(@bot)
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    surviving = live_job_ids_for(@bot)
+    assert_equal 1, surviving.size
+    assert_operator surviving.first, :>, before.max, "the newest job (this run's successor) survives"
+  end
+
+  # The failure mode that matters more than the fork: a :waiting bot with NO chain never polls
+  # again, so it is wedged until Bot::RepairOrphanedBotsJob notices. Pruning must never end empty.
+  test 'a healthy single chain still leaves exactly one chain' do
+    Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot)
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot)
+  end
+
+  test 'a poll with no existing chain still arms one' do
+    assert_equal 0, chains_for(@bot)
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot)
+  end
+
+  # prune_duplicate_solid_queue_jobs selects by job CLASS across the whole queue and narrows to the
+  # record, so a prune that got that filter wrong would silently stop every other bot in the
+  # installation from polling. That is a far worse bug than the one being fixed.
+  test 'pruning never touches another bot chain' do
+    other = create(:dca_single_asset, :started, exchange: @bot.exchange,
+                                                base_asset: @bot.base_asset, quote_asset: @bot.quote_asset)
+    other.update!(status: :waiting)
+    2.times { Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(other) }
+    Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot)
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot)
+    assert_equal 2, chains_for(other), "another bot's chains are not this poll's business"
+  end
+
+  # The transient path enqueues its successor from a different branch, so it needs the same
+  # treatment — and a transient read failure is the common way a poll ends, so it is the branch
+  # most likely to be the one perpetuating a fork.
+  test 'the transient-failure reschedule also collapses a fork' do
+    @bot.unstub(:get_price_drop_limit_condition_met?)
+    @bot.stubs(:get_price_drop_limit_condition_met?).raises(Client::TransientNetworkError, 'timeout')
+    2.times { Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot) }
+
+    assert_nothing_raised { Bot::PriceDropLimitCheckJob.new.perform(@bot) }
+
+    assert_equal 1, chains_for(@bot)
+    assert_equal 'waiting', @bot.reload.status
+  end
+
+  # A bot that has left :waiting returns at line 1 and must not be given a chain, forked or not.
+  test 'a bot that is no longer waiting is left alone' do
+    Bot::PriceDropLimitCheckJob.set(wait_until: 1.minute.from_now).perform_later(@bot)
+    @bot.update!(status: :stopped)
+
+    Bot::PriceDropLimitCheckJob.new.perform(@bot)
+
+    assert_equal 1, chains_for(@bot), 'no prune and no enqueue for a non-waiting bot'
+  end
+end

--- a/test/jobs/mail_delivery_retry_test.rb
+++ b/test/jobs/mail_delivery_retry_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+# Rails' default ActionMailer::MailDeliveryJob declares no retry policy, and it subclasses
+# ActiveJob::Base rather than ApplicationJob, so it inherits none either. A mail that hits a
+# transport failure is therefore destroyed on the first attempt — no retry, and no trace but a row
+# in solid_queue_failed_executions that nothing surfaces.
+#
+# That matters most for the alerts a bot sends when it cannot trade: the one message telling the
+# user to act is the one a momentary SMTP connect failure throws away.
+class MailDeliveryRetryTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  # The app runs Solid Queue everywhere, including tests; the enqueue assertions below need the
+  # test adapter. This is ActiveJob::TestHelper's documented hook for swapping it per test case.
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::TestAdapter.new
+  end
+
+  test 'the app configures its own delivery job' do
+    assert_equal ApplicationMailDeliveryJob, ActionMailer::Base.delivery_job,
+                 'mail must not go through the stock MailDeliveryJob, which never retries'
+  end
+
+  # Each of these fails before a TCP session exists, so no SMTP dialogue happened and no message
+  # can have been accepted. Redelivering cannot duplicate mail.
+  [
+    Net::OpenTimeout,
+    Errno::ECONNREFUSED,
+    Errno::EHOSTUNREACH,
+    Errno::ENETUNREACH,
+    SocketError
+  ].each do |error|
+    test "a connect-phase #{error} is retried, not dropped" do
+      job = ApplicationMailDeliveryJob.new('BotAlertsMailer', 'end_of_funds', 'deliver_now')
+      job.stubs(:perform).raises(error)
+
+      assert_enqueued_with(job: ApplicationMailDeliveryJob) do
+        assert_nothing_raised { job.perform_now }
+      end
+    end
+  end
+
+  # The safety boundary, and the reason the retry list is not simply "network errors".
+  #
+  # These fail on an ESTABLISHED connection. Either can land after the server accepted DATA but
+  # before its final 250 reached us, or during QUIT after acceptance — so a retry would send the
+  # message a second time. Dropping one alert is better than silently mailing a user twice, and
+  # a connect-phase failure, which is the common case, is covered above.
+  [Net::ReadTimeout, Errno::ECONNRESET].each do |error|
+    test "a read-phase #{error} is NOT retried, because the mail may already have been accepted" do
+      job = ApplicationMailDeliveryJob.new('BotAlertsMailer', 'end_of_funds', 'deliver_now')
+      job.stubs(:perform).raises(error)
+
+      assert_no_enqueued_jobs do
+        assert_raises(error) { job.perform_now }
+      end
+    end
+  end
+
+  # A template bug or a bad address is not transient. Retrying it 5 times changes nothing and
+  # hides the error, so it must still surface.
+  test 'a non-transport error is not retried' do
+    job = ApplicationMailDeliveryJob.new('BotAlertsMailer', 'end_of_funds', 'deliver_now')
+    job.stubs(:perform).raises(ArgumentError, 'bad template')
+
+    assert_no_enqueued_jobs do
+      assert_raises(ArgumentError) { job.perform_now }
+    end
+  end
+
+  # The parent declares `rescue_from StandardError, with: :handle_exception_with_mailer_class`
+  # (actionmailer mail_delivery_job.rb:19), which would otherwise swallow every transport error
+  # and hand it to the mailer. ActiveSupport::Rescuable matches handlers with `reverse_each`, so
+  # the LAST declared wins — the subclass's retry_on is registered after the inherited catch-all
+  # and therefore takes precedence. That ordering is the whole reason this fix works, and it would
+  # silently invert if the retry_on were ever moved onto a parent class; pin it.
+  test 'the transport retry takes precedence over the inherited StandardError handler' do
+    handlers = ApplicationMailDeliveryJob.rescue_handlers.map(&:first)
+
+    assert_includes handlers, 'Net::OpenTimeout', 'the subclass must register its own handler'
+    assert_operator handlers.index('Net::OpenTimeout'),
+                    :>,
+                    handlers.index('StandardError'),
+                    'retry_on must be declared after the inherited catch-all to be matched first'
+  end
+end


### PR DESCRIPTION
Two unrelated resilience gaps, both of which show up as a brief network failure causing lasting damage.

## Mail is destroyed by a single transport failure

`ActionMailer::MailDeliveryJob` declares no retry policy, and because it subclasses `ActiveJob::Base` rather than `ApplicationJob` it inherits none either. A momentary SMTP failure therefore dead-letters the message on its first attempt — no retry, and nothing that surfaces it but a `solid_queue_failed_executions` row. For a bot alert, the one message telling the user to act is the one that gets thrown away.

`ApplicationMailDeliveryJob` retries only **connect-phase** failures: `Net::OpenTimeout`, `Errno::ECONNREFUSED`, `Errno::EHOSTUNREACH`, `Errno::ENETUNREACH`, `SocketError`.

That boundary is the whole safety argument. Those errors occur before a TCP session exists, so no SMTP dialogue happened and no message can have been accepted — redelivering cannot duplicate mail. Read-phase errors are deliberately **excluded**: `Net::ReadTimeout` and `Errno::ECONNRESET` happen on an established connection and can land after the server accepted `DATA` but before its final `250` arrives, or during `QUIT` after acceptance. Retrying those would send the message twice. Losing one alert beats silently duplicating one, and there are tests pinning both halves of that boundary.

It is installed from a `to_prepare` block rather than `config.action_mailer.delivery_job = "..."`, because ActionMailer's railtie constantizes that option while framework initializers run — before the autoloaders can resolve an `app/` constant — so the string form raises `uninitialized constant` on a production boot.

## Limit-check poll chains cannot heal a fork

A `:waiting` limit bot is polled by a single self-rescheduling chain: each run of the check job enqueues exactly one successor. Being one-in-one-out, the chain cannot fork itself — but it cannot heal a fork either. If any path ever starts a second chain, the bot polls twice a minute indefinitely, doubling its exchange price reads and every log line it emits, with nothing to indicate anything is wrong.

Several paths can start a chain (recovery, resume, a manual rescue). Rather than guard each of them, the poll that every chain must pass through restores the invariant: it arms the next poll, then collapses duplicates.

Two ordering decisions carry the correctness:

- **Enqueue first, then prune.** The reverse is tempting because it never leaves two chains, but its failure mode is a bot with *no* chain, which never polls again. This way the worst case is a duplicate that the next tick removes.
- **Keep the newest live job, not "the one I just enqueued."** With an exclusion list, two chains racing would each spare their own successor and destroy the other's, ending at zero. Keeping whichever job is newest is order-independent, so every interleaving converges on exactly one and none can reach zero.

Claimed executions are never prune candidates, and a job that has been claimed between selection and destruction is skipped rather than aborted mid-run.

## Notes

`prune_duplicate_solid_queue_jobs` and the shared `live_executions_for` helper add a SQL `LIKE` prefilter on the serialized GlobalID before the existing exact Ruby check. It is a pure narrowing — the GlobalID appears verbatim in the serialized arguments, so it can only exclude rows the Ruby check would reject anyway — and it stops the prune from instantiating and JSON-parsing every live job of that class on each poll. It still cannot use an index; a `ponytail:` comment records that ceiling and the two upgrade paths should an installation ever run hundreds of waiting limit bots.

## Testing

- `test/jobs/mail_delivery_retry_test.rb` — connect-phase errors retry; read-phase errors do not; non-transport errors still surface; and the handler-precedence that makes the subclass's `retry_on` beat the inherited `rescue_from StandardError`.
- `test/jobs/bot/limit_check_chain_dedup_test.rb` — 2-way and 4-way forks collapse to one; the survivor is the newest job; a healthy single chain and a bot with no chain both end at exactly one; another bot's chains are untouched; the transient-failure branch dedups too; a non-`:waiting` bot is left alone.

Full suite: 4907 runs, 0 failures. Rubocop clean.
