### PR TITLE
Ask for the withdrawal keys right after the exchange

### DIFF
--- a/app/controllers/rules/withdrawals/add_api_keys_controller.rb
+++ b/app/controllers/rules/withdrawals/add_api_keys_controller.rb
@@ -12,14 +12,10 @@ class Rules::Withdrawals::AddApiKeysController < ApplicationController
       redirect_to new_rules_withdrawals_pick_exchange_path
       return
     end
-    if @asset.blank?
-      redirect_to new_rules_withdrawals_pick_asset_path
-      return
-    end
     return if reject_retired_exchange(@exchange, fallback: new_rules_withdrawals_pick_exchange_path)
 
     if Rails.configuration.dry_run
-      redirect_to new_rules_withdrawals_add_address_path
+      redirect_to next_step_path
       return
     end
 
@@ -63,7 +59,11 @@ class Rules::Withdrawals::AddApiKeysController < ApplicationController
     params.require(:api_key).permit(:key, :secret, :passphrase, :access_token, :rsa_signature_key, :rsa_encryption_key, :dh_param, :ibkr_realm)
   end
 
+  # The keys come right after the exchange, so the asset is normally still to be picked. Once it
+  # is, the asset step returns through here, and the destination is looked up for it.
   def next_step_path
+    return new_rules_withdrawals_pick_asset_path if @asset.blank?
+
     result = auto_select_withdrawal_address
     if result == :selected
       new_rules_withdrawals_confirm_settings_path

--- a/app/controllers/rules/withdrawals/pick_exchanges_controller.rb
+++ b/app/controllers/rules/withdrawals/pick_exchanges_controller.rb
@@ -16,7 +16,9 @@ class Rules::Withdrawals::PickExchangesController < ApplicationController
       session[:withdrawal_rule_config] ||= {}
       session[:withdrawal_rule_config]['exchange_id'] = exchange_id
       session[:withdrawal_rule_config].delete('asset_id')
-      redirect_to new_rules_withdrawals_pick_asset_path
+      # Keys next, as in every other flow: a withdrawal needs the exchange connected before
+      # there is anything to pick an asset from.
+      redirect_to new_rules_withdrawals_add_api_key_path
     else
       redirect_to new_rules_withdrawals_pick_exchange_path
     end

--- a/app/views/rules/withdrawals/add_addresses/new.html.erb
+++ b/app/views/rules/withdrawals/add_addresses/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :address, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :address, steps: { pick_exchange: 20, api: 40, pick_asset: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup"
          data-controller="conversational-sentence"

--- a/app/views/rules/withdrawals/add_api_keys/new.html.erb
+++ b/app/views/rules/withdrawals/add_api_keys/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :api, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :api, steps: { pick_exchange: 20, api: 40, pick_asset: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup"
          data-controller="conversational-sentence"
@@ -10,7 +10,11 @@
       <%= t('rules.withdrawals.sentence.withdraw_all') %>
       100 <%= t('rules.withdrawals.sentence.of_the_amount') %>
       <%= t('rules.withdrawals.sentence.of') %>
-      <%= link_to @asset.symbol, new_rules_withdrawals_pick_asset_path, data: { turbo_frame: "modal_content", **ticker_data(@asset) }, class: "ticker", style: "background: #{asset_color}" %>
+      <% if @asset %>
+        <%= link_to @asset.symbol, new_rules_withdrawals_pick_asset_path, data: { turbo_frame: "modal_content", **ticker_data(@asset) }, class: "ticker", style: "background: #{asset_color}" %>
+      <% else %>
+        …
+      <% end %>
       <%= t('rules.withdrawals.sentence.from') %>
       <%= form_with url: new_rules_withdrawals_pick_exchange_path, method: :get, class: "conversational__link filled",
                     data: { turbo_frame: "modal_content", wizard_dir: "back" } do %>

--- a/app/views/rules/withdrawals/confirm_settings/new.html.erb
+++ b/app/views/rules/withdrawals/confirm_settings/new.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :settings, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :settings, steps: { pick_exchange: 20, api: 40, pick_asset: 60, address: 80, settings: 100 } %>
 
       <%= form_with url: rules_withdrawals_confirm_settings_path, method: :post,
                     class: "bot-creation-preview",

--- a/app/views/rules/withdrawals/pick_assets/new.html.erb
+++ b/app/views/rules/withdrawals/pick_assets/new.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'layouts/modal/full_page', locals: { close_url: rules_path } do %>
   <div class="bot-creation-layout">
-    <%= render "bots/new_step_progress_bar", current_step: :pick_asset, steps: { pick_exchange: 20, pick_asset: 40, api: 60, address: 80, settings: 100 } %>
+    <%= render "bots/new_step_progress_bar", current_step: :pick_asset, steps: { pick_exchange: 20, api: 40, pick_asset: 60, address: 80, settings: 100 } %>
 
     <div class="conversational conversational--bot-setup"
          data-controller="conversational-sentence"

--- a/test/integration/rules/withdrawal_creation_test.rb
+++ b/test/integration/rules/withdrawal_creation_test.rb
@@ -42,13 +42,50 @@ class Rules::WithdrawalCreationTest < ActionDispatch::IntegrationTest
 
   # ---- Asset picker uses .ticker.active on the search form ----
 
+  # ---- Keys come right after the exchange, as in every other flow ----
+
+  test 'picking the exchange moves on to the API key step' do
+    get new_rules_withdrawals_pick_exchange_path
+    post rules_withdrawals_pick_exchange_path,
+         params: { bots_dca_single_asset: { exchange_id: @binance.id } }
+    assert_redirected_to new_rules_withdrawals_add_api_key_path
+  end
+
+  test 'without a key, the connect card shows before any asset is picked' do
+    @user.api_keys.where(exchange: @binance).destroy_all
+    # The test environment skips the key step outright (dry run); this is about the real path.
+    with_dry_run(false) do
+      get new_rules_withdrawals_pick_exchange_path
+      post rules_withdrawals_pick_exchange_path,
+           params: { bots_dca_single_asset: { exchange_id: @binance.id } }
+      follow_redirect!
+    end
+    assert_response :success
+
+    assert_select '.set-api--connect h2.set-api__title', text: "Connect #{@binance.name}"
+    assert_select '.conversational .ticker', count: 0, message: 'no asset chip yet: the asset is picked after the keys'
+    assert_select '.process-progress h4', text: I18n.t('bot.setup.progress_steps.api')
+  end
+
+  test 'with a working key already saved, the key step hands over to the asset step' do
+    with_dry_run(false) do
+      get new_rules_withdrawals_pick_exchange_path
+      post rules_withdrawals_pick_exchange_path,
+           params: { bots_dca_single_asset: { exchange_id: @binance.id } }
+      get new_rules_withdrawals_add_api_key_path
+    end
+    assert_redirected_to new_rules_withdrawals_pick_asset_path
+  end
+
+  # ---- Asset picker uses .ticker.active on the search form ----
+
   test 'pick_asset step renders the search input as a .ticker.active form, not .sinput' do
     # Drive the wizard via real HTTP so session is populated naturally —
     # do not mutate session[] directly in integration tests.
     get new_rules_withdrawals_pick_exchange_path
     post rules_withdrawals_pick_exchange_path,
          params: { bots_dca_single_asset: { exchange_id: @binance.id } }
-    follow_redirect!
+    get new_rules_withdrawals_pick_asset_path
     assert_response :success
 
     assert_match(/class="ticker active"/, response.body,
@@ -59,7 +96,8 @@ class Rules::WithdrawalCreationTest < ActionDispatch::IntegrationTest
                  'asset picker should show the exchange already picked')
   end
 
-  test 'picking the asset moves on to the API key step' do
+  # The asset step returns through the key step, which then looks the destination up for it.
+  test 'picking the asset returns through the API key step' do
     get new_rules_withdrawals_pick_exchange_path
     post rules_withdrawals_pick_exchange_path,
          params: { bots_dca_single_asset: { exchange_id: @binance.id } }


### PR DESCRIPTION
The withdrawal wizard asked for an asset before the exchange was connected, unlike every other flow. It now goes exchange, keys, asset, address, settings.

- Picking the exchange leads to the connect step. With a working key already saved, that step hands straight over to the asset picker.
- The asset step still returns through the key step, so the destination lookup for the chosen asset stays where it was.
- On the key step the sentence shows the asset slot as a placeholder until one is picked, and the progress bar follows the new order.

`test/integration/rules/withdrawal_creation_test.rb` pins the handovers: exchange to keys, keys to asset (with and without a saved key, dry run off so the real branch is exercised), and asset back through keys.
