### PR TITLE
Point the Umbrel jobs service at the cable database

### DIFF
--- a/deltabadger/docker-compose.yml
+++ b/deltabadger/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       DATABASE_PATH: /app/storage/production.sqlite3
       QUEUE_DATABASE_PATH: /app/storage/production_queue.sqlite3
       CACHE_DATABASE_PATH: /app/storage/production_cache.sqlite3
-      CABLE_DATABASE_PATH: /app/storage/production_cache.sqlite3
+      CABLE_DATABASE_PATH: /app/storage/production_cable.sqlite3
       # Setting ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY and
       # ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT here holds stored data independent of
       # this value. Both services share one database, so both blocks need the same values

--- a/test/config/umbrel_compose_test.rb
+++ b/test/config/umbrel_compose_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'yaml'
+
+class UmbrelComposeTest < ActiveSupport::TestCase
+  EXPECTED_ENVIRONMENT = {
+    'DATABASE_PATH' => '/app/storage/production.sqlite3',
+    'QUEUE_DATABASE_PATH' => '/app/storage/production_queue.sqlite3',
+    'CACHE_DATABASE_PATH' => '/app/storage/production_cache.sqlite3',
+    'CABLE_DATABASE_PATH' => '/app/storage/production_cable.sqlite3',
+    'SECRET_KEY_BASE' => '${APP_SEED}-secret-key-base',
+    'RAILS_ENV' => 'production'
+  }.freeze
+
+  # Guards against jobs broadcasting Turbo updates into CACHE_DATABASE_PATH instead of CABLE_DATABASE_PATH.
+  test 'web and jobs share the exact Umbrel runtime configuration' do
+    services = YAML.load_file(Rails.root.join('deltabadger/docker-compose.yml')).fetch('services')
+    web = services.fetch('web')
+    jobs = services.fetch('jobs')
+
+    EXPECTED_ENVIRONMENT.each do |key, expected_value|
+      { 'web' => web, 'jobs' => jobs }.each do |service_name, service|
+        environment = service.fetch('environment')
+
+        assert environment.key?(key), "#{service_name} environment is missing #{key}"
+        assert_equal expected_value, environment.fetch(key),
+                     "#{service_name} environment has the wrong #{key}"
+      end
+    end
+
+    assert_equal web.fetch('image'), jobs.fetch('image')
+    assert_equal web.fetch('volumes'), jobs.fetch('volumes')
+  end
+end


### PR DESCRIPTION
`deltabadger/docker-compose.yml` (the Umbrel app package) gave `jobs` `CABLE_DATABASE_PATH=/app/storage/production_cache.sqlite3` while `web` uses `production_cable.sqlite3`. Bots run in `jobs` and broadcast Turbo updates through Action Cable, so on Umbrel those broadcasts landed in the cache database and the browser, subscribed via `web`, never received them. Only Umbrel runs the image as two containers over one storage directory, so no other deployment could hit this.

One-line fix plus `test/config/umbrel_compose_test.rb`, which asserts every shared-state variable (`DATABASE_PATH`, `QUEUE_DATABASE_PATH`, `CACHE_DATABASE_PATH`, `CABLE_DATABASE_PATH`, `SECRET_KEY_BASE`, `RAILS_ENV`) is present in both `web` and `jobs` with its exact expected value — parity alone would pass two identically wrong values — and that both services share image and volumes.

Not bumped here: `umbrel-app.yml` `version`, so existing Umbrel installs see this at the next `rake release`; fresh installs pick up the corrected compose from `main` within Umbrel's 5-minute store poll.

Test: `bin/rails test test/config/umbrel_compose_test.rb` — 1 run, 26 assertions, green; rubocop clean.