### PR TITLE
Pick the tax report country first, then a crypto/stocks scope for Germany

### DIFF
--- a/app/javascript/controllers/tracker_export_controller.js
+++ b/app/javascript/controllers/tracker_export_controller.js
@@ -2,9 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = [
-    "typeRadio", "taxOptions", "transactionsOptions", "country", "countryRow", "year",
+    "typeRadio", "taxOptions", "transactionsOptions", "country", "year",
     "downloadBtn", "stablecoinOption", "stablecoinCheckbox", "dateFrom", "dateTo",
-    "classificationPanel", "classificationRow", "saveError"
+    "scopeRow", "scopeRadio", "classificationPanel", "classificationRow", "saveError"
   ]
 
   connect() {
@@ -16,11 +16,6 @@ export default class extends Controller {
     this.save()
   }
 
-  changeCountry() {
-    this.updateStablecoinVisibility()
-    this.save()
-  }
-
   changeYear() { this.save() }
 
   updateVisibility() {
@@ -28,6 +23,9 @@ export default class extends Controller {
     this.taxOptionsTargets.forEach(el => el.classList.toggle("hidden", !isTaxReport))
     if (this.hasTransactionsOptionsTarget) {
       this.transactionsOptionsTarget.classList.toggle("hidden", isTaxReport)
+    }
+    if (this.hasScopeRowTarget) {
+      this.scopeRowTarget.classList.toggle("hidden", !(isTaxReport && this.isGermany))
     }
     if (this.hasClassificationPanelTarget) {
       this.classificationPanelTarget.classList.toggle("hidden", !this.isBroker)
@@ -58,10 +56,6 @@ export default class extends Controller {
       const firstEnabled = Array.from(this.yearTarget.options).find(option => !option.disabled)
       if (firstEnabled) this.yearTarget.value = firstEnabled.value
     }
-
-    // The broker report is always DE and both `download()` and `save()` hardcode it, so the select
-    // is hidden rather than pinned — writing "DE" into it clobbered the user's crypto jurisdiction.
-    if (this.hasCountryRowTarget) this.countryRowTarget.classList.toggle("hidden", this.isBroker)
   }
 
   updateStablecoinVisibility() {
@@ -190,7 +184,13 @@ export default class extends Controller {
   }
 
   get exportType() { return this.typeRadioTargets.find(r => r.checked)?.value }
-  get isBroker() { return this.exportType === "broker_tax_report" }
+  get isGermany() { return this.countryTarget.value === "DE" }
+  // The scope radios stay physically checked when the row hides (another country, or the plain
+  // transactions export), so broker mode is what the row's visibility conditions AND the radio say.
+  get isBroker() {
+    return this.isTaxReport && this.isGermany && this.hasScopeRadioTarget &&
+      this.scopeRadioTargets.find(r => r.checked)?.value === "broker"
+  }
   get isTaxReport() { return this.exportType !== "transactions" }
 
   get csrfToken() {
@@ -202,16 +202,16 @@ export default class extends Controller {
       export_type: this.isTaxReport ? "tax_report" : "transactions"
     })
 
-    if (this.isBroker) {
-      // Scope only. The persisted country/year are the crypto form's preferences and the broker
-      // report has no use for them: it is always DE and picks its year at generate time.
-      params.set("report_scope", "broker")
-    } else if (this.isTaxReport) {
+    if (this.isTaxReport) {
       params.set("country", this.countryTarget.value)
-      params.set("year", this.yearTarget.value)
-      params.set("report_scope", "crypto")
-      if (this.hasStablecoinCheckboxTarget) {
-        params.set("stablecoin_as_fiat", this.stablecoinCheckboxTarget.checked)
+      params.set("report_scope", this.isBroker ? "broker" : "crypto")
+      if (!this.isBroker) {
+        // The persisted year is the crypto form's preference; the broker report has no use for it,
+        // it picks its own year at generate time.
+        params.set("year", this.yearTarget.value)
+        if (this.hasStablecoinCheckboxTarget) {
+          params.set("stablecoin_as_fiat", this.stablecoinCheckboxTarget.checked)
+        }
       }
     }
 

--- a/app/views/tracker/export_modal.html.erb
+++ b/app/views/tracker/export_modal.html.erb
@@ -13,18 +13,9 @@
           <input type="radio" name="export_type" value="tax_report"
                  data-action="tracker-export#toggle"
                  data-tracker-export-target="typeRadio"
-                 <%= 'checked' if @settings['export_type'] != 'transactions' && (!@broker_exchange || @settings['report_scope'] != 'broker') %>>
+                 <%= 'checked' if @settings['export_type'] != 'transactions' %>>
           <span><%= t('tracker.export_modal.tax_report') %></span>
         </label>
-        <% if @broker_exchange %>
-          <label class="form__radio-group">
-            <input type="radio" name="export_type" value="broker_tax_report"
-                   data-action="tracker-export#toggle"
-                   data-tracker-export-target="typeRadio"
-                   <%= 'checked' if @settings['export_type'] != 'transactions' && @settings['report_scope'] == 'broker' %>>
-            <span><%= t('tracker.export_modal.broker_tax_report') %></span>
-          </label>
-        <% end %>
         <label class="form__radio-group">
           <input type="radio" name="export_type" value="transactions"
                  data-action="tracker-export#toggle"
@@ -35,8 +26,8 @@
       </div>
 
       <div data-tracker-export-target="taxOptions" class="flex-row full-width <%= 'hidden' if @settings['export_type'] == 'transactions' %>">
-        <div class="form__row form__row--input" data-tracker-export-target="countryRow">
-          <select name="country" class="form__input" data-tracker-export-target="country" data-action="change->tracker-export#changeCountry">
+        <div class="form__row form__row--input">
+          <select name="country" class="form__input" data-tracker-export-target="country" data-action="change->tracker-export#toggle">
             <% @jurisdictions.each do |code, config| %>
               <option value="<%= code %>" <%= 'selected' if @settings['country'] == code %> data-stablecoin-ambiguous="<%= config.fetch(:stablecoin_ambiguous, false) %>"><%= t("tracker.export_modal.countries.#{code}") %></option>
             <% end %>
@@ -57,8 +48,33 @@
         </div>
       </div>
 
+      <%# The crypto/stocks split only exists under German forms (Anlage KAP / KAP-INV), so the row
+          renders only with a broker account and shows only while Germany is picked. A stale broker
+          scope saved under another country is not restored — that country offers no such choice. %>
+      <% if @broker_exchange %>
+        <% selected_country = @settings['country'] || @jurisdictions.each_key.first %>
+        <% broker_scope = @settings['report_scope'] == 'broker' && selected_country == 'DE' %>
+        <div class="flex form__row flex-center gap-3 <%= 'hidden' if @settings['export_type'] == 'transactions' || selected_country != 'DE' %>"
+             data-tracker-export-target="scopeRow">
+          <label class="form__radio-group">
+            <input type="radio" name="report_scope" value="crypto"
+                   data-action="tracker-export#toggle"
+                   data-tracker-export-target="scopeRadio"
+                   <%= 'checked' unless broker_scope %>>
+            <span><%= t('tracker.export_modal.scope_crypto') %></span>
+          </label>
+          <label class="form__radio-group">
+            <input type="radio" name="report_scope" value="broker"
+                   data-action="tracker-export#toggle"
+                   data-tracker-export-target="scopeRadio"
+                   <%= 'checked' if broker_scope %>>
+            <span><%= t('tracker.export_modal.scope_broker') %></span>
+          </label>
+        </div>
+      <% end %>
+
       <%# No rows means nothing to classify — an empty table under "assign a type to every security"
-          reads as a bug. The broker radio still shows; the report simply has no securities to refuse. %>
+          reads as a bug. The scope choice still shows; the report simply has no securities to refuse. %>
       <%= render 'tracker/fund_classifications', rows: @fund_classification_rows if @fund_classification_rows.any? %>
 
       <%# Same target as the option row above, so it hides with them: this disclaimer is about the tax

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -465,7 +465,8 @@ bg:
         export_modal:
             title: 'Генериране на отчет'
             tax_report: 'Данъчен отчет'
-            broker_tax_report: 'Данъчен отчет от брокера (Германия — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Крипто'
+            scope_broker: 'Акции и ETF'
             classification_title: 'Класифициране на ценни книжа'
             classification_hint: 'Попълнихме каквото успяхме от пазарните данни — проверете всичко по-долу, преди да генерирате отчета.'
             classification_settled:

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -472,7 +472,8 @@ cs:
         export_modal:
             title: 'Generovat přehled'
             tax_report: 'Daňový přehled'
-            broker_tax_report: 'Daňový přehled brokera (Německo — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Akcie a ETF'
             classification_title: 'Klasifikace cenných papírů'
             classification_hint: 'Vyplnili jsme, co bylo možné zjistit z tržních dat — před vygenerováním přehledu zkontrolujte vše níže.'
             classification_settled:

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -465,7 +465,8 @@ da:
         export_modal:
             title: 'Generér rapport'
             tax_report: 'Skatterapport'
-            broker_tax_report: 'Skatterapport fra mægler (Tyskland — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Aktier & ETF''er'
             classification_title: 'Klassificér værdipapirer'
             classification_hint: 'Vi udfyldte det, vi kunne ud fra markedsdata — kontrollér alt nedenfor, før du genererer rapporten.'
             classification_settled:

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -462,7 +462,8 @@ de:
         export_modal:
             title: 'Bericht erstellen'
             tax_report: 'Steuerbericht'
-            broker_tax_report: 'Broker-Steuerbericht (Deutschland — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Aktien & ETFs'
             classification_title: 'Wertpapiere klassifizieren'
             classification_hint: 'Wir haben anhand der Marktdaten eingetragen, was möglich war — prüfe alles unten, bevor du den Bericht erstellst.'
             classification_settled:

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -465,7 +465,8 @@ el:
         export_modal:
             title: 'Δημιουργία αναφοράς'
             tax_report: 'Φορολογική αναφορά'
-            broker_tax_report: 'Φορολογική αναφορά χρηματιστηριακού λογαριασμού (Γερμανία — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Κρύπτο'
+            scope_broker: 'Μετοχές & ETF'
             classification_title: 'Ταξινόμηση κινητών αξιών'
             classification_hint: 'Συμπληρώσαμε όσα μπορέσαμε από τα δεδομένα αγοράς — ελέγξτε ό,τι εμφανίζεται παρακάτω πριν δημιουργήσετε την αναφορά.'
             classification_settled:

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -465,7 +465,8 @@ en:
         export_modal:
             title: 'Generate Report'
             tax_report: 'Tax Report'
-            broker_tax_report: 'Broker tax report (Germany — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Crypto'
+            scope_broker: 'Stocks & ETFs'
             classification_title: 'Classify securities'
             classification_hint: 'We typed what we could from market data — check anything below before generating the report.'
             classification_settled:

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -462,7 +462,8 @@ es:
         export_modal:
             title: 'Generar informe'
             tax_report: 'Informe fiscal'
-            broker_tax_report: 'Informe fiscal del bróker (Alemania — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Cripto'
+            scope_broker: 'Acciones y ETFs'
             classification_title: 'Clasificar valores'
             classification_hint: 'Hemos rellenado lo que permiten los datos de mercado — revisa todo lo que aparece a continuación antes de generar el informe.'
             classification_settled:

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -462,7 +462,8 @@ fr:
         export_modal:
             title: 'Générer le rapport'
             tax_report: 'Rapport fiscal'
-            broker_tax_report: 'Rapport fiscal du courtier (Allemagne — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Crypto'
+            scope_broker: 'Actions & ETF'
             classification_title: 'Classer les titres'
             classification_hint: 'Nous avons renseigné ce que permettaient les données de marché — vérifiez les éléments ci-dessous avant de générer le rapport.'
             classification_settled:

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -461,7 +461,8 @@ it:
         export_modal:
             title: 'Genera report'
             tax_report: 'Report fiscale'
-            broker_tax_report: 'Report fiscale del broker (Germania — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Cripto'
+            scope_broker: 'Azioni ed ETF'
             classification_title: 'Classifica i titoli'
             classification_hint: 'Abbiamo compilato ciò che era possibile ricavare dai dati di mercato — controlla quanto segue prima di generare il report.'
             classification_settled:

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -461,7 +461,8 @@ nl:
         export_modal:
             title: 'Rapport genereren'
             tax_report: 'Belastingrapport'
-            broker_tax_report: 'Belastingrapport van de broker (Duitsland — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Crypto'
+            scope_broker: 'Aandelen & ETF''s'
             classification_title: 'Effecten classificeren'
             classification_hint: 'We hebben ingevuld wat we uit de marktgegevens konden halen — controleer alles hieronder voordat u het rapport genereert.'
             classification_settled:

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -463,7 +463,8 @@ pl:
         export_modal:
             title: 'Generuj raport'
             tax_report: 'Raport podatkowy'
-            broker_tax_report: 'Raport podatkowy brokera (Niemcy — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Akcje i ETF-y'
             classification_title: 'Klasyfikuj papiery wartościowe'
             classification_hint: 'Uzupełniliśmy to, co dało się ustalić na podstawie danych rynkowych — przed wygenerowaniem raportu sprawdź wszystko poniżej.'
             classification_settled:

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -460,7 +460,8 @@ pt:
         export_modal:
             title: 'Gerar relatório'
             tax_report: 'Relatório fiscal'
-            broker_tax_report: 'Relatório fiscal da corretora (Alemanha — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Cripto'
+            scope_broker: 'Ações e ETFs'
             classification_title: 'Classificar títulos'
             classification_hint: 'Preenchemos o que foi possível com base nos dados de mercado — verifique tudo o que aparece abaixo antes de gerar o relatório.'
             classification_settled:

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -464,7 +464,8 @@ ru:
         export_modal:
             title: 'Создать отчёт'
             tax_report: 'Налоговый отчёт'
-            broker_tax_report: 'Налоговый отчёт брокера (Германия — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Крипто'
+            scope_broker: 'Акции и ETF'
             classification_title: 'Классификация ценных бумаг'
             classification_hint: 'Мы заполнили всё, что удалось определить по рыночным данным — проверьте сведения ниже перед созданием отчёта.'
             classification_settled:

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -472,7 +472,8 @@ sk:
         export_modal:
             title: 'Generovať prehľad'
             tax_report: 'Daňový prehľad'
-            broker_tax_report: 'Daňový prehľad brokera (Nemecko — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Akcie a ETF'
             classification_title: 'Klasifikácia cenných papierov'
             classification_hint: 'Vyplnili sme, čo sa dalo zistiť z trhových dát — pred vygenerovaním prehľadu skontrolujte všetko nižšie.'
             classification_settled:

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -465,7 +465,8 @@ sv:
         export_modal:
             title: 'Generera rapport'
             tax_report: 'Skatterapport'
-            broker_tax_report: 'Skatterapport från mäklare (Tyskland — Anlage KAP / KAP-INV)'
+            scope_crypto: 'Krypto'
+            scope_broker: 'Aktier & ETF:er'
             classification_title: 'Klassificera värdepapper'
             classification_hint: 'Vi fyllde i det vi kunde utifrån marknadsdata — kontrollera allt nedan innan du genererar rapporten.'
             classification_settled:

--- a/test/controllers/tracker_controller_test.rb
+++ b/test/controllers/tracker_controller_test.rb
@@ -144,13 +144,14 @@ class TrackerControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, toggle_transfer_tracker_transaction_path(withdrawal)
   end
 
-  test 'export modal hides the broker report without an Alpaca ledger' do
+  test 'export modal hides the report scope choice without an Alpaca ledger' do
     MarketData.stubs(:configured?).returns(true)
 
     get export_modal_tracker_path
 
     assert_response :success
-    assert_not_includes @response.body, 'value="broker_tax_report"'
+    assert_not_includes @response.body, 'name="report_scope"'
+    assert_not_includes @response.body, 'data-tracker-export-target="scopeRow"'
   end
 
   test 'export modal shows the broker classification panel with exact ledger symbols' do
@@ -170,10 +171,53 @@ class TrackerControllerTest < ActionDispatch::IntegrationTest
     get export_modal_tracker_path
 
     assert_response :success
-    assert_includes @response.body, 'value="broker_tax_report"'
+    assert_select 'input[name="report_scope"][value="crypto"]'
+    assert_select 'input[name="report_scope"][value="broker"]'
     assert_includes @response.body, 'data-tracker-export-target="classificationPanel"'
     assert_includes @response.body, 'data-symbol="Brk.B"'
     assert_no_match(/translation_missing/, @response.body)
+  end
+
+  # Germany is the registry's first entry, so a fresh user with a broker ledger lands on DE and
+  # must see the crypto/stocks choice immediately, defaulted to crypto.
+  test 'the scope choice shows for the default country with crypto preselected' do
+    MarketData.stubs(:configured?).returns(true)
+    broker_ledger('AAPL' => 'stock')
+
+    get export_modal_tracker_path
+
+    assert_response :success
+    scope_row = Nokogiri::HTML(@response.body).at_css('[data-tracker-export-target="scopeRow"]')
+    assert scope_row, 'the scope row is missing'
+    assert_not_includes scope_row['class'], 'hidden'
+    assert_select 'input[name="report_scope"][value="crypto"][checked]'
+  end
+
+  test 'the saved broker scope is restored for Germany' do
+    MarketData.stubs(:configured?).returns(true)
+    broker_ledger('AAPL' => 'stock')
+    @user.update!(tracker_settings: { 'country' => 'DE', 'report_scope' => 'broker' })
+
+    get export_modal_tracker_path
+
+    assert_response :success
+    assert_select 'input[name="report_scope"][value="broker"][checked]'
+  end
+
+  # The scope only exists under German forms. A saved country elsewhere renders the row hidden and
+  # ignores a stale broker scope rather than restoring a choice the country no longer offers.
+  test 'the scope choice is hidden for a non-German country' do
+    MarketData.stubs(:configured?).returns(true)
+    broker_ledger('AAPL' => 'stock')
+    @user.update!(tracker_settings: { 'country' => 'PL', 'report_scope' => 'broker' })
+
+    get export_modal_tracker_path
+
+    assert_response :success
+    scope_row = Nokogiri::HTML(@response.body).at_css('[data-tracker-export-target="scopeRow"]')
+    assert scope_row, 'the scope row is missing'
+    assert_includes scope_row['class'], 'hidden'
+    assert_select 'input[name="report_scope"][value="crypto"][checked]'
   end
 
   # A hundred holdings used to render a hundred rows, and the user had to scroll all of them to


### PR DESCRIPTION
The export modal offered the German broker report as a third top-level radio beside "Tax Report" — with a long parenthetical label — while the country picker applied only to the crypto report and disappeared when the broker option was selected.

The modal now follows the choice the user is actually making:

1. Pick **Tax Report** or **All** (transactions export).
2. Pick the **country** — Germany is a normal entry in the list.
3. With Germany selected and a broker account connected, a scope choice appears: **Crypto** or **Stocks & ETFs** (Anlage KAP / KAP-INV). Everyone else sees no extra row.

Details:

- The wire format and persisted settings are unchanged (`report_scope` stays `crypto`/`broker`), so saved preferences and pending reports carry over.
- A saved broker scope under a non-German country renders hidden and falls back to crypto — the scope only exists under German forms.
- The year narrowing to the broker report's supported years, the securities classification panel, and the generate-button gating all carry over keyed to the new scope radios.
- The `broker_tax_report` label is replaced by short `scope_crypto` / `scope_broker` labels in all 15 locales.
