### PR TITLE
Say why a value in a sentence was rejected, and where

### DIFF
--- a/app/assets/stylesheets/_forms.sass
+++ b/app/assets/stylesheets/_forms.sass
@@ -72,8 +72,6 @@ $formUnit: 2rem
         &~.form__label
           color: var(--berry)
           font-weight: 600
-      &~.form__info--invalid
-        display: block
       &:focus
         &~.form__info--invalid
           color: var(--link)

--- a/app/assets/stylesheets/_forms.sass
+++ b/app/assets/stylesheets/_forms.sass
@@ -82,8 +82,6 @@ $formUnit: 2rem
     font-size: 1.75rem
     margin-top: .5rem
     margin-bottom: -.4rem
-    &--invalid
-      display: none
     &--invalid, &--alert, &--notice
       font-weight: 600
     &--invalid, &--alert

--- a/app/javascript/controllers/form/html5_validations_controller.js
+++ b/app/javascript/controllers/form/html5_validations_controller.js
@@ -1,20 +1,41 @@
 import { Controller } from "@hotwired/stimulus"
 
 // This controller allows showing native html5 form validation errors with custom style, inline (below each field).
-// The form fields have to be wrapped in a div with class `form__row` for the error to be displayed correctly.
 // The field will include the class `invalid` when the field is invalid.
 // The error message will be displayed in a div with class `form__info--invalid`.
 // Errors are removed when the input changes.
 // source: https://www.jorgemanrubia.com/2019/02/16/form-validations-with-html5-and-modern-rails/
+//
+// Where the message goes depends on the form. A stacked form wraps each field in `.form__row` and
+// gets the message right under the field, as before. A conversational form has no such row: its
+// fields sit inside a sentence laid out as a row flex, where a block element next to the input
+// lands BESIDE the words instead of under them. Those get the message in the widget's text column.
+//
+// A field's message is looked up in this order:
+//   data-html5-<failed constraint>-message   e.g. data-html5-range-underflow-message
+//   data-html5-error-message                 the catch-all
+//   field.validationMessage                  the browser's own sentence
+// so a field that explains its own minimum is not made to answer a typo with that explanation.
+
+// In `validity` order, so the first match is the most specific thing wrong with the value.
+const CONSTRAINTS = [
+  'valueMissing', 'typeMismatch', 'patternMismatch', 'tooLong', 'tooShort',
+  'rangeUnderflow', 'rangeOverflow', 'stepMismatch', 'badInput'
+]
 
 // Connects to data-controller="form--html5-validations"
 export default class extends Controller {
+  // Keyed by the field itself: the multi-asset allocation inputs carry neither an id nor a name, so
+  // any DOM-attribute key collides across them and lets one valid field erase another's message.
+  #errors = new WeakMap()
+
   connect() {
     this.element.setAttribute('novalidate', true)
     this.element.addEventListener('blur', this.#onBlur, true)
     this.element.addEventListener('submit', this.#onSubmit)
     this.element.addEventListener('ajax:beforeSend', this.#onSubmit)
     this.element.addEventListener('input', this.#onInput, true)
+    this.#adoptServerRenderedErrors()
   }
 
   disconnect() {
@@ -67,6 +88,19 @@ export default class extends Controller {
       !['file', 'reset', 'submit', 'button'].includes(field.type)
   }
 
+  // The server renders the same div for model errors (config/initializers/inline_form_errors.rb),
+  // right after the field and before this controller ever runs. Take ownership of those so they
+  // land where a client-side message would, and so typing clears them.
+  #adoptServerRenderedErrors() {
+    this.element.querySelectorAll('.form__info--invalid').forEach((error) => {
+      const field = error.previousElementSibling
+      if (!field || !this.#shouldValidateField(field)) return
+
+      this.#errors.set(field, error)
+      this.#placeErrorMessage(field, error)
+    })
+  }
+
   #refreshErrorForInvalidField(field, isValid) {
     this.#removeExistingErrorMessage(field)
     if (!isValid)
@@ -74,22 +108,45 @@ export default class extends Controller {
   }
 
   #removeExistingErrorMessage(field) {
-    const fieldContainer = field.closest('.form__row')
-    if(!fieldContainer) {
-      return;
-    }
-    const existingErrorMessageElement = fieldContainer.querySelector('.form__info--invalid')
-    if (existingErrorMessageElement)
-      existingErrorMessageElement.parentNode.removeChild(existingErrorMessageElement)
+    this.#errors.get(field)?.remove()
+    this.#errors.delete(field)
   }
 
   #showErrorForInvalidField(field) {
-    field.insertAdjacentHTML('afterend', this.#buildFieldErrorHtml(field))
+    const error = this.#buildFieldError(field)
+    this.#errors.set(field, error)
+    this.#placeErrorMessage(field, error)
   }
 
-  #buildFieldErrorHtml(field) {
-    const errorMessage = field.dataset.html5ErrorMessage || field.validationMessage
-    return `<div class="form__info form__info--invalid">${errorMessage}</div>`
+  #placeErrorMessage(field, error) {
+    const row = field.closest('.form__row')
+    if (row) {
+      field.insertAdjacentElement('afterend', error)
+      return
+    }
+
+    // `.toggle-group__info` is the rule widget's text column (a column flex), so the message lands
+    // under the sentence and its `.small-info`, aligned with them. Anything else falls back to the
+    // form, which is itself a `.widget` column — a card-level message at the bottom.
+    const column = field.closest('.toggle-group__info') || this.element
+    column.appendChild(error)
+  }
+
+  // textContent, not markup: these messages interpolate exchange names and asset symbols that come
+  // from exchange APIs.
+  #buildFieldError(field) {
+    const error = document.createElement('div')
+    error.className = 'form__info form__info--invalid'
+    error.textContent = this.#messageFor(field)
+    return error
+  }
+
+  #messageFor(field) {
+    const failed = CONSTRAINTS.find((constraint) => field.validity[constraint])
+    const specific = failed &&
+      field.dataset[`html5${failed[0].toUpperCase()}${failed.slice(1)}Message`]
+
+    return specific || field.dataset.html5ErrorMessage || field.validationMessage
   }
 
   get #formFields() {

--- a/app/models/bot/smart_intervalable.rb
+++ b/app/models/bot/smart_intervalable.rb
@@ -19,12 +19,18 @@ module Bot::SmartIntervalable
     # additionally waits for a sell amount, so flipping a smart-on bot with no sell sentence yet
     # can't fail validation. A quote-denominated sell validates NEITHER split — the rule is not
     # offered in that mode (see Bot::Reversible#effective_interval_duration).
-    validates :smart_interval_quote_amount,
-              numericality: { greater_than_or_equal_to: :minimum_smart_interval_quote_amount },
-              if: -> { smart_intervaled? && !selling? }
-    validates :smart_interval_base_amount,
-              numericality: { greater_than_or_equal_to: :minimum_smart_interval_base_amount },
-              if: -> { smart_intervaled? && sells_base_amount? && sell_amount.present? }
+    #
+    # The floor is a separate validation rather than numericality's greater_than_or_equal_to: that
+    # option's `message` is validator-wide, so wiring the explanation into it would answer "abc"
+    # with a minimum-order-size sentence instead of "is not a number".
+    validates :smart_interval_quote_amount, numericality: true,
+                                            if: -> { smart_intervaled? && !selling? }
+    validate :validate_smart_interval_quote_minimum,
+             if: -> { smart_intervaled? && !selling? }
+    validates :smart_interval_base_amount, numericality: true,
+                                           if: -> { smart_intervaled? && sells_base_amount? && sell_amount.present? }
+    validate :validate_smart_interval_base_minimum,
+             if: -> { smart_intervaled? && sells_base_amount? && sell_amount.present? }
 
     decorators = Module.new do
       def parse_params(params)
@@ -61,7 +67,103 @@ module Bot::SmartIntervalable
     smart_intervaled == true
   end
 
+  # The floor a split may not go under, and WHY. The form's `min`, the form's message and the
+  # validation all read this one method, so the number they enforce and the sentence they show
+  # cannot disagree. `kind` is :quote (buying) or :base (selling a base amount).
+  #
+  # Three floors compete and the binding one names the reason, resolved :exchange, :frequency,
+  # :precision so the most concrete explanation wins a tie. The frequency term is compared
+  # UNROUNDED: round_up of any positive frequency already lands on at least 10**-decimals, so
+  # comparing the rounded value would make :precision unreachable even where precision is what
+  # actually set the floor.
+  def smart_interval_minimum(kind)
+    return { value: 0, reason: :none } if tickers.empty?
+
+    decimals = kind == :base ? least_precise_base_decimals : least_precise_quote_decimals
+    frequency = smart_interval_frequency_minimum(kind)
+    precision = 1.0 / (10**decimals)
+    exchange = kind == :base ? minimum_base_for_exchange : minimum_for_exchange
+
+    reason = if exchange >= frequency && exchange >= precision
+               :exchange
+             elsif frequency >= precision
+               :frequency
+             else
+               :precision
+             end
+
+    {
+      value: [Utilities::Number.round_up(frequency, precision: decimals), precision, exchange].max,
+      reason: reason
+    }
+  end
+
+  # The sentence that explains the floor, shown inline by the form and repeated in the flash when a
+  # request gets past the browser. nil when there is nothing to explain — the browser's own wording
+  # then stands.
+  def smart_interval_minimum_message(kind)
+    minimum = smart_interval_minimum(kind)
+    return if minimum[:reason] == :none
+
+    currency = (kind == :base ? base_asset : quote_asset)&.symbol
+    amount = BigDecimal(minimum[:value].to_s).to_s('F').sub(/([0-9]\d*)\.0$/, '\\1')
+
+    case minimum[:reason]
+    when :exchange
+      I18n.t('bot.smart_intervals_disclaimer', exchange: exchange&.name, currency: currency, minimum: amount)
+    when :frequency
+      I18n.t('bot.smart_intervals_minimum_frequency', currency: currency, minimum: amount)
+    when :precision
+      I18n.t('bot.smart_intervals_minimum_precision', currency: currency, minimum: amount,
+                                                      decimals: kind == :base ? least_precise_base_decimals : least_precise_quote_decimals)
+    end
+  end
+
   private
+
+  def validate_smart_interval_quote_minimum
+    validate_smart_interval_minimum(:quote, :smart_interval_quote_amount)
+  end
+
+  def validate_smart_interval_base_minimum
+    validate_smart_interval_minimum(:base, :smart_interval_base_amount)
+  end
+
+  # Parse rather than assume a Numeric: a split stored through the JSON settings column comes back
+  # as the STRING "0.2", which numericality accepts and which raises on a comparison with a
+  # BigDecimal. Skip only what will not parse at all — numericality has already spoken for those.
+  # An is_a?(Numeric) guard here would instead quietly stop enforcing the floor on every such row.
+  def validate_smart_interval_minimum(kind, attribute)
+    value = BigDecimal(public_send(attribute).to_s, exception: false)
+    return if value.nil?
+
+    minimum = smart_interval_minimum(kind)
+    return if value >= BigDecimal(minimum[:value].to_s)
+
+    message = smart_interval_minimum_message(kind)
+    if message
+      errors.add(attribute, message)
+    else
+      errors.add(attribute, :greater_than_or_equal_to, count: minimum[:value])
+    end
+  end
+
+  # Smallest split that still leaves at least `maximum_frequency` between two orders.
+  def smart_interval_frequency_minimum(kind)
+    maximum_frequency = 300 # seconds — at most one order every 5 minutes
+
+    if kind == :base
+      amount = try(:sell_amount).to_f
+      interval_secs = (Automation::Schedulable::INTERVALS[try(:sell_interval)] || interval_duration).to_f
+      return 0 unless amount.positive? && interval_secs.positive?
+
+      amount / interval_secs * maximum_frequency
+    else
+      return 0 if quote_amount.blank?
+
+      quote_amount / interval_duration.to_f * maximum_frequency
+    end
+  end
 
   def initialize_smart_intervalable_settings
     self.smart_intervaled ||= false
@@ -92,18 +194,7 @@ module Bot::SmartIntervalable
   end
 
   def minimum_smart_interval_base_amount
-    return 0 if tickers.empty?
-
-    maximum_frequency = 300 # seconds — at most one sale every 5 minutes
-    sell_amount_value = try(:sell_amount).to_f
-    interval_secs = (Automation::Schedulable::INTERVALS[try(:sell_interval)] || interval_duration).to_f
-    minimum_for_frequency = sell_amount_value.positive? && interval_secs.positive? ? sell_amount_value / interval_secs * maximum_frequency : 0
-    minimum_for_precision = 1.0 / (10**least_precise_base_decimals)
-
-    [
-      Utilities::Number.round_up(minimum_for_frequency, precision: least_precise_base_decimals),
-      minimum_for_precision
-    ].max
+    smart_interval_minimum(:base)[:value]
   end
 
   def least_precise_base_decimals
@@ -111,28 +202,20 @@ module Bot::SmartIntervalable
   end
 
   def minimum_smart_interval_quote_amount
-    return 0 if tickers.empty?
-
-    # the minimum amount would set one order every 5 minutes
-    maximum_frequency = 300 # seconds
-    minimum_for_frequency = if quote_amount.present?
-                              quote_amount / interval_duration.to_f * maximum_frequency
-                            else
-                              0
-                            end
-
-    minimum_for_precision = 1.0 / (10**least_precise_quote_decimals)
-
-    [
-      Utilities::Number.round_up(minimum_for_frequency, precision: least_precise_quote_decimals),
-      minimum_for_precision,
-      minimum_for_exchange
-    ].max
+    smart_interval_minimum(:quote)[:value]
   end
 
   # Override in subclasses to set exchange-specific minimums
   # For Index bots, this returns the highest minimum_quote_size among tickers
   def minimum_for_exchange
+    0
+  end
+
+  # The venue's own floor on the SELL side. Still 0 everywhere: DcaSingleAsset is the only type that
+  # sells, and giving it a ticker-derived floor here would make the numericality check reject splits
+  # already stored on live bots — including during Bot::Lifecycle#stop, which goes through `update`.
+  # That change needs its own backfill; see docs/superpowers/plans/2026-09-02-conversational-validation-feedback.md.
+  def minimum_base_for_exchange
     0
   end
 

--- a/app/views/bots/settings/_smart_intervals.html.erb
+++ b/app/views/bots/settings/_smart_intervals.html.erb
@@ -19,19 +19,19 @@
           <% if bot.sells_base_amount? %>
             <%# Selling splits the SELL amount into base units (issue #5), the mirror of the buy split. %>
             <% amount_html = content_tag(:div) do %>
-              <% min_amount = bot.send(:minimum_smart_interval_base_amount) %>
+              <% min_amount = bot.smart_interval_minimum(:base)[:value] %>
               <% current = bot.smart_interval_base_amount.presence || (bot.sell_amount.present? ? bot.sell_amount / 10 : min_amount) %>
               <% value = [current.to_d, min_amount.to_d].max.to_s('F').sub(/([0-9]\d*)\.0$/, '\1') %>
-              <%= amount_field f, :smart_interval_base_amount, value: value, min: min_amount, class: 'sinput numeric-input', step: :any, size: 2, data: { controller: "autowidth-input", action: "input->form--submit-after-delay#submit input->autowidth-input#resize", form__move_cursor_to_end_target: "input" }, style: "margin-left: 0.125rem; width: 50px;", disabled: bot.working? %>
+              <%= amount_field f, :smart_interval_base_amount, value: value, min: min_amount, class: 'sinput numeric-input', step: :any, size: 2, data: { controller: "autowidth-input", action: "input->form--submit-after-delay#submit input->autowidth-input#resize", form__move_cursor_to_end_target: "input", html5_range_underflow_message: bot.smart_interval_minimum_message(:base) }, style: "margin-left: 0.125rem; width: 50px;", disabled: bot.working? %>
             <% end %>
             <%= t("bot.settings.smart_intervals.sell_sentence_html",
                   amount_html: amount_html.html_safe,
                   base: bot.base_asset&.symbol).html_safe %>
           <% else %>
             <% amount_html = content_tag(:div) do %>
-              <% min_amount = bot.send(:minimum_smart_interval_quote_amount) %>
+              <% min_amount = bot.smart_interval_minimum(:quote)[:value] %>
               <% value = bot.smart_interval_quote_amount.present? ? [bot.smart_interval_quote_amount, min_amount].max.to_d.to_s('F').sub(/([0-9]\d*)\.0$/, '\1') : nil %>
-              <%= amount_field f, :smart_interval_quote_amount, value: value, min: min_amount, class: 'sinput numeric-input', step: :any, size: 2, data: { controller: "autowidth-input", action: "input->form--submit-after-delay#submit input->autowidth-input#resize", form__move_cursor_to_end_target: "input" }, style: "margin-left: 0.125rem; width: 50px;", disabled: bot.working? %>
+              <%= amount_field f, :smart_interval_quote_amount, value: value, min: min_amount, class: 'sinput numeric-input', step: :any, size: 2, data: { controller: "autowidth-input", action: "input->form--submit-after-delay#submit input->autowidth-input#resize", form__move_cursor_to_end_target: "input", html5_range_underflow_message: bot.smart_interval_minimum_message(:quote) }, style: "margin-left: 0.125rem; width: 50px;", disabled: bot.working? %>
             <% end %>
             <%= t("bot.settings.smart_intervals.sentence_html",
                   amount_html: amount_html.html_safe,

--- a/config/initializers/inline_form_errors.rb
+++ b/config/initializers/inline_form_errors.rb
@@ -13,7 +13,10 @@ ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
   # error_message = model.errors.messages.values.join(', ')  # formatted as <error_message>
   # # error_message = model.errors.full_messages.join(', ')  # formatted as <attribute_name> <error_message>
 
-  error_message = instance.error_message.join(', ')
+  # Escaped: the whole fragment below is marked html_safe, so an error message is rendered as
+  # MARKUP. Harmless while every message is a Rails default made of attribute names and numbers,
+  # not harmless now that one carries an exchange name and an asset symbol, both API-derived.
+  error_message = ERB::Util.html_escape(instance.error_message.join(', '))
 
   html = if field
            field['class'] = "#{field['class']} is-invalid"

--- a/config/locales/bot.bg.yml
+++ b/config/locales/bot.bg.yml
@@ -174,7 +174,6 @@ bg:
             do_you_want_to_archive: 'Искате ли да архивирате този бот?'
             symbol_not_supported: "%{symbol} не се поддържа"
             specify_percentage_limit_order: "При създаване на лимитирана поръчка задайте процент"
-            smart_intervals_above_minimum: "Стойността на умните интервали трябва да е по-висока от %{minimum}"
             invalid_price_range: "Ценовият диапазон е невалиден"
             subaccounts_not_allowed: "Подсметките не са разрешени за тази борса"
             no_subaccount_name: "Не е зададено име на подсметка"
@@ -211,9 +210,9 @@ bg:
         taker_fee: "Taker"
         withdrawal_fee: "Теглене"
         additional_title: "Двупосочен бот"
-        smart_intervals_disclaimer: 'Размерът на поръчките в %{exchange} е определен в %{currency}. Минималният размер на поръчка е %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Размерът на поръчките в %{exchange} е определен в %{currency}. Минималният размер на поръчка е %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Минималният размер на поръчка е %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Размерът на поръчките в %{exchange} е определен в %{currency}. Минималният размер на поръчка е %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "По-малки части биха подавали поръчки по-често от веднъж на 5 минути. Използвайте поне %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} се котира с %{decimals} знака след десетичната запетая, затова частта не може да е по-малка от %{minimum} %{currency}."
         starting: Стартиране
         subaccounts_info: 'Използвай подсметка'
         week: Седмица

--- a/config/locales/bot.cs.yml
+++ b/config/locales/bot.cs.yml
@@ -174,7 +174,6 @@ cs:
             do_you_want_to_archive: 'Chcete archivovat tohoto bota?'
             symbol_not_supported: "%{symbol} není podporován"
             specify_percentage_limit_order: "Při vytváření limitního příkazu zadejte procento"
-            smart_intervals_above_minimum: "Hodnota chytrých intervalů musí být vyšší než %{minimum}"
             invalid_price_range: "Cenový rozsah je neplatný"
             subaccounts_not_allowed: "Podúčty nejsou na této burze povoleny"
             no_subaccount_name: "Není zadán název podúčtu"
@@ -211,9 +210,9 @@ cs:
         taker_fee: "Taker"
         withdrawal_fee: "Výběr"
         additional_title: "Obousměrný bot"
-        smart_intervals_disclaimer: 'Velikost příkazů na %{exchange} je definována v %{currency}. Minimální velikost příkazu je %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Velikost příkazů na %{exchange} je definována v %{currency}. Minimální velikost příkazu je %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Minimální velikost příkazu je %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Velikost příkazů na %{exchange} je definována v %{currency}. Minimální velikost příkazu je %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Menší části by zadávaly příkazy častěji než jednou za 5 minut. Použijte alespoň %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} se uvádí na %{decimals} desetinných míst, takže část nemůže být menší než %{minimum} %{currency}."
         starting: Spouštění
         subaccounts_info: 'Použít podúčet'
         week: Týden

--- a/config/locales/bot.da.yml
+++ b/config/locales/bot.da.yml
@@ -174,7 +174,6 @@ da:
             do_you_want_to_archive: 'Vil du arkivere denne bot?'
             symbol_not_supported: "%{symbol} understøttes ikke"
             specify_percentage_limit_order: "Angiv en procentdel for limitordrer"
-            smart_intervals_above_minimum: "Smarte intervallers værdi skal være større end %{minimum}"
             invalid_price_range: "Prisintervallet er ugyldigt"
             subaccounts_not_allowed: "Underkonti er ikke tilladt på denne børs"
             no_subaccount_name: "Intet underkonto-navn angivet"
@@ -211,9 +210,9 @@ da:
         taker_fee: "Taker"
         withdrawal_fee: "Udbetaling"
         additional_title: "Tovejs-bot"
-        smart_intervals_disclaimer: 'Ordrestørrelsen på %{exchange} er defineret i %{currency}. Minimumsordrestørrelsen er %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Ordrestørrelsen på %{exchange} er defineret i %{currency}. Minimumsordrestørrelsen er %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Minimumsordrestørrelsen er %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Ordrestørrelsen på %{exchange} er defineret i %{currency}. Minimumsordrestørrelsen er %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Mindre enheder ville placere ordrer oftere end hvert 5. minut. Brug mindst %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} noteres med %{decimals} decimaler, så en enhed kan ikke være mindre end %{minimum} %{currency}."
         starting: Starter
         subaccounts_info: 'Brug underkonto'
         week: Uge

--- a/config/locales/bot.de.yml
+++ b/config/locales/bot.de.yml
@@ -165,7 +165,6 @@ de:
             do_you_want_to_archive: 'Möchtest du diesen Bot archivieren?'
             symbol_not_supported: "%{symbol} wird nicht unterstützt"
             specify_percentage_limit_order: "Gib den Prozentsatz bei der Erstellung einer Limit-Order an"
-            smart_intervals_above_minimum: "Der Wert der intelligenten Intervalle sollte größer als %{minimum} sein"
             invalid_price_range: "Der Preisbereich ist ungültig"
             failed_tooltip_explanation: "Diese Bestellung ist fehlgeschlagen: %{error_message}"
             skipped_tooltip_explanation: "Diese Bestellung wurde übersprungen, da der Betrag unter der Mindestbestellgröße von %{exchange_name} lag. Der übersprungene Betrag wurde gepuffert und wird der nächsten Bestellung hinzugefügt."
@@ -198,9 +197,9 @@ de:
         taker_fee: "Taker"
         withdrawal_fee: "Auszahlung"
         additional_title: "Zwei-Wege-Bot"
-        smart_intervals_disclaimer: ' Die Mindestordergröße beträgt %{minimum}%{currency}'
-        smart_intervals_disclaimer_base: ' Die Mindestordergröße beträgt %{minimum}%{currency}'
-        smart_intervals_disclaimer_quote: 'Die Mindestordergröße beträgt %{minimum}%{currency}'
+        smart_intervals_disclaimer: 'Die Ordergröße auf %{exchange} wird in %{currency} angegeben. Die Mindestordergröße beträgt %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Kleinere Einheiten würden Orders häufiger als alle 5 Minuten auslösen. Verwenden Sie mindestens %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} wird mit %{decimals} Nachkommastellen notiert, eine Einheit kann daher nicht kleiner als %{minimum} %{currency} sein."
         starting: 'Wird gestartet'
         week: Woche
         withdraw_interval_html: 'Zahle alle <split>2</split> Tage aus.'

--- a/config/locales/bot.el.yml
+++ b/config/locales/bot.el.yml
@@ -174,7 +174,6 @@ el:
             do_you_want_to_archive: 'Θέλεις να αρχειοθετήσεις αυτό το bot;'
             symbol_not_supported: "Το %{symbol} δεν υποστηρίζεται"
             specify_percentage_limit_order: "Όρισε ποσοστό κατά τη δημιουργία εντολής limit"
-            smart_intervals_above_minimum: "Η τιμή των έξυπνων διαστημάτων πρέπει να είναι μεγαλύτερη από %{minimum}"
             invalid_price_range: "Μη έγκυρο εύρος τιμής"
             subaccounts_not_allowed: "Δεν επιτρέπονται υπολογαριασμοί σε αυτό το ανταλλακτήριο"
             no_subaccount_name: "Δεν δόθηκε όνομα υπολογαριασμού"
@@ -211,9 +210,9 @@ el:
         taker_fee: "Taker"
         withdrawal_fee: "Ανάληψη"
         additional_title: "Bot δύο κατευθύνσεων"
-        smart_intervals_disclaimer: 'Το μέγεθος εντολών στο %{exchange} ορίζεται σε %{currency}. Το ελάχιστο μέγεθος εντολής είναι %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Το μέγεθος εντολών στο %{exchange} ορίζεται σε %{currency}. Το ελάχιστο μέγεθος εντολής είναι %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Το ελάχιστο μέγεθος εντολής είναι %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Το μέγεθος εντολών στο %{exchange} ορίζεται σε %{currency}. Το ελάχιστο μέγεθος εντολής είναι %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Μικρότερες μονάδες θα τοποθετούσαν εντολές συχνότερα από κάθε 5 λεπτά. Χρησιμοποιήστε τουλάχιστον %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "Το %{currency} εκφράζεται με %{decimals} δεκαδικά ψηφία, οπότε μια μονάδα δεν μπορεί να είναι μικρότερη από %{minimum} %{currency}."
         starting: Εκκίνηση
         subaccounts_info: 'Χρήση υπολογαριασμού'
         week: Εβδομάδα

--- a/config/locales/bot.en.yml
+++ b/config/locales/bot.en.yml
@@ -174,7 +174,6 @@ en:
             do_you_want_to_archive: 'Do you want to archive this bot?'
             symbol_not_supported: "%{symbol} is not supported"
             specify_percentage_limit_order: "Specify percentage when creating a limit order"
-            smart_intervals_above_minimum: "Smart intervals value should be greater than %{minimum}"
             invalid_price_range: "Price range is invalid"
             subaccounts_not_allowed: "Subaccounts not allowed on this exchange"
             no_subaccount_name: "No subaccount name supplied"
@@ -211,9 +210,9 @@ en:
         taker_fee: "Taker"
         withdrawal_fee: "Withdrawal"
         additional_title: "Two-way bot"
-        smart_intervals_disclaimer: 'Orders size on %{exchange} is defined in %{currency}. The minimum order size is %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Orders size on %{exchange} is defined in %{currency}. The minimum order size is %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'The minimum order size is %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Orders size on %{exchange} is defined in %{currency}. The minimum order size is %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Smaller units would place orders more often than every 5 minutes. Use at least %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} is quoted to %{decimals} decimal places, so a unit cannot be smaller than %{minimum} %{currency}."
         starting: Starting
         subaccounts_info: 'Use subaccount'
         week: Week

--- a/config/locales/bot.es.yml
+++ b/config/locales/bot.es.yml
@@ -169,7 +169,6 @@ es:
             do_you_want_to_archive: '¿Quieres archivar este bot?'
             symbol_not_supported: "%{symbol} no es compatible"
             specify_percentage_limit_order: "Especifica el porcentaje al crear una orden limitada"
-            smart_intervals_above_minimum: "El valor de los intervalos inteligentes debe ser mayor que %{minimum}"
             invalid_price_range: "El rango de precios no es válido"
             failed_tooltip_explanation: "Esta orden falló: %{error_message}"
             skipped_tooltip_explanation: "Esta orden se ha omitido porque la cantidad estaba por debajo del tamaño mínimo de orden de %{exchange_name}. La cantidad omitida se ha almacenado y se añadirá a la siguiente orden."
@@ -191,9 +190,9 @@ es:
         price_range_buy_html: 'Pero solo en el rango de precios de <split>100 $</split> a <split>1000 $</split> %{quote} por %{base}.'
         price_range_sell_html: 'Vende solo en el rango de precios de <split>100 $</split> a <split>1000 $</split> %{quote} por %{base}.'
         sell: Vender
-        smart_intervals_disclaimer: 'El tamaño de las órdenes en %{exchange} se define en %{currency}. El tamaño mínimo de la orden es de %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'El tamaño de las órdenes en %{exchange} se define en %{currency}. El tamaño mínimo de la orden es de %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'El tamaño mínimo de orden es de %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'El tamaño de las órdenes en %{exchange} se define en %{currency}. El tamaño mínimo de la orden es de %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Unidades más pequeñas colocarían órdenes con más frecuencia que cada 5 minutos. Usa al menos %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} se cotiza con %{decimals} decimales, así que una unidad no puede ser menor que %{minimum} %{currency}."
         starting: Empezar
         week: Semana
         withdraw_interval_html: 'Retirar cada <split>2</split> días.'

--- a/config/locales/bot.fr.yml
+++ b/config/locales/bot.fr.yml
@@ -169,7 +169,6 @@ fr:
             do_you_want_to_archive: 'Voulez-vous vraiment archiver ce bot ?'
             symbol_not_supported: "%{symbol} n''est pas pris en charge"
             specify_percentage_limit_order: "Spécifiez le pourcentage lors de la création d''un ordre limité"
-            smart_intervals_above_minimum: "La valeur des intervalles intelligents doit être supérieure à %{minimum}"
             invalid_price_range: "La fourchette de prix est invalide"
             failed_tooltip_explanation: "Cette commande a échoué: %{error_message}"
             skipped_tooltip_explanation: "Cette commande a été ignorée car le montant était inférieur à la taille minimale de commande de %{exchange_name}. Le montant ignoré a été mis en mémoire tampon et sera ajouté à la prochaine commande."
@@ -191,9 +190,9 @@ fr:
         price_range_buy_html: 'Acheter uniquement dans une fourchette de prix comprise entre <split>100 $</split> et <split>1 000 $</split> %{quote} par %{base}.'
         price_range_sell_html: 'Vendre uniquement dans une fourchette de prix comprise entre <split>100 $</split> et <split>1 000 $</split> %{quote} par %{base}.'
         sell: 'Vendre'
-        smart_intervals_disclaimer: 'Le montant des ordres sur %{exchange} est définie en %{currency}. Le montant minimum est de %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Le montant des ordres sur %{exchange} est définie en %{currency}. Le montant minimum est de %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Le montant minimal d''un ordre est de %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Le montant des ordres sur %{exchange} est définie en %{currency}. Le montant minimum est de %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Des unités plus petites passeraient des ordres plus souvent que toutes les 5 minutes. Utilisez au moins %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} est coté avec %{decimals} décimales, une unité ne peut donc pas être inférieure à %{minimum} %{currency}."
         starting: 'Commencer'
         week: 'Semaine'
         withdraw_interval_html: 'Retirer tous les <split>2</split> jours.'

--- a/config/locales/bot.it.yml
+++ b/config/locales/bot.it.yml
@@ -167,7 +167,6 @@ it:
             do_you_want_to_archive: 'Vuoi archiviare questo bot?'
             symbol_not_supported: "%{symbol} non è supportato"
             specify_percentage_limit_order: "Specifica la percentuale quando crei un ordine limite"
-            smart_intervals_above_minimum: "Il valore degli intervalli intelligenti dovrebbe essere maggiore di %{minimum}"
             invalid_price_range: "L'intervallo di prezzo non è valido"
             failed_tooltip_explanation: "Questo ordine è fallito: %{error_message}"
             skipped_tooltip_explanation: "Questo ordine è stato saltato perché l'importo era inferiore alla dimensione minima dell'ordine di %{exchange_name}. L'importo saltato è stato messo in buffer e verrà aggiunto al prossimo ordine."
@@ -200,9 +199,9 @@ it:
         taker_fee: "Taker"
         withdrawal_fee: "Prelievo"
         additional_title: "Bot bidirezionale"
-        smart_intervals_disclaimer: 'La dimensione degli ordini su %{exchange} è definita in %{currency}. La dimensione minima dell''ordine è %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'La dimensione degli ordini su %{exchange} è definita in %{currency}. La dimensione minima dell''ordine è %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'La dimensione minima dell''ordine è %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'La dimensione degli ordini su %{exchange} è definita in %{currency}. La dimensione minima dell''ordine è %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Unità più piccole invierebbero ordini più spesso di una volta ogni 5 minuti. Usa almeno %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} è quotato con %{decimals} decimali, quindi un'unità non può essere inferiore a %{minimum} %{currency}."
         starting: Avvio in corso
         week: Settimana
         withdraw_interval_html: 'Preleva ogni <split>2</split> giorni.'

--- a/config/locales/bot.nl.yml
+++ b/config/locales/bot.nl.yml
@@ -169,7 +169,6 @@ nl:
             do_you_want_to_archive: 'Wil je deze bot archiveren?'
             symbol_not_supported: "%{symbol} wordt niet ondersteund"
             specify_percentage_limit_order: "Geef het percentage op bij het maken van een limietorder"
-            smart_intervals_above_minimum: "De waarde van slimme intervallen moet groter zijn dan %{minimum}"
             invalid_price_range: "De prijsklasse is ongeldig"
             failed_tooltip_explanation: "Deze bestelling is mislukt: %{error_message}"
             skipped_tooltip_explanation: "Deze bestelling is overgeslagen omdat het bedrag onder de minimale ordergrootte van %{exchange_name} lag. Het overgeslagen bedrag is gebufferd en wordt toegevoegd aan de volgende bestelling."
@@ -191,9 +190,9 @@ nl:
         price_range_buy_html: 'Koop alleen in het prijsbereik van <split>$100</split> tot <split>$1000</split> %{quote} per %{base}.'
         price_range_sell_html: 'Verkoop enkel in het prijsbereik van <split>$100</split> tot <split>$1000</split> %{quote} per %{base}.'
         sell: Verkopen
-        smart_intervals_disclaimer: 'De ordergrootte bij %{exchange} wordt bepaald in %{currency}. De minimale ordergrootte is %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'De ordergrootte bij %{exchange} wordt bepaald in %{currency}. De minimale ordergrootte is %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'De minimale ordergrootte is %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'De ordergrootte bij %{exchange} wordt bepaald in %{currency}. De minimale ordergrootte is %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Kleinere eenheden zouden vaker dan elke 5 minuten orders plaatsen. Gebruik minstens %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} wordt genoteerd met %{decimals} decimalen, dus een eenheid kan niet kleiner zijn dan %{minimum} %{currency}."
         starting: Startend
         week: Week
         withdraw_interval_html: 'Neem elke <split>2</split> dagen fondsen op.'

--- a/config/locales/bot.pl.yml
+++ b/config/locales/bot.pl.yml
@@ -169,7 +169,6 @@ pl:
             do_you_want_to_archive: 'Czy chcesz zarchiwizować tego bota?'
             symbol_not_supported: "%{symbol} nie jest obsługiwany"
             specify_percentage_limit_order: "Podaj procent przy tworzeniu zlecenia z limitem"
-            smart_intervals_above_minimum: "Wartość inteligentnych interwałów powinna być większa niż %{minimum}"
             invalid_price_range: "Zakres cenowy jest nieprawidłowy"
             failed_tooltip_explanation: "To zlecenie zakończyło się niepowodzeniem: %{error_message}"
             skipped_tooltip_explanation: "To zlecenie zostało pominięte, ponieważ kwota była poniżej minimalnego rozmiaru zlecenia %{exchange_name}. Pominięta kwota została zbuforowana i zostanie dodana do następnego zlecenia."
@@ -192,8 +191,8 @@ pl:
         price_range_sell_html: 'Sprzedawaj tylko w przedziale cenowym od <split> 100 USD </split> do <split> 1000 USD </split> %{quote} za %{base}.'
         sell: Sprzedaj
         smart_intervals_disclaimer: '%{exchange} definiuje zlecenia w %{currency}. Minimalna wielkość zlecenia to %{minimum} %{currency}.'
-        smart_intervals_disclaimer_base: '%{exchange} definiuje zlecenia w %{currency}. Minimalna wielkość zlecenia to %{minimum} %{currency}.'
-        smart_intervals_disclaimer_quote: 'Minimalna wielkość zlecenia to%{minimum}%{currency}.'
+        smart_intervals_minimum_frequency: "Mniejsze części składałyby zlecenia częściej niż co 5 minut. Użyj co najmniej %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} jest kwotowany z dokładnością do %{decimals} miejsc po przecinku, więc część nie może być mniejsza niż %{minimum} %{currency}."
         starting: Uruchamianie
         week: tydzień
         withdraw_interval_html: 'Wypłacaj co <split>2</split> dni.'

--- a/config/locales/bot.pt.yml
+++ b/config/locales/bot.pt.yml
@@ -167,7 +167,6 @@ pt:
             do_you_want_to_archive: 'Quer arquivar este bot?'
             symbol_not_supported: "%{symbol} não é suportado"
             specify_percentage_limit_order: "Especifique a porcentagem ao criar uma ordem limitada"
-            smart_intervals_above_minimum: "O valor dos intervalos inteligentes deve ser maior que %{minimum}"
             invalid_price_range: "A faixa de preço é inválida"
             failed_tooltip_explanation: "Esta ordem falhou: %{error_message}"
             skipped_tooltip_explanation: "Esta ordem foi pulada porque a quantidade estava abaixo do tamanho mínimo de ordem da %{exchange_name}. A quantidade pulada foi armazenada e será adicionada à próxima ordem."
@@ -187,9 +186,9 @@ pt:
         price_range_buy_html: 'Comprar apenas no intervalo de preços de <split>$100</split> a <split>$1000</split> %{quote} por %{base}.'
         price_range_sell_html: 'Vender apenas no intervalo de preços de  <split>$100</split> a <split>$1000</split> %{quote} por %{base}.'
         sell: Vender
-        smart_intervals_disclaimer: 'A dimensão das ordens em %{exchange} é definida em %{currency}. A dimensão mínima da ordem é %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'A dimensão das ordens em %{exchange} é definida em %{currency}. A dimensão mínima da ordem é %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'A dimensão da ordem mínima é %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'A dimensão das ordens em %{exchange} é definida em %{currency}. A dimensão mínima da ordem é %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Unidades menores colocariam ordens com mais frequência do que a cada 5 minutos. Use pelo menos %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} é cotado com %{decimals} casas decimais, por isso uma unidade não pode ser menor que %{minimum} %{currency}."
         starting: Começar
         week: Semana
         warning:

--- a/config/locales/bot.ru.yml
+++ b/config/locales/bot.ru.yml
@@ -167,7 +167,6 @@ ru:
             do_you_want_to_archive: 'Вы хотите архивировать этого бота?'
             symbol_not_supported: "%{symbol} не поддерживается"
             specify_percentage_limit_order: "Укажите процент при создании лимитного ордера"
-            smart_intervals_above_minimum: "Значение умных интервалов должно быть больше, чем %{minimum}"
             invalid_price_range: "Диапазон цен недействителен"
             failed_tooltip_explanation: "Этот ордер не выполнен: %{error_message}"
             skipped_tooltip_explanation: "Этот ордер был пропущен, так как сумма была ниже минимального размера ордера на %{exchange_name}. Пропущенная сумма была буферизована и будет добавлена к следующему ордеру."
@@ -189,9 +188,9 @@ ru:
         price_range_buy_html: 'Покупать только в диапазоне цен от  <split>$100</split> до <split>$1000</split> %{quote} за %{base}.'
         price_range_sell_html: 'Продавать только в диапазоне цен от  <split>$100</split> до <split>$1000</split> %{quote} за %{base}.'
         sell: Продать
-        smart_intervals_disclaimer: 'Размер ордеров на %{exchange} указывается в %{currency}. Минимальный размер ордера составляет %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Размер ордеров на %{exchange} указывается в %{currency}. Минимальный размер ордера составляет %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Минимальный размер ордера составляет %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Размер ордеров на %{exchange} указывается в %{currency}. Минимальный размер ордера составляет %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Меньшие части создавали бы ордера чаще, чем раз в 5 минут. Используйте не менее %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} котируется с точностью до %{decimals} знаков после запятой, поэтому часть не может быть меньше %{minimum} %{currency}."
         starting: Начало
         week: Неделя
         withdraw_interval_html: ''

--- a/config/locales/bot.sk.yml
+++ b/config/locales/bot.sk.yml
@@ -174,7 +174,6 @@ sk:
             do_you_want_to_archive: 'Chcete archivovať tohto bota?'
             symbol_not_supported: "%{symbol} nie je podporovaný"
             specify_percentage_limit_order: "Pri vytváraní limitného príkazu zadajte percento"
-            smart_intervals_above_minimum: "Hodnota inteligentných intervalov musí byť vyššia ako %{minimum}"
             invalid_price_range: "Cenový rozsah je neplatný"
             subaccounts_not_allowed: "Podúčty nie sú na tejto burze povolené"
             no_subaccount_name: "Nie je zadaný názov podúčtu"
@@ -211,9 +210,9 @@ sk:
         taker_fee: "Taker"
         withdrawal_fee: "Výber"
         additional_title: "Obojsmerný bot"
-        smart_intervals_disclaimer: 'Veľkosť príkazov na %{exchange} je definovaná v %{currency}. Minimálna veľkosť príkazu je %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Veľkosť príkazov na %{exchange} je definovaná v %{currency}. Minimálna veľkosť príkazu je %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Minimálna veľkosť príkazu je %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Veľkosť príkazov na %{exchange} je definovaná v %{currency}. Minimálna veľkosť príkazu je %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Menšie časti by zadávali príkazy častejšie než raz za 5 minút. Použite aspoň %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} sa uvádza na %{decimals} desatinných miest, takže časť nemôže byť menšia než %{minimum} %{currency}."
         starting: Spúšťanie
         subaccounts_info: 'Použiť podúčet'
         week: Týždeň

--- a/config/locales/bot.sv.yml
+++ b/config/locales/bot.sv.yml
@@ -174,7 +174,6 @@ sv:
             do_you_want_to_archive: 'Vill du arkivera denna bot?'
             symbol_not_supported: "%{symbol} stöds inte"
             specify_percentage_limit_order: "Ange procentsats vid limitorder"
-            smart_intervals_above_minimum: "Smarta intervall-beloppet måste vara större än %{minimum}"
             invalid_price_range: "Ogiltigt prisintervall"
             subaccounts_not_allowed: "Underkonton tillåts inte på denna börs"
             no_subaccount_name: "Inget underkontonamn angivet"
@@ -211,9 +210,9 @@ sv:
         taker_fee: "Taker"
         withdrawal_fee: "Uttag"
         additional_title: "Tvåvägsbot"
-        smart_intervals_disclaimer: 'Orderstorleken på %{exchange} definieras i %{currency}. Minsta orderstorlek är %{minimum}%{currency}.'
-        smart_intervals_disclaimer_base: 'Orderstorleken på %{exchange} definieras i %{currency}. Minsta orderstorlek är %{minimum}%{currency}.'
-        smart_intervals_disclaimer_quote: 'Minsta orderstorlek är %{minimum}%{currency}.'
+        smart_intervals_disclaimer: 'Orderstorleken på %{exchange} definieras i %{currency}. Minsta orderstorlek är %{minimum} %{currency}.'
+        smart_intervals_minimum_frequency: "Mindre enheter skulle lägga ordrar oftare än var 5:e minut. Använd minst %{minimum} %{currency}."
+        smart_intervals_minimum_precision: "%{currency} noteras med %{decimals} decimaler, så en enhet kan inte vara mindre än %{minimum} %{currency}."
         starting: Startar
         subaccounts_info: 'Använd underkonto'
         week: Vecka

--- a/test/config/inline_form_errors_test.rb
+++ b/test/config/inline_form_errors_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+# field_error_proc marks the fragment it builds html_safe, so a model error message is rendered as
+# markup. Now that one of those messages carries an exchange name and an asset symbol — both
+# API-derived — it has to be escaped on the way in.
+class InlineFormErrorsTest < ActiveSupport::TestCase
+  test 'a model error message is escaped, not rendered as markup' do
+    html = render_field_error('<script>alert(1)</script>')
+
+    assert_includes html, '&lt;script&gt;'
+    refute_includes html, '<script>'
+  end
+
+  test 'an ordinary message still renders, and the field is marked invalid' do
+    html = render_field_error('must be greater than or equal to 5')
+
+    assert_includes html, 'Must be greater than or equal to 5'
+    assert_includes html, 'is-invalid'
+  end
+
+  private
+
+  def render_field_error(message)
+    instance = Struct.new(:error_message).new([message])
+    ActionView::Base.field_error_proc.call('<input name="bot[amount]">', instance)
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -100,7 +100,9 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
           headers: { 'Turbo-Frame' => 'update_name_form' }
 
     assert_response :unprocessable_entity
-    assert_includes @response.body, I18n.t('devise.registrations.new.name_invalid')
+    # Escaped on the way in (config/initializers/inline_form_errors.rb marks the fragment
+    # html_safe), so the apostrophe arrives as an entity and renders as one.
+    assert_includes @response.body, ERB::Util.html_escape(I18n.t('devise.registrations.new.name_invalid'))
   end
 
   test 'a wrong current password comes back with the reason attached to the field' do

--- a/test/models/bot/smart_interval_minimum_test.rb
+++ b/test/models/bot/smart_interval_minimum_test.rb
@@ -1,0 +1,146 @@
+require 'test_helper'
+
+# The floor a Smart Intervals split may not go under, and the sentence that explains it. The form's
+# `min`, the form's message and the validation all read one method, so these cover all three.
+class Bot::SmartIntervalMinimumTest < ActiveSupport::TestCase
+  # A venue floor beats the others: multi-asset bots take the highest minimum_quote_size in the
+  # basket (10 from the ticker factory) over a 100/week cadence's 0.05.
+  test 'exchange floor binds and names itself' do
+    bot = multi_asset(quote_amount: 100.0, interval: 'week')
+
+    minimum = bot.smart_interval_minimum(:quote)
+
+    assert_equal :exchange, minimum[:reason]
+    assert_in_delta 10.0, minimum[:value]
+  end
+
+  # 100 USD an hour is 8.34 every five minutes, well over the venue's 0 and the 0.01 tick.
+  test 'frequency floor binds when it is the tallest' do
+    bot = single_asset(quote_amount: 100.0, interval: 'hour')
+
+    minimum = bot.smart_interval_minimum(:quote)
+
+    assert_equal :frequency, minimum[:reason]
+    assert_in_delta 8.34, minimum[:value]
+  end
+
+  # The regression the reason-picking exists for: round_up of any positive frequency already lands
+  # on at least one tick, so choosing the reason from the ROUNDED number would credit :frequency
+  # here even though precision is what set the floor.
+  test 'precision floor binds when the frequency requirement falls under one tick' do
+    bot = single_asset(quote_amount: 1.0, interval: 'day') # 0.00347 per 5 min, under 0.01
+
+    minimum = bot.smart_interval_minimum(:quote)
+
+    assert_equal :precision, minimum[:reason]
+    assert_in_delta 0.01, minimum[:value]
+  end
+
+  test 'no tickers means no floor and nothing to explain' do
+    bot = Bots::DcaSingleAsset.new
+
+    assert_equal({ value: 0, reason: :none }, bot.smart_interval_minimum(:quote))
+    assert_nil bot.smart_interval_minimum_message(:quote)
+  end
+
+  test 'the readers the validator and the form use come from the descriptor' do
+    bot = single_asset(quote_amount: 100.0, interval: 'hour')
+
+    assert_equal bot.smart_interval_minimum(:quote)[:value], bot.send(:minimum_smart_interval_quote_amount)
+    assert_equal bot.smart_interval_minimum(:base)[:value], bot.send(:minimum_smart_interval_base_amount)
+  end
+
+  test 'exchange reason names the venue and the amount' do
+    bot = multi_asset(quote_amount: 100.0, interval: 'week')
+
+    message = bot.smart_interval_minimum_message(:quote)
+
+    assert_includes message, bot.exchange.name
+    assert_includes message, '10 USD'
+    refute_includes message, '10.0'
+  end
+
+  test 'frequency and precision reasons explain themselves' do
+    bot = single_asset(quote_amount: 100.0, interval: 'hour')
+    frequency = bot.smart_interval_minimum_message(:quote)
+
+    bot.settings = bot.settings.merge('quote_amount' => 1.0, 'interval' => 'day')
+    precision = bot.smart_interval_minimum_message(:quote)
+
+    assert_equal I18n.t('bot.smart_intervals_minimum_frequency', minimum: '8.34', currency: 'USD'), frequency
+    assert_equal I18n.t('bot.smart_intervals_minimum_precision', minimum: '0.01', currency: 'USD', decimals: 2),
+                 precision
+  end
+
+  # A split written through the JSON settings column comes back as a String. It has to be compared,
+  # not skipped (which would stop enforcing the floor) and not raised on.
+  test 'a split stored as a string is compared, not skipped' do
+    bot = single_asset(quote_amount: 100.0, interval: 'hour')
+    bot.smart_intervaled = true
+
+    bot.smart_interval_quote_amount = '20.0'
+    assert_predicate bot, :valid?
+
+    bot.smart_interval_quote_amount = '0.2'
+    refute_predicate bot, :valid?
+    assert_includes bot.errors[:smart_interval_quote_amount], bot.smart_interval_minimum_message(:quote)
+  end
+
+  # numericality keeps its own wording: the floor explanation would be a nonsense answer to a typo.
+  # (Unreachable through the controller, where parse_params .to_f's it to 0.0 first.)
+  test 'a non-numeric split is still answered as not a number' do
+    bot = single_asset(quote_amount: 100.0, interval: 'hour')
+    bot.smart_intervaled = true
+    bot.smart_interval_quote_amount = 'abc'
+
+    refute_predicate bot, :valid?
+    assert_includes bot.errors[:smart_interval_quote_amount],
+                    I18n.t('activerecord.errors.models.bot.attributes.smart_interval_quote_amount.not_a_number')
+    refute_includes bot.errors[:smart_interval_quote_amount], bot.smart_interval_minimum_message(:quote)
+  end
+
+  test 'every locale renders both new keys with their interpolations' do
+    I18n.available_locales.each do |locale|
+      %w[smart_intervals_minimum_frequency smart_intervals_minimum_precision].each do |key|
+        assert I18n.exists?("bot.#{key}", locale, fallback: false),
+               "#{locale} is missing bot.#{key}"
+      end
+
+      assert_nothing_raised do
+        I18n.t('bot.smart_intervals_minimum_frequency', locale: locale, minimum: '1', currency: 'USD')
+        I18n.t('bot.smart_intervals_minimum_precision', locale: locale, minimum: '1', currency: 'USD', decimals: 2)
+        I18n.t('bot.smart_intervals_disclaimer', locale: locale, minimum: '1', currency: 'USD', exchange: 'Binance',
+                                                 raise: true)
+      end
+    end
+  end
+
+  test 'the content-free keys are gone everywhere' do
+    dead = %w[bot.messages.smart_intervals_above_minimum
+              bot.smart_intervals_disclaimer_base
+              bot.smart_intervals_disclaimer_quote]
+
+    I18n.available_locales.each do |locale|
+      dead.each do |key|
+        refute I18n.exists?(key, locale, fallback: false), "#{locale} still defines #{key}"
+      end
+    end
+  end
+
+  private
+
+  # Assigned, not saved: the floor is a pure function of the settings, and saving would drag in
+  # Accountable's set_missed_quote_amount guard for nothing.
+  def single_asset(quote_amount:, interval:)
+    with_settings(create(:dca_single_asset), quote_amount, interval)
+  end
+
+  def multi_asset(quote_amount:, interval:)
+    with_settings(create(:dca_multi_asset), quote_amount, interval)
+  end
+
+  def with_settings(bot, quote_amount, interval)
+    bot.settings = bot.settings.merge('quote_amount' => quote_amount, 'interval' => interval)
+    bot
+  end
+end

--- a/test/views/smart_intervals_widget_test.rb
+++ b/test/views/smart_intervals_widget_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The Smart Intervals split is the one conversational input carrying a `min`, so it is the one that
+# gets rejected in a sentence. The browser's own answer to that — "Value must be greater than or
+# equal to 5." — names a number without naming the rule behind it, so the field carries its own.
+class SmartIntervalsWidgetTest < ActionView::TestCase
+  setup do
+    def @controller.default_url_options = { locale: I18n.default_locale }
+  end
+
+  def render_widget(bot)
+    render partial: 'bots/settings/smart_intervals',
+           locals: { bot: bot, method: :patch, path: '/bots/1' }
+    rendered
+  end
+
+  test 'the buy split carries the explanation and the floor it belongs to' do
+    bot = create(:dca_multi_asset)
+    bot.settings = bot.settings.merge('quote_amount' => 100.0, 'interval' => 'week')
+    bot.smart_intervaled = true
+
+    html = render_widget(bot)
+    field = Nokogiri::HTML.fragment(html).at('input[name*="smart_interval_quote_amount"]')
+
+    assert_equal bot.smart_interval_minimum_message(:quote), field['data-html5-range-underflow-message']
+    assert_equal bot.smart_interval_minimum(:quote)[:value].to_s, field['min']
+    assert_includes field['data-html5-range-underflow-message'], bot.exchange.name
+  end
+
+  test 'the sell split carries its own explanation' do
+    bot = create(:dca_single_asset)
+    bot.settings = bot.settings.merge('direction' => 'selling', 'sell_denomination' => 'base',
+                                      'sell_amount' => 1.0, 'sell_interval' => 'day')
+    bot.smart_intervaled = true
+    assert_predicate bot, :sells_base_amount?
+
+    html = render_widget(bot)
+    field = Nokogiri::HTML.fragment(html).at('input[name*="smart_interval_base_amount"]')
+
+    assert_equal bot.smart_interval_minimum_message(:base), field['data-html5-range-underflow-message']
+    assert_equal bot.smart_interval_minimum(:base)[:value].to_s, field['min']
+  end
+end


### PR DESCRIPTION
Typing a too-small Smart Intervals split turned the input red and did nothing else. The value never saved and nothing said why.

## What was wrong

`_smart_intervals.html.erb` is the only conversational input carrying a `min`. The form controller sets `novalidate`, validates on blur and submit, and `preventDefault()`s the auto-submit — so the value never reached the server either, and the model's own error never got a chance to render.

Three defects sat behind the one symptom:

1. **The message was invisible.** `.form__info--invalid` was `display: none`, un-hidden only by `.form__input.is-invalid ~ .form__info--invalid`. Conversational inputs are `.sinput .numeric-input`, never `.form__input`, so the rule never matched.
2. **Once visible it landed inline.** `insertAdjacentHTML('afterend')` drops a block element into the middle of a sentence. And the removal that should have replaced the previous one returned early without a `.form__row` ancestor — exactly the conversational case — so every failed validation appended another copy.
3. **The text explained nothing.** It fell through to the browser's `validationMessage`: *"Value must be greater than or equal to 5."* Nothing said the 5 is the venue's minimum order size.

## Placement

Resolved rather than assumed. A field inside a `.form__row` still gets its message directly beneath it. A field in a rule widget gets it in the widget's text column, under the sentence and its info line. Anything else gets a message at the bottom of the form.

Two supporting changes:

- Messages are built with `createElement` + `textContent` instead of injected as markup — they interpolate exchange names and asset symbols that come from exchange APIs.
- Each message is tracked against its field in a `WeakMap` rather than by a DOM key. The multi-asset allocation inputs carry neither an `id` nor a `name`, so any attribute-based key collides across them and lets one valid field erase another's message. This is also what stops the duplicates.

Server-rendered errors from `field_error_proc` are adopted when the controller connects, so they end up in the same place a client-side one would and typing clears them too.

## Wording

`Bot::SmartIntervalable#smart_interval_minimum` returns the binding floor together with the reason for it — the venue's minimum order size, the "at most one order every five minutes" rule, or the quote currency's decimal precision. The form's `min`, the form's message and the validation all read that one method, so the number enforced and the number explained cannot drift.

The frequency term is compared unrounded when picking the reason: rounding up any positive frequency already lands on at least one tick, so comparing rounded values would credit the cadence rule even where precision set the floor.

The same sentence is used server-side, so the flash on a rejected update says what the field says. The floor check moved out of `numericality`'s `greater_than_or_equal_to` to get there — that option's `message` is validator-wide, so an explanation wired into it would answer a typo with a minimum-order-size sentence instead of "is not a number".

`smart_intervals_above_minimum` ("Smart intervals value should be greater than %{minimum}") is deleted; it says no more than the browser did. Two byte-identical duplicates of the disclaimer go with it — all three have been unreferenced since the Hotwire rewrite. Two new keys are translated across all 15 locales.

## Escaping

`field_error_proc` marked the fragment it builds `html_safe` while interpolating a model error message into it, so a message was rendered as markup. Harmless while every such message was made of attribute names and numbers; not harmless now that one carries an exchange name and an asset symbol. Escaped, with a test.

## Not included

`minimum_for_exchange` is overridden only by the multi-asset and index types — the single-asset type inherits `0`, so its split is never floored at the venue minimum and a sub-minimum bot silently skips every tick instead. Raising that floor makes the validation reject values already stored on live bots, and stopping a bot goes through `update`, so a legacy bot would become unstoppable. It needs a backfill and its own lifecycle tests; the reasoning is in `docs/superpowers/plans/2026-09-02-conversational-validation-feedback.md`.

## Verification

4925 tests green. Checked by hand in the browser: the message lands under the sentence with the reason; four failed blurs leave one message, not four; a different constraint gets the browser's own wording rather than the minimum explanation; a valid value clears it; a server-rejected update puts its message in the same place; and two allocation inputs failing at once keep separate messages, with fixing one leaving the other standing.
