### PR TITLE
Only call solid_queue_mode when the Solid Queue plugin is loaded

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -65,5 +65,7 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 plugin :tmp_restart
 
 # Run Solid Queue in Puma (async = threaded mode, no forking)
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] || rails_env == 'development'
-solid_queue_mode :async
+if ENV['SOLID_QUEUE_IN_PUMA'] || rails_env == 'development'
+  plugin :solid_queue
+  solid_queue_mode :async
+end

--- a/test/config/puma_config_test.rb
+++ b/test/config/puma_config_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require 'puma'
+require 'puma/configuration'
+
+class PumaConfigTest < ActiveSupport::TestCase
+  test 'production loads without Solid Queue in Puma' do
+    assert_nothing_raised { load_puma_config(solid_queue_in_puma: nil) }
+  end
+
+  test 'production loads the Solid Queue Puma plugin when enabled' do
+    configuration = nil
+
+    assert_nothing_raised do
+      configuration = load_puma_config(solid_queue_in_puma: 'true')
+    end
+
+    assert_equal :async, configuration._options.file_options[:solid_queue_mode]
+  end
+
+  private
+
+  def load_puma_config(solid_queue_in_puma:)
+    original_env = ENV.slice('RAILS_ENV', 'SOLID_QUEUE_IN_PUMA')
+    ENV['RAILS_ENV'] = 'production'
+
+    if solid_queue_in_puma
+      ENV['SOLID_QUEUE_IN_PUMA'] = solid_queue_in_puma
+    else
+      ENV.delete('SOLID_QUEUE_IN_PUMA')
+    end
+
+    configuration = Puma::Configuration.new do |user_config|
+      user_config.load Rails.root.join('config/puma.rb').to_s
+    end
+    configuration.load
+    configuration
+  ensure
+    ENV.delete('RAILS_ENV')
+    ENV.delete('SOLID_QUEUE_IN_PUMA')
+    original_env&.each { |key, value| ENV[key] = value }
+  end
+end


### PR DESCRIPTION
`config/puma.rb` loads the Solid Queue plugin only when `SOLID_QUEUE_IN_PUMA` is set, but called `solid_queue_mode :async` unconditionally. `solid_queue_mode` is a DSL method the plugin defines, so any production boot without the variable aborted before Puma started:

```
config/puma.rb:69:in 'Puma::DSL#_load_from': undefined method 'solid_queue_mode' for an instance of Puma::DSL (NoMethodError)
```

Hosted tenants, self-hosted `standalone` and the desktop app all set the variable, so they never saw it. The Umbrel package runs `web` and `jobs` as two containers and `web` correctly leaves it unset — so **every Umbrel install since v2.0.0 (2026-02-11, "optimize puma") has crash-looped on first start**. Reproduced today on a fresh umbrelOS 1.7.4 with the v2.47.0 image: `deltabadger_web_1` restarting every ~20 s, umbreld reporting the install failed.

Fix: both lines under the one condition. `test/config/puma_config_test.rb` loads `config/puma.rb` through `Puma::Configuration` in production with the variable unset (fails before this change) and set (asserts `solid_queue_mode` is `:async`).

Needs a release (`rake release:patch`) to reach Umbrel users — `:latest` is what their compose pulls.

Tests: focused 2 runs / 3 assertions; `bin/rails test test/config` 125 runs / 465 assertions; rubocop clean.