### PR TITLE
Drop the hosted platform, use the update-check switch

### DIFF
--- a/app/models/app_update.rb
+++ b/app/models/app_update.rb
@@ -20,12 +20,13 @@ class AppUpdate
     Rails.application.config.version
   end
 
-  # False where something else delivers updates, and wherever the owner has switched the check off.
+  # False on the desktop, which updates itself, and wherever the owner has switched the check off
+  # — a container someone else keeps current (a hosting platform, a managed fleet) sets that too.
   # This is the only outbound call an otherwise offline install makes, so it owes them a switch —
   # read through the application's own resolver because ActiveModel::Type::Boolean has a closed
   # false list that reads 'no' as true.
   def self.enabled?
-    return false if Installation.managed_updates?
+    return false if Installation.desktop?
 
     Deltabadger::Application.env_boolean(ENV[OPT_OUT]) != false
   end

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -6,23 +6,18 @@
 # something narrower than what it would be used to claim: /.dockerenv proves "a container", not
 # "started with Compose", and MARKET_DATA_URL proves "a market-data service was configured", which
 # the manual documents for self-hosted installs pointing at their own. Both ways of guessing wrong
-# cost the user something real — an install wrongly read as managed never hears about an update,
-# and one wrongly read as Compose is handed a command that cannot update it — so an install that
-# has not been told what it is stays :unknown and gets pointed at the manual, which covers every
-# way of starting it.
+# cost the user something real — an install wrongly read as self-updating never hears about an
+# update, and one wrongly read as Compose is handed a command that cannot update it — so an install
+# that has not been told what it is stays :unknown and gets pointed at the manual, which covers
+# every way of starting it.
 #
-# The marker is set by each launcher: src-tauri/src/lib.rs, docker-compose.yml,
-# deltabadger/docker-compose.yml, and DockerManager#container_env in the hosting platform.
+# The marker is set by each launcher: src-tauri/src/lib.rs, docker-compose.yml and
+# deltabadger/docker-compose.yml. An install somebody else keeps up to date needs no marker of its
+# own — it switches the check off with DELTABADGER_UPDATE_CHECK=false and this section stays away.
 class Installation
   MARKER = 'DELTABADGER_PLATFORM'
 
-  PLATFORMS = %i[desktop umbrel docker hosted].freeze
-
-  # Platforms where a new version arrives without the user doing anything in this app: the desktop
-  # build has Tauri's own signed updater, which prompts on launch, and a hosted container is
-  # recreated by the platform. Neither should be told to check GitHub — for the desktop the signed
-  # update manifest, not the release, decides what is installable.
-  MANAGED = %i[desktop hosted].freeze
+  PLATFORMS = %i[desktop umbrel docker].freeze
 
   def self.platform
     platform_from_env(ENV)
@@ -40,7 +35,10 @@ class Installation
     :unknown
   end
 
-  def self.managed_updates?(platform = self.platform)
-    MANAGED.include?(platform)
+  # The one platform that installs updates itself: Tauri's signed updater prompts on launch, and
+  # its manifest rather than the GitHub release decides what is installable. So the desktop build
+  # gets a button instead of instructions, and never asks GitHub for a release of its own.
+  def self.desktop?(platform = self.platform)
+    platform == :desktop
   end
 end

--- a/app/views/settings/widgets/_app_update.html.erb
+++ b/app/views/settings/widgets/_app_update.html.erb
@@ -2,8 +2,8 @@
     failures, or with the check switched off, the section stays away rather than reporting an
     install current on no evidence. %>
 <% platform = Installation.platform %>
-<% state = if Installation.managed_updates?(platform)
-             platform
+<% state = if Installation.desktop?(platform)
+             :desktop
            elsif AppUpdate.available?
              :available
            elsif AppUpdate.latest_version.present?
@@ -15,8 +15,6 @@
     <h4 class="modal__title"><%= t('settings.app_update.title') %></h4>
 
     <% case state %>
-    <% when :hosted %>
-      <p><%= t('settings.app_update.hosted') %></p>
     <% when :desktop %>
       <%# The desktop build installs updates itself, so it gets the button rather than the
           instructions the container platforms need. app/javascript/tauri.js calls the updater. %>

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -116,7 +116,6 @@ bg:
             umbrel: "Обновете Deltabadger от вашия Umbrel App Store."
             manual: "Как да обновите"
             desktop: "Deltabadger проверява за обновления при всяко стартиране."
-            hosted: "Обновленията се инсталират вместо вас."
             release_notes: "Бележки към версията"
             check_now: "Проверка за обновления"
             checking: "Проверява се…"

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -117,7 +117,6 @@ cs:
             umbrel: "Aktualizujte Deltabadger ve svém Umbrel App Storu."
             manual: "Jak aktualizovat"
             desktop: "Deltabadger hledá aktualizace při každém spuštění."
-            hosted: "Aktualizace se instalují za vás."
             release_notes: "Poznámky k verzi"
             check_now: "Zkontrolovat aktualizace"
             checking: "Kontroluje se…"

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -116,7 +116,6 @@ da:
             umbrel: "Opdater Deltabadger fra din Umbrel App Store."
             manual: "Sådan opdaterer du"
             desktop: "Deltabadger søger efter opdateringer, hver gang den starter."
-            hosted: "Opdateringerne bliver installeret for dig."
             release_notes: "Udgivelsesnoter"
             check_now: "Søg efter opdateringer"
             checking: "Søger…"

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -115,7 +115,6 @@ de:
             umbrel: 'Aktualisieren Sie Deltabadger in Ihrem Umbrel App Store.'
             manual: 'So wird aktualisiert'
             desktop: 'Deltabadger sucht bei jedem Start nach Updates.'
-            hosted: 'Updates werden für Sie installiert.'
             release_notes: 'Versionshinweise'
             check_now: 'Nach Updates suchen'
             checking: 'Wird gesucht …'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -116,7 +116,6 @@ el:
             umbrel: "Ενημέρωσε το Deltabadger από το Umbrel App Store σου."
             manual: "Πώς γίνεται η ενημέρωση"
             desktop: "Το Deltabadger ελέγχει για ενημερώσεις σε κάθε εκκίνηση."
-            hosted: "Οι ενημερώσεις εγκαθίστανται για σένα."
             release_notes: "Σημειώσεις έκδοσης"
             check_now: "Έλεγχος για ενημερώσεις"
             checking: "Γίνεται έλεγχος…"

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -116,7 +116,6 @@ en:
             umbrel: 'Update Deltabadger from your Umbrel App Store.'
             manual: 'How to update'
             desktop: 'Deltabadger checks for updates each time it starts.'
-            hosted: 'Updates are installed for you.'
             release_notes: 'Release notes'
             check_now: 'Check for updates'
             checking: 'Checking…'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -115,7 +115,6 @@ es:
             umbrel: 'Actualiza Deltabadger desde tu App Store de Umbrel.'
             manual: 'Cómo actualizar'
             desktop: 'Deltabadger busca actualizaciones cada vez que se inicia.'
-            hosted: 'Las actualizaciones se instalan por ti.'
             release_notes: 'Notas de la versión'
             check_now: 'Buscar actualizaciones'
             checking: 'Buscando…'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -115,7 +115,6 @@ fr:
             umbrel: 'Mettez Deltabadger à jour depuis votre App Store Umbrel.'
             manual: 'Comment mettre à jour'
             desktop: 'Deltabadger vérifie les mises à jour à chaque démarrage.'
-            hosted: 'Les mises à jour sont installées pour vous.'
             release_notes: 'Notes de version'
             check_now: 'Rechercher des mises à jour'
             checking: 'Recherche…'

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -115,7 +115,6 @@ it:
             umbrel: 'Aggiorna Deltabadger dal tuo App Store di Umbrel.'
             manual: 'Come aggiornare'
             desktop: 'Deltabadger controlla gli aggiornamenti a ogni avvio.'
-            hosted: 'Gli aggiornamenti vengono installati per te.'
             release_notes: 'Note di rilascio'
             check_now: 'Cerca aggiornamenti'
             checking: 'Ricerca…'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -115,7 +115,6 @@ nl:
             umbrel: 'Werk Deltabadger bij via uw Umbrel App Store.'
             manual: 'Zo werkt u bij'
             desktop: 'Deltabadger controleert bij elke start op updates.'
-            hosted: 'Updates worden voor u geïnstalleerd.'
             release_notes: 'Releaseopmerkingen'
             check_now: 'Controleren op updates'
             checking: 'Bezig met controleren…'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -117,7 +117,6 @@ pl:
             umbrel: 'Zaktualizuj Deltabadgera w swoim Umbrel App Store.'
             manual: 'Jak zaktualizować'
             desktop: 'Deltabadger sprawdza aktualizacje przy każdym uruchomieniu.'
-            hosted: 'Aktualizacje instalują się automatycznie.'
             release_notes: 'Informacje o wersji'
             check_now: 'Sprawdź aktualizacje'
             checking: 'Sprawdzanie…'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -115,7 +115,6 @@ pt:
             umbrel: 'Atualize o Deltabadger a partir da sua App Store do Umbrel.'
             manual: 'Como atualizar'
             desktop: 'O Deltabadger procura atualizações sempre que arranca.'
-            hosted: 'As atualizações são instaladas por si.'
             release_notes: 'Notas da versão'
             check_now: 'Procurar atualizações'
             checking: 'A procurar…'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -119,7 +119,6 @@ ru:
             umbrel: 'Обновите Deltabadger в вашем Umbrel App Store.'
             manual: 'Как обновить'
             desktop: 'Deltabadger проверяет обновления при каждом запуске.'
-            hosted: 'Обновления устанавливаются за вас.'
             release_notes: 'Описание версии'
             check_now: 'Проверить обновления'
             checking: 'Проверка…'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -117,7 +117,6 @@ sk:
             umbrel: "Aktualizujte Deltabadger vo svojom Umbrel App Store."
             manual: "Ako aktualizovať"
             desktop: "Deltabadger hľadá aktualizácie pri každom spustení."
-            hosted: "Aktualizácie sa inštalujú za vás."
             release_notes: "Poznámky k vydaniu"
             check_now: "Skontrolovať aktualizácie"
             checking: "Kontroluje sa…"

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -116,7 +116,6 @@ sv:
             umbrel: "Uppdatera Deltabadger från din Umbrel App Store."
             manual: "Så uppdaterar du"
             desktop: "Deltabadger söker efter uppdateringar varje gång den startar."
-            hosted: "Uppdateringarna installeras åt dig."
             release_notes: "Versionsinformation"
             check_now: "Sök efter uppdateringar"
             checking: "Söker…"

--- a/manual/29-configuration.md
+++ b/manual/29-configuration.md
@@ -85,7 +85,7 @@ See [Market data](35-market-data.md) for what each provider covers.
 | `RAILS_LOG_TO_STDOUT` | Set by the image. Logs go to the container output, so `docker compose logs -f` shows them. |
 | `RAILS_SERVE_STATIC_FILES` | Set by the image. The app serves its own assets; keep it unless a web server in front serves `/public`. |
 | `DELTABADGER_UPDATE_CHECK` | `false` stops the twice-daily check for a newer release. See [Updating](07-updating.md). |
-| `DELTABADGER_PLATFORM` | How this copy was installed — `docker`, `umbrel`, `desktop` or `hosted` — which decides what **Settings → Account** offers when an update exists. Set for you by the Compose file, the Umbrel app and the desktop app. Set it yourself only if you start the container some other way and want the Compose instructions: `docker` if you use Compose, otherwise leave it unset and the manual is linked instead. |
+| `DELTABADGER_PLATFORM` | How this copy was installed — `docker`, `umbrel` or `desktop` — which decides what **Settings → Account** offers when an update exists. Set for you by the Compose file, the Umbrel app and the desktop app. Set it yourself only if you start the container some other way and want the Compose instructions: `docker` if you use Compose, otherwise leave it unset and the manual is linked instead. |
 
 ## Command modes
 

--- a/test/integration/app_update_widget_test.rb
+++ b/test/integration/app_update_widget_test.rb
@@ -66,21 +66,12 @@ class AppUpdateWidgetTest < ActionDispatch::IntegrationTest
     AppUpdate.stubs(:latest_version).returns('2.47.0')
     AppUpdate.stubs(:latest_url).returns(RELEASE_URL)
 
-    %i[docker umbrel unknown hosted].each do |platform|
+    %i[docker umbrel unknown].each do |platform|
       Installation.stubs(:platform).returns(platform)
       get settings_account_path
 
       assert_select '#app_update [data-desktop-update]', false, "#{platform} must not offer the desktop button"
     end
-  end
-
-  test 'a hosted install is told nothing is needed' do
-    Installation.stubs(:platform).returns(:hosted)
-    get settings_account_path
-
-    assert_select '#app_update'
-    assert_select '#app_update [data-clipboard-text-value]', false
-    assert_select '#app_update a[href*=?]', 'releases', false
   end
 
   test 'an install that is current gets no instructions' do

--- a/test/models/app_update_test.rb
+++ b/test/models/app_update_test.rb
@@ -93,14 +93,6 @@ class AppUpdateTest < ActiveSupport::TestCase
     assert_requested :get, RELEASES_URL, times: 1
   end
 
-  test 'a hosted install never asks' do
-    Installation.stubs(:platform).returns(:hosted)
-
-    refute AppUpdate.enabled?
-    assert_nil AppUpdate.refresh!
-    assert_not_requested :get, RELEASES_URL
-  end
-
   test 'a desktop install never asks — its own updater is the authority' do
     Installation.stubs(:platform).returns(:desktop)
 

--- a/test/models/installation_test.rb
+++ b/test/models/installation_test.rb
@@ -12,7 +12,6 @@ class InstallationTest < ActiveSupport::TestCase
     assert_equal :docker, platform_for('DELTABADGER_PLATFORM' => 'docker')
     assert_equal :umbrel, platform_for('DELTABADGER_PLATFORM' => 'umbrel')
     assert_equal :desktop, platform_for('DELTABADGER_PLATFORM' => 'desktop')
-    assert_equal :hosted, platform_for('DELTABADGER_PLATFORM' => 'hosted')
   end
 
   test 'a marker is read regardless of case and surrounding space' do
@@ -30,18 +29,17 @@ class InstallationTest < ActiveSupport::TestCase
   end
 
   # MARKET_DATA_URL names any separately managed market-data service — the manual documents it
-  # for self-hosted installs pointing at their own. Reading it as "this is a hosted container"
-  # would silently freeze those installs out of update notices forever.
-  test 'MARKET_DATA_URL does not make an install hosted' do
+  # for self-hosted installs pointing at their own, so it says nothing about how this copy was
+  # installed. Reading it as a platform would freeze those installs out of update notices forever.
+  test 'MARKET_DATA_URL names no platform' do
     assert_equal :unknown, platform_for('MARKET_DATA_URL' => 'https://data.example.com')
   end
 
-  test 'managed updates only where something else delivers them' do
-    assert Installation.managed_updates?(:hosted)
-    assert Installation.managed_updates?(:desktop)
-    refute Installation.managed_updates?(:docker)
-    refute Installation.managed_updates?(:umbrel)
-    refute Installation.managed_updates?(:unknown)
+  test 'only the desktop build installs updates itself' do
+    assert Installation.desktop?(:desktop)
+    refute Installation.desktop?(:docker)
+    refute Installation.desktop?(:umbrel)
+    refute Installation.desktop?(:unknown)
   end
 
   test 'platform reads the real environment' do


### PR DESCRIPTION
Removes `hosted` as a platform. A platform that recreates its own containers already has a way to say so — `DELTABADGER_UPDATE_CHECK=false` — which stops the GitHub call and leaves the section off the Settings page entirely, rather than replacing it with a sentence saying an update is somebody else's job. The version is already on show; that is enough.

Naming it as a fourth platform bought that one sentence and cost an enum value, a branch in the widget and a string in fifteen locales.

`Installation` now answers only the question it is needed for — desktop, Umbrel, Compose, or unknown — and `MANAGED` collapses to `Installation.desktop?`, the one platform that really does install updates itself.

Nothing changes for a self-hosted install: the marker is still declared rather than guessed, and an install that has not been told what it is still gets pointed at the manual.

4943 runs, 18923 assertions, 0 failures.
