### PR TITLE
One size for small helper text, and no hand-placed offsets

### DIFF
--- a/app/assets/stylesheets/_forms.sass
+++ b/app/assets/stylesheets/_forms.sass
@@ -76,10 +76,7 @@ $formUnit: 2rem
         &~.form__info--invalid
           color: var(--link)
   &__info
-    padding-left: .4rem
-    font-size: 1.75rem
-    margin-top: .5rem
-    margin-bottom: -.4rem
+    font-size: 1.5rem
     &--invalid, &--alert, &--notice
       font-weight: 600
     &--invalid, &--alert

--- a/app/assets/stylesheets/new/_small-random.sass
+++ b/app/assets/stylesheets/new/_small-random.sass
@@ -5,7 +5,7 @@
     gap: 1rem
     align-content: flex-start
     color: var(--stone)
-    font-size: 0.8em
+    font-size: 1.75rem
     font-weight: 450
     .text-success
         font-weight: 600

--- a/app/assets/stylesheets/new/_toggle.sass
+++ b/app/assets/stylesheets/new/_toggle.sass
@@ -121,7 +121,7 @@ input[type=checkbox]
     &__info
         display: flex
         flex-direction: column
-        gap: 2rem
+        gap: 1rem
         flex-grow: 1
         &__label
             display: flex

--- a/app/assets/stylesheets/new/_widget.sass
+++ b/app/assets/stylesheets/new/_widget.sass
@@ -68,7 +68,6 @@ $stack-open: 0.2s ease-out
         background: var(--insight-background)
     .small-info
         font-size: 1.75rem
-        padding-top: 0.5em
         display: block
         width: 100%
     &.data-grid


### PR DESCRIPTION
Small helper text under a field was rendered at three different sizes depending on where it landed.

- `.form__info` was `1.75rem` with a `.4rem` left pad, a `.5rem` top margin and a `-.4rem` bottom margin — hand-placed offsets to make that size sit right.
- `.small-info` was `0.8em`, so its size depended on whatever the parent happened to be.
- Widgets overrode `.small-info` back to `1.75rem` and added a `0.5em` top pad to compensate.

Now `.small-info` is `1.75rem` outright, matching what the widget override already asked for, and the compensating offsets are gone from both places. `.form__info` drops to `1.5rem` so a validation message sits under its field without competing with the label. Toggle info rows tighten from a `2rem` gap to `1rem`.

CSS only — `dartsass:build` compiles clean.
