### PR TITLE
Settings connects Alpaca, CoinGecko and Deltabadger.com with the same card

### DIFF
--- a/app/assets/stylesheets/new/_set-api.sass
+++ b/app/assets/stylesheets/new/_set-api.sass
@@ -13,6 +13,9 @@
         display: flex
         flex-direction: column
         gap: 2rem
+        max-width: 64rem
+        margin: 0 auto 5rem
+        width: 100%
         ul,ol,li
             margin-top:0
             padding-top:0
@@ -29,9 +32,7 @@
                     text-decoration: none
     &__form
         flex: 0 0 auto
-        max-width: 64rem
-        margin: 0 auto 5rem
-        width: 100%
+        
     &__instructions
         flex: 1 1 auto
         padding-right: 1rem
@@ -76,9 +77,6 @@
             color: var(--ash)
             text-align: center
             text-wrap: balance
-        .set-api__mode
-            display: flex
-            justify-content: center
         .set-api__form .button
             align-self: center
         .set-api__instructions
@@ -93,3 +91,23 @@
             text-transform: uppercase
             font-weight: 700
             color: var(--ash)
+        // Connect, and beside it whatever else the card offers (a Disconnect, in Settings). Too
+        // narrow for both and they stack, each still the card's button width.
+        .set-api__actions
+            display: flex
+            flex-wrap: wrap
+            justify-content: center
+            gap: 1rem
+            .button
+                max-width: 100%
+
+// A choice made before the keys — Paper or Live, which market-data feed — centred, whether it
+// sits inside the card or stands on its own as a widget's switch.
+.set-api__mode
+    display: flex
+    justify-content: center
+
+// Inside a settings widget the widget already pads; the card brings no margins of its own.
+.widget .set-api
+    margin: 0
+    padding: 0

--- a/app/javascript/controllers/form/market_data_controller.js
+++ b/app/javascript/controllers/form/market_data_controller.js
@@ -1,36 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="form--market-data"
+// The market data widget's provider switch.
+//
+// The segmented control announces the provider as `segmented:change`; this puts it in the switch
+// form's hidden field and submits, so the server makes the switch and re-renders the widget in
+// whatever state that provider needs — CoinGecko without a key comes back with its connect card.
+// The one provider the server cannot switch to on its own is an unclaimed Deltabadger.com: that
+// needs a connect code first, so its form is shown instead.
+//
+// Connects to data-controller="form--market-data" on the widget.
 export default class extends Controller {
-  static targets = ["providerForm", "coingeckoFields", "coingeckoButtons", "deltabadgerButtons"]
+  static targets = ["providerForm", "provider", "coingeckoFields", "deltabadgerButtons"]
+  static values = { platformConnected: Boolean }
 
-  selectNone(event) {
-    this.#hideCoinGeckoForm()
-    this.#hideDeltabadgerButtons()
+  select(event) {
+    const provider = event.detail.value
+    this.providerTarget.value = provider
+    if (this.hasCoingeckoFieldsTarget) this.coingeckoFieldsTarget.hidden = provider !== "coingecko"
+    if (this.hasDeltabadgerButtonsTarget) this.deltabadgerButtonsTarget.hidden = provider !== "deltabadger"
+    if (provider === "deltabadger" && !this.platformConnectedValue) return
+
     this.providerFormTarget.requestSubmit()
-  }
-
-  selectCoinGecko(event) {
-    this.#hideDeltabadgerButtons()
-    this.providerFormTarget.requestSubmit()
-  }
-
-  selectDeltabadger(event) {
-    this.#hideCoinGeckoForm()
-    if (this.hasDeltabadgerButtonsTarget) this.deltabadgerButtonsTarget.style.display = 'flex'
-  }
-
-  selectConnectedDeltabadger(event) {
-    this.#hideCoinGeckoForm()
-    this.providerFormTarget.requestSubmit()
-  }
-
-  #hideCoinGeckoForm() {
-    if (this.hasCoinGeckoFieldsTarget) this.coingeckoFieldsTarget.style.display = 'none'
-    if (this.hasCoinGeckoButtonsTarget) this.coingeckoButtonsTarget.style.display = 'none'
-  }
-
-  #hideDeltabadgerButtons() {
-    if (this.hasDeltabadgerButtonsTarget) this.deltabadgerButtonsTarget.style.display = 'none'
   }
 }

--- a/app/views/settings/widgets/_market_data.html.erb
+++ b/app/views/settings/widgets/_market_data.html.erb
@@ -1,13 +1,21 @@
 <%= turbo_frame_tag "market_data_settings" do %>
-  <div class="widget widget--settings" data-controller="form--market-data">
-    <% is_coingecko_configured = MarketDataSettings.coingecko? %>
-    <% is_deltabadger_configured = MarketDataSettings.deltabadger? %>
-    <% is_deltabadger_available = MarketDataSettings.deltabadger_available? %>
-    <% is_platform_connected = AppConfig.platform_connected? %>
-    <% is_configured = MarketData.configured? %>
-    <% show_coingecko_form = @show_coingecko_form || false %>
-    <% show_platform_form = @show_platform_form || false %>
-    <% deltabadger_action = is_platform_connected ? 'form--market-data#selectConnectedDeltabadger' : 'form--market-data#selectDeltabadger' %>
+  <% is_coingecko_configured = MarketDataSettings.coingecko? %>
+  <% is_deltabadger_configured = MarketDataSettings.deltabadger? %>
+  <% is_deltabadger_available = MarketDataSettings.deltabadger_available? %>
+  <% is_platform_connected = AppConfig.platform_connected? %>
+  <% is_configured = MarketData.configured? %>
+  <% show_coingecko_form = @show_coingecko_form || false %>
+  <% show_platform_form = @show_platform_form || false %>
+  <%# What the reader is in the middle of (a claim that failed, a key still to paste) outranks what
+      is stored: the control has to point at the form on screen. %>
+  <% selected = if show_platform_form then MarketDataSettings::PROVIDER_DELTABADGER
+                elsif show_coingecko_form || is_coingecko_configured then MarketDataSettings::PROVIDER_COINGECKO
+                elsif is_deltabadger_configured then MarketDataSettings::PROVIDER_DELTABADGER
+                else ''
+                end %>
+  <div class="widget widget--settings" data-controller="form--market-data"
+       data-action="segmented:change->form--market-data#select"
+       data-form--market-data-platform-connected-value="<%= is_platform_connected %>">
     <h4 class="modal__title">
       <%= t('settings.index.resync_assets_section') %>:
       <% if is_configured %>
@@ -17,102 +25,84 @@
       <% end %>
     </h4>
 
-    <%= form_with url: settings_update_market_data_path, method: :patch, data: {
-      form__market_data_target: "providerForm",
-      turbo_frame: "market_data_settings"
-    } do |f| %>
-      <div class="form__radios" style="display: flex; justify-content: center;">
-        <% if is_deltabadger_available %>
-          <%# Platform-provided market data is available. Lock to it — no other choices, no toggling. %>
-          <label class="form__radio">
-            <%= radio_button_tag :market_data_provider, MarketDataSettings::PROVIDER_DELTABADGER, true, disabled: true %>
-            <span><%= AppConfig.market_data_env_provider_name %></span>
-          </label>
-        <% else %>
-          <label class="form__radio">
-            <%= radio_button_tag :market_data_provider, '', !is_configured && !show_coingecko_form && !show_platform_form, data: { action: "form--market-data#selectNone" } %>
-            <span><%= t('settings.market_data.none') %></span>
-          </label>
-
-          <label class="form__radio">
-            <%= radio_button_tag :market_data_provider, MarketDataSettings::PROVIDER_COINGECKO, is_coingecko_configured || show_coingecko_form, data: { action: "form--market-data#selectCoinGecko" } %>
-            <span>CoinGecko</span>
-          </label>
-
-          <label class="form__radio">
-            <%= radio_button_tag :market_data_provider, MarketDataSettings::PROVIDER_DELTABADGER, is_deltabadger_configured || show_platform_form, data: { action: deltabadger_action } %>
-            <span><%= t('settings.platform.option') %></span>
-          </label>
+    <% if is_deltabadger_available %>
+      <%# Platform-provided market data is the only feed there is: nothing to switch. %>
+      <p class="set-api__note"><%= t('settings.market_data.deltabadger_configured', provider_name: AppConfig.market_data_env_provider_name) %></p>
+    <% else %>
+      <%# The switch: one segmented control over a hidden field, submitted as soon as it moves. A
+          saved CoinGecko key rides along, so switching back to it needs no re-paste. %>
+      <%= form_with url: settings_update_market_data_path, method: :patch, class: "set-api__mode",
+                    data: { form__market_data_target: "providerForm", turbo_frame: "market_data_settings" } do |f| %>
+        <%= render 'shared/segmented', fluid: true, label: t('settings.index.resync_assets_section'), options: [
+              { value: '', label: t('settings.market_data.none'), active: selected == '' },
+              { value: MarketDataSettings::PROVIDER_COINGECKO, label: 'CoinGecko',
+                active: selected == MarketDataSettings::PROVIDER_COINGECKO },
+              { value: MarketDataSettings::PROVIDER_DELTABADGER, label: t('settings.platform.option'),
+                active: selected == MarketDataSettings::PROVIDER_DELTABADGER }
+            ] %>
+        <%= f.hidden_field :market_data_provider, value: selected, data: { form__market_data_target: "provider" } %>
+        <% if AppConfig.coingecko_api_key.present? %>
+          <%= hidden_field_tag :coingecko_api_key, AppConfig.coingecko_api_key %>
         <% end %>
-      </div>
-
-      <% if AppConfig.coingecko_api_key.present? %>
-        <%# Keep the saved key in provider-change submissions even while another feed is active. %>
-        <%= hidden_field_tag :coingecko_api_key, AppConfig.coingecko_api_key %>
       <% end %>
 
-      <% if is_deltabadger_available %>
-        <%# Platform provider is the only option; no further UI needed — the
-            green ON indicator already reflects the active state via
-            MarketDataSettings.current_provider. %>
-      <% elsif is_coingecko_configured %>
-        <%# CoinGecko configured: show status and actions %>
-        <div data-form--market-data-target="coingeckoFields">
-          <p style="text-align: center; margin-top: 3rem"><%= t('settings.market_data.coingecko_configured') %></p>
+      <% if is_coingecko_configured %>
+        <div data-form--market-data-target="coingeckoFields" <%= 'hidden' if show_platform_form %>>
+          <p class="set-api__note"><%= t('settings.market_data.coingecko_configured') %></p>
           <div class="setting-form">
             <%= button_to t('settings.resync_assets.button'), settings_resync_assets_path, method: :post, class: "button button--outline", data: { turbo_frame: "_top" } %>
             <%= link_to t('settings.market_data.disconnect'), settings_disconnect_market_data_path, data: { turbo_method: :delete, turbo_frame: "market_data_settings" }, class: "button button--danger", style: "margin-top: 0" %>
           </div>
         </div>
       <% elsif !is_deltabadger_configured && AppConfig.coingecko_api_key.blank? %>
-        <%# CoinGecko setup form (no key yet) %>
-        <div class="setting-form" data-form--market-data-target="coingeckoFields" style="margin: 4rem auto 2rem; display: <%= show_coingecko_form ? 'flex' : 'none' %>;">
-          <div class="form__row form__row--input">
-            <%= tag.input class: "form__input",
-                          type: "text",
-                          name: "coingecko_api_key",
-                          id: "coingecko_api_key",
-                          placeholder: " " %>
-            <%= label_tag :coingecko_api_key, t('setup.coingecko_api_key'), class: "form__label" %>
-          </div>
-          <p class="form__info"><%= t('setup.coingecko_api_key_hint_html') %></p>
-        </div>
-        <div class="setting-form" data-form--market-data-target="coingeckoButtons" style="display: <%= show_coingecko_form ? 'flex' : 'none' %>; margin-top: 2rem;">
-          <%= f.submit t('setup.submit'), class: "button button--success", style: "margin-top: 0" %>
+        <%# No key yet: the same connect card as the index wizard's CoinGecko step. %>
+        <div data-form--market-data-target="coingeckoFields" <%= 'hidden' unless show_coingecko_form %>>
+          <%= render layout: 'shared/connect_form', locals: {
+                title: t('bot.setup.connect_to', name: 'CoinGecko'),
+                mark: 'svg/coingecko',
+                path: settings_update_market_data_path, method: :patch,
+                form_data: { turbo_frame: "market_data_settings", controller: "form--html5-validations form--label-animations" },
+                instructions_title: t('bot.setup.how_to_get_keys', exchange: 'CoinGecko'),
+                instructions: t('setup.coingecko_api_key_hint_html')
+              } do |f| %>
+            <%= f.hidden_field :market_data_provider, value: MarketDataSettings::PROVIDER_COINGECKO %>
+            <div class="form__row form__row--input">
+              <%= f.text_field :coingecko_api_key, required: true, autocomplete: "off", class: "form__input" %>
+              <%= f.label :coingecko_api_key, t('setup.coingecko_api_key'), class: "form__label" %>
+            </div>
+          <% end %>
         </div>
       <% end %>
-    <% end %>
 
-    <% if !is_deltabadger_available && is_platform_connected %>
-      <% proxy_suffix = AppConfig.platform_proxies_configured? ? 'with_proxies' : 'without_proxies' %>
-      <p style="text-align: center; margin-top: 3rem">
-        <%= t("settings.platform.connected_#{proxy_suffix}") %>
-      </p>
-      <div class="setting-form">
-        <%= link_to t('settings.platform.disconnect'), settings_platform_connection_path,
-                    data: { turbo_method: :delete, turbo_frame: "market_data_settings" },
-                    class: "button button--danger", style: "margin-top: 0" %>
-      </div>
-    <% end %>
-
-    <% unless is_deltabadger_available || is_platform_connected %>
-      <div class="setting-form" data-form--market-data-target="deltabadgerButtons"
-           style="display: <%= show_platform_form ? 'flex' : 'none' %>; margin-top: 2rem;">
-        <%= form_with url: settings_platform_connection_path, method: :post,
-                      class: 'setting-form', data: { turbo_frame: 'market_data_settings',
-                                                    controller: 'form--html5-validations form--label-animations' } do |form| %>
-          <% if @platform_errors.present? %>
-            <div class="form__info form__info--alert" role="alert"><%= @platform_errors.to_sentence %></div>
+      <% if is_platform_connected %>
+        <% proxy_suffix = AppConfig.platform_proxies_configured? ? 'with_proxies' : 'without_proxies' %>
+        <p class="set-api__note"><%= t("settings.platform.connected_#{proxy_suffix}") %></p>
+        <div class="setting-form">
+          <%= link_to t('settings.platform.disconnect'), settings_platform_connection_path,
+                      data: { turbo_method: :delete, turbo_frame: "market_data_settings" },
+                      class: "button button--danger", style: "margin-top: 0" %>
+        </div>
+      <% else %>
+        <%# Not claimed yet: the same card, with what the subscription brings where a walkthrough would be. %>
+        <div data-form--market-data-target="deltabadgerButtons" <%= 'hidden' unless show_platform_form %>>
+          <%= render layout: 'shared/connect_form', locals: {
+                title: t('bot.setup.connect_to', name: t('settings.platform.option')),
+                mark: 'svg/40x30_logo',
+                path: settings_platform_connection_path,
+                form_data: { turbo_frame: 'market_data_settings', controller: 'form--html5-validations form--label-animations' },
+                instructions_title: t('settings.platform.subscription_title'),
+                instructions: tag.p(t('settings.platform.subscription_html'))
+              } do |f| %>
+            <% if @platform_errors.present? %>
+              <div class="form__info form__info--alert" role="alert"><%= @platform_errors.to_sentence %></div>
+            <% end %>
+            <div class="form__row form__row--input">
+              <%= f.text_field :claim_code, required: true, autocomplete: 'off', class: 'form__input' %>
+              <%= f.label :claim_code, t('settings.platform.code'), class: 'form__label' %>
+            </div>
           <% end %>
-
-          <div class="form__row form__row--input">
-            <%= text_field_tag :claim_code, nil, class: 'form__input', required: true, autocomplete: 'off' %>
-            <%= label_tag :claim_code, t('settings.platform.code'), class: 'form__label' %>
-          </div>
-
-          <%= form.submit t('settings.platform.connect'), class: 'button button--success', style: 'margin-top: 0' %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/settings/widgets/_stocks.html.erb
+++ b/app/views/settings/widgets/_stocks.html.erb
@@ -15,6 +15,9 @@
       <% is_configured = AppConfig.alpaca_configured? %>
       <% catalog_active = StockTradingSettings.active? %>
       <% stored_mode = AppConfig.get('alpaca_mode') %>
+      <% mode = stored_mode == 'paper' ? 'paper' : 'live' %>
+      <%# Unsaved on purpose: only the name and the venue id are wanted, for the card and its walkthrough. %>
+      <% alpaca = Exchanges::Alpaca.new(name: 'Alpaca') %>
       <h4 class="modal__title">
         <%= t('settings.stocks.title_html') %>:
         <% if catalog_active %>
@@ -24,42 +27,40 @@
         <% end %>
       </h4>
 
-      <% if is_configured %>
-        <p style="text-align: center; margin-top: 3rem"><%= t('settings.stocks.configured', mode: stored_mode&.capitalize || 'Paper') %></p>
-      <% elsif catalog_active %>
-        <p class="text-center" style="text-wrap:balance; margin: 0"><%= t('settings.stocks.not_refreshing') %></p>
-      <% else %>
-        <p class="text-center" style="text-wrap:balance; margin: 0"><%= t('settings.stocks.instructions_html') %></p>
-      <% end %>
-
-      <%= form_with url: settings_update_stocks_path, method: :patch, data: {
-        turbo_frame: "stocks_settings"
-      }, class: "form" do |f| %>
-        <div class="set-api__form" style="margin-top: 3rem;">
-          <div class="form__radios">
-            <label class="form__radio">
-              <%= radio_button_tag :alpaca_mode, 'live', stored_mode != 'paper' %>
-              <span><%= t('settings.stocks.mode_live') %></span>
-            </label>
-            <label class="form__radio">
-              <%= radio_button_tag :alpaca_mode, 'paper', stored_mode == 'paper' %>
-              <span><%= t('settings.stocks.mode_paper') %></span>
-            </label>
-          </div>
-          <div class="form__row form__row--input">
-            <%= tag.input class: "form__input", type: "text", name: "alpaca_api_key", id: "alpaca_api_key", placeholder: " ", autocomplete: "off" %>
-            <%= label_tag :alpaca_api_key, "API Key", class: "form__label" %>
-          </div>
-          <div class="form__row form__row--input">
-            <%= tag.input class: "form__input", type: "text", name: "alpaca_api_secret", id: "alpaca_api_secret", placeholder: " ", autocomplete: "off" %>
-            <%= label_tag :alpaca_api_secret, "API Secret", class: "form__label" %>
-          </div>
-          <div class="setting-form">
-            <%= f.submit t('button.connect'), class: "button button--success", style: "margin-top: 0" %>
-            <% if is_configured %>
-              <%= link_to t('settings.stocks.disconnect'), settings_disconnect_stocks_path, data: { turbo_method: :delete, turbo_frame: "stocks_settings" }, class: "button button--danger", style: "margin-top: 0" %>
-            <% end %>
-          </div>
+      <%# The same connect card as the bot wizard's key step. This credential is the container's
+          catalog-sync key, so it can be rotated while connected, and dropped. %>
+      <%= render layout: 'shared/connect_form', locals: {
+            title: t('bot.setup.connect_to', name: alpaca.name),
+            mark: 'svg/exchange-alpaca', mark_class: 'sbutton--exchange--alpaca',
+            path: settings_update_stocks_path, method: :patch,
+            form_data: { turbo_frame: "stocks_settings", controller: "form--html5-validations form--label-animations" },
+            actions: (if is_configured
+                        link_to t('settings.stocks.disconnect'), settings_disconnect_stocks_path,
+                                data: { turbo_method: :delete, turbo_frame: "stocks_settings" }, class: "button button--danger"
+                      end),
+            instructions_title: t('bot.setup.how_to_get_keys', exchange: alpaca.name),
+            instructions: render_api_key_instructions_for(alpaca)
+          } do |f| %>
+        <% if is_configured %>
+          <p class="set-api__note"><%= t('settings.stocks.configured', mode: stored_mode&.capitalize || 'Paper') %></p>
+        <% elsif catalog_active %>
+          <p class="set-api__note"><%= t('settings.stocks.not_refreshing') %></p>
+        <% end %>
+        <div class="set-api__mode" data-controller="form--segmented-field"
+             data-action="segmented:change->form--segmented-field#set">
+          <%= render 'shared/segmented', label: 'Mode', options: [
+                { value: 'paper', label: t('settings.stocks.mode_paper'), active: mode == 'paper' },
+                { value: 'live', label: t('settings.stocks.mode_live'), active: mode == 'live' }
+              ] %>
+          <%= f.hidden_field :alpaca_mode, value: mode, data: { 'form--segmented-field-target': 'field' } %>
+        </div>
+        <div class="form__row form__row--input">
+          <%= f.text_field :alpaca_api_key, autocomplete: "off", class: "form__input" %>
+          <%= f.label :alpaca_api_key, "API Key", class: "form__label" %>
+        </div>
+        <div class="form__row form__row--input">
+          <%= f.text_field :alpaca_api_secret, autocomplete: "off", class: "form__input" %>
+          <%= f.label :alpaca_api_secret, "API Secret", class: "form__label" %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/shared/_connect_form.html.erb
+++ b/app/views/shared/_connect_form.html.erb
@@ -1,7 +1,7 @@
 <%# The connect step: every place that asks for an API key renders this one card — a brand mark,
     "Connect X", the fields, one Connect button that reads "Validating…" while the key is checked,
     and the venue's walkthrough as help under a small label. It names itself, so it reads the same
-    under a wizard sentence and alone in a modal.
+    under a wizard sentence, alone in a modal, and inside a settings widget.
 
     Rendered as a layout: the block receives the form builder and supplies the fields, since what
     a venue asks for is the one thing that differs between them.
@@ -10,14 +10,20 @@
       title, mark, mark_class - see shared/connect_brand
       model                   - optional; the form's model (an ApiKey), or nothing for a bare param
       path, form_data         - where the form posts, and its data attributes
+      method                  - optional; :post unless told otherwise
+      actions                 - optional html; a second control beside Connect (a Disconnect link)
       instructions_title      - optional; the label over the help block
       instructions            - optional html; the walkthrough. None given, no help block. %>
 <div class="set-api set-api--connect">
   <%= render 'shared/connect_brand', title: title, mark: mark, mark_class: local_assigns[:mark_class] %>
-  <%= form_with model: local_assigns.fetch(:model, false), url: path, method: :post, data: form_data, class: "set-api__form form" do |f| %>
+  <%= form_with model: local_assigns.fetch(:model, false), url: path, method: local_assigns.fetch(:method, :post),
+                data: form_data, class: "set-api__form form" do |f| %>
     <%= yield f %>
-    <%= f.submit t('button.connect'), class: "button button--success",
-                 data: { turbo_stream: true, turbo_submits_with: t('bot.setup.validating') } %>
+    <div class="set-api__actions">
+      <%= f.submit t('button.connect'), class: "button button--success",
+                   data: { turbo_stream: true, turbo_submits_with: t('bot.setup.validating') } %>
+      <%= local_assigns[:actions] %>
+    </div>
   <% end %>
   <% if local_assigns[:instructions].present? %>
     <section class="set-api__instructions">

--- a/config/locales/api.bg.yml
+++ b/config/locales/api.bg.yml
@@ -5,7 +5,7 @@ bg:
             private_key_label: API секрет
             whitelist_ip_fallback_html: 'IP адреса на компютъра, на който е инсталиран Deltabadger. Ако работи на сървър, използвайте публичния IP на сървъра. Ако е на локалния ви компютър, <a href="https://whatismyipaddress.com" target="_blank">проверете IP адреса си тук</a>'
             alpaca:
-                instructions: 'Влезте в Trading API на <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> и вземете ключовете си от таблото (Dashboard).'
+                instructions: 'Отидете на <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">таблото на Alpaca</a> — изберете <b>Trading API</b>, а не Broker API — и намерете секцията <b>API Keys</b> в десния панел. Натиснете <b>Generate New Keys</b> и запазете генерираните данни за достъп.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Влезте в акаунта си в %{exchange_link}.'

--- a/config/locales/api.cs.yml
+++ b/config/locales/api.cs.yml
@@ -5,7 +5,7 @@ cs:
             private_key_label: API tajný klíč
             whitelist_ip_fallback_html: 'IP adresu počítače, na kterém je Deltabadger nainstalován. Pokud běží na serveru, použijte veřejnou IP serveru. Pokud jde o váš lokální počítač, <a href="https://whatismyipaddress.com" target="_blank">zjistěte svou IP zde</a>'
             alpaca:
-                instructions: 'Přihlaste se do Trading API na <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> a získejte své klíče v sekci Dashboard.'
+                instructions: 'Přejdi na <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca dashboard</a> — zvol <b>Trading API</b>, ne Broker API — a najdi sekci <b>API Keys</b> v pravém panelu. Klikni na <b>Generate New Keys</b> a ulož si vygenerované přihlašovací údaje.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Přihlaste se ke svému účtu na %{exchange_link}.'

--- a/config/locales/api.da.yml
+++ b/config/locales/api.da.yml
@@ -5,7 +5,7 @@ da:
             private_key_label: API-hemmelighed
             whitelist_ip_fallback_html: 'IP-adressen på maskinen, hvor Deltabadger er installeret. Hvis den kører på en server, brug serverens offentlige IP. Hvis det er din lokale computer, <a href="https://whatismyipaddress.com" target="_blank">tjek din IP her</a>'
             alpaca:
-                instructions: 'Log ind på <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a>s Trading API, og hent dine nøgler fra Dashboardet.'
+                instructions: 'Gå til <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca-oversigten</a> – vælg <b>Trading API</b>, ikke Broker API – og find <b>API Keys</b>-sektionen i højre sidepanel. Klik på <b>Generate New Keys</b> og gem de genererede API-legitimationsoplysninger.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Log ind på din %{exchange_link}-konto.'

--- a/config/locales/api.de.yml
+++ b/config/locales/api.de.yml
@@ -5,7 +5,7 @@ de:
             private_key_label: API-Secret
             whitelist_ip_fallback_html: 'die IP-Adresse der Maschine, auf der Deltabadger installiert ist. Wenn es auf einem Server läuft, verwenden Sie die öffentliche IP des Servers. Wenn es Ihr lokaler Computer ist, <a href="https://whatismyipaddress.com" target="_blank">prüfen Sie Ihre IP hier</a>'
             alpaca:
-                instructions: 'Melden Sie sich bei der Trading API von <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> an und holen Sie Ihre Schlüssel im Dashboard.'
+                instructions: 'Gehe zum <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca-Dashboard</a> – wähle <b>Trading API</b>, nicht Broker API – und finde den Bereich <b>API Keys</b> in der rechten Seitenleiste. Klicke auf <b>Generate New Keys</b> und speichere die erzeugten API-Zugangsdaten.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Melden Sie sich bei Ihrem %{exchange_link}-Konto an.'

--- a/config/locales/api.el.yml
+++ b/config/locales/api.el.yml
@@ -5,7 +5,7 @@ el:
             private_key_label: Secret API
             whitelist_ip_fallback_html: 'τη διεύθυνση IP του μηχανήματος όπου είναι εγκατεστημένο το Deltabadger. Αν τρέχει σε server, χρησιμοποίησε τη δημόσια IP του server. Αν είναι ο προσωπικός σου υπολογιστής, <a href="https://whatismyipaddress.com" target="_blank">δες την IP σου εδώ</a>'
             alpaca:
-                instructions: 'Συνδέσου στο Trading API της <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> και πάρε τα κλειδιά σου από το Dashboard.'
+                instructions: 'Πήγαινε στον <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">πίνακα ελέγχου του Alpaca</a> — διάλεξε <b>Trading API</b>, όχι Broker API — και βρες την ενότητα <b>API Keys</b> στη δεξιά πλαϊνή μπάρα. Πάτησε <b>Generate New Keys</b> και αποθήκευσε τα κλειδιά API.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Συνδέσου στον λογαριασμό σου στο %{exchange_link}.'

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -5,7 +5,7 @@ en:
             private_key_label: API Secret
             whitelist_ip_fallback_html: 'the IP address of the machine where Deltabadger is installed. If running on a server, use the server''s public IP. If it''s your local computer <a href="https://whatismyipaddress.com" target="_blank">check your IP here</a>'
             alpaca:
-                instructions: 'Login to <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a>''s Trading API and get your keys from the Dashboard.'
+                instructions: 'Go to the <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca dashboard</a> — choose <b>Trading API</b>, not Broker API — and find the <b>API Keys</b> section on the right sidebar. Click on <b>Generate New Keys</b> and save the generated API credentials.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Log into your %{exchange_link} account.'

--- a/config/locales/api.es.yml
+++ b/config/locales/api.es.yml
@@ -5,7 +5,7 @@ es:
             private_key_label: Secret API
             whitelist_ip_fallback_html: 'la dirección IP de la máquina donde está instalado Deltabadger. Si está en un servidor, usa la IP pública del servidor. Si es tu ordenador personal, <a href="https://whatismyipaddress.com" target="_blank">comprueba tu IP aquí</a>'
             alpaca:
-                instructions: 'Inicia sesión en la Trading API de <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> y obtén tus claves en el Dashboard.'
+                instructions: 'Ve al <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">panel de Alpaca</a> — elige <b>Trading API</b>, no Broker API — y busca la sección <b>API Keys</b> en la barra lateral derecha. Haz clic en <b>Generate New Keys</b> y guarda las credenciales API generadas.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Inicia sesión en tu cuenta de %{exchange_link}.'

--- a/config/locales/api.fr.yml
+++ b/config/locales/api.fr.yml
@@ -5,7 +5,7 @@ fr:
             private_key_label: Secret API
             whitelist_ip_fallback_html: "l'adresse IP de la machine où Deltabadger est installé. Si vous utilisez un serveur, utilisez l'IP publique du serveur. Si c'est votre ordinateur personnel, <a href=\"https://whatismyipaddress.com\" target=\"_blank\">vérifiez votre IP ici</a>"
             alpaca:
-                instructions: 'Connectez-vous à la Trading API d’<a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> et récupérez vos clés dans le Dashboard.'
+                instructions: 'Rends-toi sur le <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">tableau de bord Alpaca</a> — choisis <b>Trading API</b>, pas Broker API — et trouve la section <b>API Keys</b> dans la barre latérale droite. Clique sur <b>Generate New Keys</b> et enregistre les identifiants API générés.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Connectez-vous à votre compte %{exchange_link}.'

--- a/config/locales/api.it.yml
+++ b/config/locales/api.it.yml
@@ -5,7 +5,7 @@ it:
             private_key_label: Secret API
             whitelist_ip_fallback_html: "l'indirizzo IP della macchina dove è installato Deltabadger. Se è su un server, usa l'IP pubblico del server. Se è il tuo computer locale, <a href=\"https://whatismyipaddress.com\" target=\"_blank\">controlla il tuo IP qui</a>"
             alpaca:
-                instructions: 'Accedi alla Trading API di <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> e recupera le tue chiavi dalla Dashboard.'
+                instructions: 'Vai alla <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">dashboard di Alpaca</a> — scegli <b>Trading API</b>, non Broker API — e trova la sezione <b>API Keys</b> nella barra laterale destra. Clicca su <b>Generate New Keys</b> e salva le credenziali API generate.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Accedi al tuo account %{exchange_link}.'

--- a/config/locales/api.nl.yml
+++ b/config/locales/api.nl.yml
@@ -5,7 +5,7 @@ nl:
             private_key_label: API-secret
             whitelist_ip_fallback_html: 'het IP-adres van de machine waar Deltabadger is geïnstalleerd. Als het op een server draait, gebruik dan het publieke IP van de server. Als het je lokale computer is, <a href="https://whatismyipaddress.com" target="_blank">controleer je IP hier</a>'
             alpaca:
-                instructions: 'Log in op de Trading API van <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> en haal je sleutels op uit het Dashboard.'
+                instructions: 'Ga naar het <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca-dashboard</a> – kies <b>Trading API</b>, niet Broker API – en zoek de sectie <b>API Keys</b> in de rechterzijbalk. Klik op <b>Generate New Keys</b> en bewaar de gegenereerde API-gegevens.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Log in op je %{exchange_link}-account.'

--- a/config/locales/api.pl.yml
+++ b/config/locales/api.pl.yml
@@ -5,7 +5,7 @@ pl:
             private_key_label: Sekretny klucz API
             whitelist_ip_fallback_html: 'adres IP maszyny, na której zainstalowany jest Deltabadger. Jeśli to serwer, użyj publicznego IP serwera. Jeśli to twój komputer lokalny, <a href="https://whatismyipaddress.com" target="_blank">sprawdź swoje IP tutaj</a>'
             alpaca:
-                instructions: 'Zaloguj się do Trading API <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> i pobierz swoje klucze z panelu (Dashboard).'
+                instructions: 'Przejdź do <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">panelu Alpaca</a> — wybierz <b>Trading API</b>, nie Broker API — i znajdź sekcję <b>API Keys</b> na prawym pasku bocznym. Kliknij <b>Generate New Keys</b> i zapisz wygenerowane dane dostępowe API.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Zaloguj się na swoje konto %{exchange_link}.'

--- a/config/locales/api.pt.yml
+++ b/config/locales/api.pt.yml
@@ -5,7 +5,7 @@ pt:
             private_key_label: Secret API
             whitelist_ip_fallback_html: 'o endereço IP da máquina onde o Deltabadger está instalado. Se estiver num servidor, use o IP público do servidor. Se for o seu computador pessoal, <a href="https://whatismyipaddress.com" target="_blank">verifique o seu IP aqui</a>'
             alpaca:
-                instructions: 'Inicie sessão na Trading API da <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> e obtenha as suas chaves no Dashboard.'
+                instructions: 'Vai ao <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">painel da Alpaca</a> — escolhe <b>Trading API</b>, não Broker API — e encontra a secção <b>API Keys</b> na barra lateral direita. Clica em <b>Generate New Keys</b> e guarda as credenciais API geradas.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Faça login na sua conta %{exchange_link}.'

--- a/config/locales/api.ru.yml
+++ b/config/locales/api.ru.yml
@@ -5,7 +5,7 @@ ru:
             private_key_label: Секретный ключ API
             whitelist_ip_fallback_html: 'IP-адрес машины, на которой установлен Deltabadger. Если это сервер, используйте публичный IP сервера. Если это ваш локальный компьютер, <a href="https://whatismyipaddress.com" target="_blank">проверьте свой IP здесь</a>'
             alpaca:
-                instructions: 'Войдите в Trading API <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> и возьмите ключи в разделе Dashboard.'
+                instructions: 'Перейдите в <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">панель Alpaca</a> — выберите <b>Trading API</b>, а не Broker API — и найдите раздел <b>API Keys</b> в правой боковой панели. Нажмите <b>Generate New Keys</b> и сохраните сгенерированные API-ключи.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Войдите в свою учетную запись %{exchange_link}.'

--- a/config/locales/api.sk.yml
+++ b/config/locales/api.sk.yml
@@ -5,7 +5,7 @@ sk:
             private_key_label: API tajný kľúč
             whitelist_ip_fallback_html: 'IP adresu počítača, na ktorom je Deltabadger nainštalovaný. Ak beží na serveri, použite verejnú IP servera. Ak ide o váš lokálny počítač, <a href="https://whatismyipaddress.com" target="_blank">zistite svoju IP tu</a>'
             alpaca:
-                instructions: 'Prihláste sa do Trading API na <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a> a získajte svoje kľúče v sekcii Dashboard.'
+                instructions: 'Prejdi na <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca dashboard</a> — zvoľ <b>Trading API</b>, nie Broker API — a nájdi sekciu <b>API Keys</b> v pravom paneli. Klikni na <b>Generate New Keys</b> a ulož si vygenerované prihlasovacie údaje.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Prihláste sa do svojho účtu na %{exchange_link}.'

--- a/config/locales/api.sv.yml
+++ b/config/locales/api.sv.yml
@@ -5,7 +5,7 @@ sv:
             private_key_label: API-hemlighet
             whitelist_ip_fallback_html: 'IP-adressen till maskinen där Deltabadger är installerad. Om den körs på en server, använd serverns publika IP. Om det är din lokala dator <a href="https://whatismyipaddress.com" target="_blank">kontrollera din IP här</a>'
             alpaca:
-                instructions: 'Logga in på <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca</a>s Trading API och hämta dina nycklar från Dashboard.'
+                instructions: 'Gå till <a href="https://app.alpaca.markets/" target="_blank" rel="noopener">Alpaca-panelen</a> – välj <b>Trading API</b>, inte Broker API – och hitta <b>API Keys</b>-sektionen i höger sidofält. Klicka på <b>Generate New Keys</b> och spara de genererade API-uppgifterna.'
             binance: &binance_config
                 instructions:
                     -   text_html: 'Logga in på ditt %{exchange_link}-konto.'

--- a/config/locales/base.bg.yml
+++ b/config/locales/base.bg.yml
@@ -157,7 +157,9 @@ bg:
             disconnect: 'Прекъсни'
             disconnected: 'Доставчикът на пазарни данни е прекъснат.'
         platform:
-            option: 'Deltabadger.com — поставете кода за свързване'
+            option: 'Deltabadger.com'
+            subscription_title: 'Абонамент Self-hosted'
+            subscription_html: 'Абонаментът Self-hosted на <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> включва Market Data API и фиксиран IP адрес за белия списък на борсите.'
             code: 'Код за свързване'
             connect: 'Свързване'
             connected_with_proxies: 'Deltabadger.com е свързан за пазарни данни и прокси сървъри за борсите.'
@@ -168,7 +170,6 @@ bg:
             title: 'Акции'
             title_html: 'Акции (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Каталогът с акции се предоставя от %{provider_name}. Потребителите свързват собствените си Alpaca ключове при създаване на бот.'
-            instructions_html: 'Отидете на <a href="https://alpaca.markets" target="_blank">таблото на Alpaca</a> и намерете секцията API Keys в десния панел. Натиснете Generate New Keys и запазете генерираните данни за достъп.'
             enabled: 'Акциите са включени. Синхронизиране на активи от Alpaca...'
             disconnected: 'Връзката с Alpaca е прекъсната. Каталогът с акции вече няма да се обновява; съществуващите ботове и API ключове не са засегнати.'
             configured: 'Свързано с Alpaca (%{mode}). Активите с акции са синхронизирани.'

--- a/config/locales/base.cs.yml
+++ b/config/locales/base.cs.yml
@@ -158,7 +158,9 @@ cs:
             disconnect: 'Odpojit'
             disconnected: 'Poskytovatel tržních dat byl odpojen.'
         platform:
-            option: 'Deltabadger.com — vložte kód připojení'
+            option: 'Deltabadger.com'
+            subscription_title: 'Předplatné Self-hosted'
+            subscription_html: 'Předplatné Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> zahrnuje Market Data API a pevnou IP adresu pro whitelist na burzách.'
             code: 'Kód připojení'
             connect: 'Připojit'
             connected_with_proxies: 'Připojeno k Deltabadger.com pro tržní data a proxy servery burz.'
@@ -169,7 +171,6 @@ cs:
             title: 'Akcie'
             title_html: 'Akcie (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Katalog akcií poskytuje %{provider_name}. Uživatelé připojují vlastní klíče Alpaca při vytváření bota.'
-            instructions_html: 'Přejdi na <a href="https://alpaca.markets" target="_blank">Alpaca dashboard</a> a najdi sekci API Keys v pravém panelu. Klikni na Generate New Keys a ulož si vygenerované přihlašovací údaje.'
             enabled: 'Akcie zapnuty. Synchronizace aktiv z Alpaca...'
             disconnected: 'Alpaca odpojena. Katalog akcií se už nebude aktualizovat; stávající boti a API klíče zůstávají beze změny.'
             configured: 'Připojeno k Alpaca (%{mode}). Akciová aktiva jsou synchronizována.'

--- a/config/locales/base.da.yml
+++ b/config/locales/base.da.yml
@@ -157,7 +157,9 @@ da:
             disconnect: 'Afbryd'
             disconnected: 'Markedsdataudbyder afbrudt.'
         platform:
-            option: 'Deltabadger.com — indsæt forbindelseskoden'
+            option: 'Deltabadger.com'
+            subscription_title: 'Self-hosted-abonnement'
+            subscription_html: 'Et <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> Self-hosted-abonnement inkluderer Market Data API og en fast IP-adresse til whitelisting hos børserne.'
             code: 'Forbindelseskode'
             connect: 'Opret forbindelse'
             connected_with_proxies: 'Forbundet til Deltabadger.com for markedsdata og børsproxyer.'
@@ -168,7 +170,6 @@ da:
             title: 'Aktier'
             title_html: 'Aktier (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Aktiekataloget leveres af %{provider_name}. Brugere forbinder deres egne Alpaca-nøgler, når de opretter en bot.'
-            instructions_html: 'Gå til <a href="https://alpaca.markets" target="_blank">Alpaca-oversigten</a> og find API Keys-sektionen i højre sidepanel. Klik på Generate New Keys og gem de genererede API-legitimationsoplysninger.'
             enabled: 'Aktier aktiveret. Synkroniserer aktiver fra Alpaca...'
             disconnected: 'Alpaca afbrudt. Aktiekataloget opdateres ikke længere; eksisterende bots og API-nøgler påvirkes ikke.'
             configured: 'Forbundet til Alpaca (%{mode}). Aktieaktiver er synkroniseret.'

--- a/config/locales/base.de.yml
+++ b/config/locales/base.de.yml
@@ -156,7 +156,9 @@ de:
             disconnect: 'Trennen'
             disconnected: 'Marktdatenanbieter getrennt.'
         platform:
-            option: 'Deltabadger.com — Verbindungscode einfügen'
+            option: 'Deltabadger.com'
+            subscription_title: 'Self-Hosted-Abo'
+            subscription_html: 'Ein <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a>-Self-Hosted-Abo umfasst die Market Data API und eine feste IP, die du bei Börsen freischalten kannst.'
             code: 'Verbindungscode'
             connect: 'Verbinden'
             connected_with_proxies: 'Mit Deltabadger.com für Marktdaten und Börsen-Proxys verbunden.'
@@ -185,7 +187,6 @@ de:
             title: 'Aktien'
             title_html: 'Aktien (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Der Aktienkatalog wird von %{provider_name} bereitgestellt. Nutzer verbinden ihre eigenen Alpaca-Schlüssel beim Erstellen eines Bots.'
-            instructions_html: 'Gehe zum <a href="https://alpaca.markets" target="_blank">Alpaca-Dashboard</a> und finde den Bereich API Keys in der rechten Seitenleiste. Klicke auf Generate New Keys und speichere die erzeugten API-Zugangsdaten.'
             enabled: 'Aktienhandel aktiviert. Assets werden von Alpaca synchronisiert...'
             disconnected: 'Alpaca getrennt. Der Aktienkatalog wird nicht mehr aktualisiert; bestehende Bots und API-Schlüssel bleiben davon unberührt.'
             configured: 'Mit Alpaca verbunden (%{mode}). Aktien-Assets werden synchronisiert.'

--- a/config/locales/base.el.yml
+++ b/config/locales/base.el.yml
@@ -157,7 +157,9 @@ el:
             disconnect: 'Αποσύνδεση'
             disconnected: 'Ο πάροχος δεδομένων αγοράς αποσυνδέθηκε.'
         platform:
-            option: 'Deltabadger.com — επικολλήστε τον κωδικό σύνδεσης'
+            option: 'Deltabadger.com'
+            subscription_title: 'Συνδρομή Self-hosted'
+            subscription_html: 'Η συνδρομή Self-hosted του <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> περιλαμβάνει το Market Data API και σταθερή IP για whitelist στα ανταλλακτήρια.'
             code: 'Κωδικός σύνδεσης'
             connect: 'Σύνδεση'
             connected_with_proxies: 'Συνδεθήκατε στο Deltabadger.com για δεδομένα αγοράς και διακομιστές μεσολάβησης ανταλλακτηρίων.'
@@ -168,7 +170,6 @@ el:
             title: 'Μετοχές'
             title_html: 'Μετοχές (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Ο κατάλογος μετοχών παρέχεται από %{provider_name}. Οι χρήστες συνδέουν τα δικά τους κλειδιά Alpaca κατά τη δημιουργία bot.'
-            instructions_html: 'Πήγαινε στον <a href="https://alpaca.markets" target="_blank">πίνακα ελέγχου του Alpaca</a> και βρες την ενότητα API Keys στη δεξιά πλαϊνή μπάρα. Πάτησε Generate New Keys και αποθήκευσε τα κλειδιά API.'
             enabled: 'Οι μετοχές ενεργοποιήθηκαν. Συγχρονισμός assets από Alpaca...'
             disconnected: 'Το Alpaca αποσυνδέθηκε. Ο κατάλογος μετοχών δεν θα ανανεώνεται πια· τα υπάρχοντα bots και τα κλειδιά API δεν επηρεάζονται.'
             configured: 'Συνδεδεμένο στο Alpaca (%{mode}). Τα assets μετοχών συγχρονίστηκαν.'

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -157,7 +157,9 @@ en:
             disconnect: 'Disconnect'
             disconnected: 'Market data provider disconnected.'
         platform:
-            option: 'Deltabadger.com — paste connect code'
+            option: 'Deltabadger.com'
+            subscription_title: 'Self-hosted subscription'
+            subscription_html: 'A <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> Self-hosted subscription includes the Market Data API and a fixed IP to whitelist on exchanges.'
             code: 'Connect code'
             connect: 'Connect'
             connected_with_proxies: 'Connected to Deltabadger.com for market data and exchange proxies.'
@@ -168,7 +170,6 @@ en:
             title: 'Stocks'
             title_html: 'Stocks (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Stock catalog provided by %{provider_name}. Users connect their own Alpaca keys when creating a bot.'
-            instructions_html: 'Go to the <a href="https://alpaca.markets" target="_blank">Alpaca dashboard</a> and find the API Keys section on the right sidebar. Click on Generate New Keys and save the generated API credentials.'
             enabled: 'Stocks enabled. Syncing assets from Alpaca...'
             disconnected: 'Alpaca disconnected. The stock catalog will no longer refresh; existing bots and API keys are unaffected.'
             configured: 'Connected to Alpaca (%{mode}). Stock assets are synced.'

--- a/config/locales/base.es.yml
+++ b/config/locales/base.es.yml
@@ -156,7 +156,9 @@ es:
             disconnect: 'Desconectar'
             disconnected: 'Proveedor de datos de mercado desconectado.'
         platform:
-            option: 'Deltabadger.com — pega el código de conexión'
+            option: 'Deltabadger.com'
+            subscription_title: 'Suscripción Self-hosted'
+            subscription_html: 'Una suscripción Self-hosted de <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> incluye la Market Data API y una IP fija para añadir a la lista blanca de los exchanges.'
             code: 'Código de conexión'
             connect: 'Conectar'
             connected_with_proxies: 'Conectado a Deltabadger.com para obtener datos de mercado y usar proxies de los exchanges.'
@@ -185,7 +187,6 @@ es:
             title: 'Acciones'
             title_html: 'Acciones (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'El catálogo de acciones lo proporciona %{provider_name}. Los usuarios conectan sus propias claves de Alpaca al crear un bot.'
-            instructions_html: 'Ve al <a href="https://alpaca.markets" target="_blank">panel de Alpaca</a> y busca la sección API Keys en la barra lateral derecha. Haz clic en Generate New Keys y guarda las credenciales API generadas.'
             enabled: 'Acciones activadas. Sincronizando activos desde Alpaca...'
             disconnected: 'Alpaca desconectado. El catálogo de acciones dejará de actualizarse; los bots existentes y las claves API no se ven afectados.'
             configured: 'Conectado a Alpaca (%{mode}). Los activos de acciones están sincronizados.'

--- a/config/locales/base.fr.yml
+++ b/config/locales/base.fr.yml
@@ -157,7 +157,9 @@ fr:
             disconnect: 'Déconnecter'
             disconnected: 'Fournisseur de données de marché déconnecté.'
         platform:
-            option: 'Deltabadger.com — collez le code de connexion'
+            option: 'Deltabadger.com'
+            subscription_title: 'Abonnement Self-hosted'
+            subscription_html: 'Un abonnement Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> inclut la Market Data API et une IP fixe à autoriser sur les plateformes d’échange.'
             code: 'Code de connexion'
             connect: 'Connecter'
             connected_with_proxies: 'Connecté à Deltabadger.com pour les données de marché et les proxys des plateformes d’échange.'
@@ -186,7 +188,6 @@ fr:
             title: 'Actions'
             title_html: 'Actions (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: "Le catalogue d'actions est fourni par %{provider_name}. Les utilisateurs connectent leurs propres clés Alpaca lors de la création d'un bot."
-            instructions_html: 'Rends-toi sur le <a href="https://alpaca.markets" target="_blank">tableau de bord Alpaca</a> et trouve la section API Keys dans la barre latérale droite. Clique sur Generate New Keys et enregistre les identifiants API générés.'
             enabled: 'Actions activées. Synchronisation des actifs depuis Alpaca...'
             disconnected: "Alpaca déconnecté. Le catalogue d'actions ne sera plus actualisé ; les bots existants et les clés API ne sont pas affectés."
             configured: "Connecté à Alpaca (%{mode}). Les actifs d'actions sont synchronisés."

--- a/config/locales/base.it.yml
+++ b/config/locales/base.it.yml
@@ -156,7 +156,9 @@ it:
             disconnect: 'Disconnetti'
             disconnected: 'Fornitore di dati di mercato disconnesso.'
         platform:
-            option: 'Deltabadger.com — incolla il codice di connessione'
+            option: 'Deltabadger.com'
+            subscription_title: 'Abbonamento Self-hosted'
+            subscription_html: 'Un abbonamento Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> include la Market Data API e un IP fisso da inserire nella whitelist degli exchange.'
             code: 'Codice di connessione'
             connect: 'Connetti'
             connected_with_proxies: 'Connesso a Deltabadger.com per i dati di mercato e i proxy degli exchange.'
@@ -185,7 +187,6 @@ it:
             title: 'Azioni'
             title_html: 'Azioni (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Il catalogo azioni è fornito da %{provider_name}. Gli utenti collegano le proprie chiavi Alpaca durante la creazione di un bot.'
-            instructions_html: 'Vai alla <a href="https://alpaca.markets" target="_blank">dashboard di Alpaca</a> e trova la sezione API Keys nella barra laterale destra. Clicca su Generate New Keys e salva le credenziali API generate.'
             enabled: 'Azioni attivate. Sincronizzazione degli asset da Alpaca...'
             disconnected: 'Alpaca disconnesso. Il catalogo azioni non verrà più aggiornato; i bot esistenti e le chiavi API restano invariati.'
             configured: 'Connesso ad Alpaca (%{mode}). Gli asset azionari sono sincronizzati.'

--- a/config/locales/base.nl.yml
+++ b/config/locales/base.nl.yml
@@ -156,7 +156,9 @@ nl:
             disconnect: 'Ontkoppelen'
             disconnected: 'Marktgegevensprovider ontkoppeld.'
         platform:
-            option: 'Deltabadger.com — plak de verbindingscode'
+            option: 'Deltabadger.com'
+            subscription_title: 'Self-hosted-abonnement'
+            subscription_html: 'Een <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> Self-hosted-abonnement omvat de Market Data API en een vast IP-adres dat je bij exchanges kunt whitelisten.'
             code: 'Verbindingscode'
             connect: 'Verbinden'
             connected_with_proxies: "Verbonden met Deltabadger.com voor marktgegevens en beursproxy's."
@@ -185,7 +187,6 @@ nl:
             title: 'Aandelen'
             title_html: 'Aandelen (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'De aandelencatalogus wordt geleverd door %{provider_name}. Gebruikers koppelen hun eigen Alpaca-sleutels bij het aanmaken van een bot.'
-            instructions_html: 'Ga naar het <a href="https://alpaca.markets" target="_blank">Alpaca-dashboard</a> en zoek de sectie API Keys in de rechterzijbalk. Klik op Generate New Keys en bewaar de gegenereerde API-gegevens.'
             enabled: 'Aandelen ingeschakeld. Assets worden gesynchroniseerd vanaf Alpaca...'
             disconnected: 'Alpaca ontkoppeld. De aandelencatalogus wordt niet meer ververst; bestaande bots en API-sleutels blijven ongewijzigd.'
             configured: 'Verbonden met Alpaca (%{mode}). Aandelen-assets zijn gesynchroniseerd.'

--- a/config/locales/base.pl.yml
+++ b/config/locales/base.pl.yml
@@ -158,7 +158,9 @@ pl:
             disconnect: 'Odłącz'
             disconnected: 'Dostawca danych rynkowych został odłączony.'
         platform:
-            option: 'Deltabadger.com — wklej kod połączenia'
+            option: 'Deltabadger.com'
+            subscription_title: 'Subskrypcja Self-hosted'
+            subscription_html: 'Subskrypcja Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> obejmuje Market Data API oraz stały adres IP do dodania na białą listę giełd.'
             code: 'Kod połączenia'
             connect: 'Połącz'
             connected_with_proxies: 'Połączono z Deltabadger.com, aby korzystać z danych rynkowych i serwerów proxy giełd.'
@@ -187,7 +189,6 @@ pl:
             title: 'Akcje'
             title_html: 'Akcje (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Katalog akcji dostarcza %{provider_name}. Użytkownicy podłączają własne klucze Alpaca podczas tworzenia bota.'
-            instructions_html: 'Przejdź do <a href="https://alpaca.markets" target="_blank">panelu Alpaca</a> i znajdź sekcję API Keys na prawym pasku bocznym. Kliknij Generate New Keys i zapisz wygenerowane dane dostępowe API.'
             enabled: 'Akcje włączone. Synchronizowanie aktywów z Alpaca...'
             disconnected: 'Alpaca odłączona. Katalog akcji nie będzie już odświeżany; istniejące boty i klucze API pozostają bez zmian.'
             configured: 'Połączono z Alpaca (%{mode}). Aktywa akcyjne są zsynchronizowane.'

--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -155,7 +155,9 @@ pt:
             disconnect: 'Desconectar'
             disconnected: 'Fornecedor de dados de mercado desconectado.'
         platform:
-            option: 'Deltabadger.com — cole o código de ligação'
+            option: 'Deltabadger.com'
+            subscription_title: 'Subscrição Self-hosted'
+            subscription_html: 'Uma subscrição Self-hosted da <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> inclui a Market Data API e um IP fixo para colocar na lista branca das exchanges.'
             code: 'Código de ligação'
             connect: 'Ligar'
             connected_with_proxies: 'Ligado ao Deltabadger.com para obter dados de mercado e usar proxies das bolsas.'
@@ -184,7 +186,6 @@ pt:
             title: 'Ações'
             title_html: 'Ações (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'O catálogo de ações é fornecido por %{provider_name}. Os utilizadores ligam as suas próprias chaves Alpaca ao criar um bot.'
-            instructions_html: 'Vai ao <a href="https://alpaca.markets" target="_blank">painel da Alpaca</a> e encontra a secção API Keys na barra lateral direita. Clica em Generate New Keys e guarda as credenciais API geradas.'
             enabled: 'Ações ativadas. A sincronizar ativos da Alpaca...'
             disconnected: 'Alpaca desligada. O catálogo de ações deixa de ser atualizado; os bots existentes e as chaves API não são afetados.'
             configured: 'Ligado à Alpaca (%{mode}). Os ativos de ações estão sincronizados.'

--- a/config/locales/base.ru.yml
+++ b/config/locales/base.ru.yml
@@ -159,7 +159,9 @@ ru:
             disconnect: 'Отключить'
             disconnected: 'Поставщик рыночных данных отключен.'
         platform:
-            option: 'Deltabadger.com — вставьте код подключения'
+            option: 'Deltabadger.com'
+            subscription_title: 'Подписка Self-hosted'
+            subscription_html: 'Подписка Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> включает Market Data API и фиксированный IP для добавления в белый список бирж.'
             code: 'Код подключения'
             connect: 'Подключить'
             connected_with_proxies: 'Deltabadger.com подключён для получения рыночных данных и использования прокси бирж.'
@@ -188,7 +190,6 @@ ru:
             title: 'Акции'
             title_html: 'Акции (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Каталог акций предоставляется %{provider_name}. Пользователи подключают собственные API-ключи Alpaca при создании бота.'
-            instructions_html: 'Перейдите в <a href="https://alpaca.markets" target="_blank">панель Alpaca</a> и найдите раздел API Keys в правой боковой панели. Нажмите Generate New Keys и сохраните сгенерированные API-ключи.'
             enabled: 'Акции включены. Синхронизация активов из Alpaca...'
             disconnected: 'Alpaca отключена. Каталог акций больше не будет обновляться; существующие боты и API-ключи не затронуты.'
             configured: 'Подключено к Alpaca (%{mode}). Активы акций синхронизированы.'

--- a/config/locales/base.sk.yml
+++ b/config/locales/base.sk.yml
@@ -158,7 +158,9 @@ sk:
             disconnect: 'Odpojiť'
             disconnected: 'Poskytovateľ trhových dát bol odpojený.'
         platform:
-            option: 'Deltabadger.com — vložte kód pripojenia'
+            option: 'Deltabadger.com'
+            subscription_title: 'Predplatné Self-hosted'
+            subscription_html: 'Predplatné Self-hosted <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> zahŕňa Market Data API a pevnú IP adresu na whitelist na burzách.'
             code: 'Kód pripojenia'
             connect: 'Pripojiť'
             connected_with_proxies: 'Pripojené k Deltabadger.com pre trhové dáta a proxy servery búrz.'
@@ -169,7 +171,6 @@ sk:
             title: 'Akcie'
             title_html: 'Akcie (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Katalóg akcií poskytuje %{provider_name}. Používatelia pripájajú vlastné kľúče Alpaca pri vytváraní bota.'
-            instructions_html: 'Prejdi na <a href="https://alpaca.markets" target="_blank">Alpaca dashboard</a> a nájdi sekciu API Keys v pravom paneli. Klikni na Generate New Keys a ulož si vygenerované prihlasovacie údaje.'
             enabled: 'Akcie zapnuté. Synchronizácia aktív z Alpaca...'
             disconnected: 'Alpaca odpojená. Katalóg akcií sa už nebude aktualizovať; existujúci boti a API kľúče zostávajú bez zmeny.'
             configured: 'Pripojené k Alpaca (%{mode}). Akciové aktíva sú synchronizované.'

--- a/config/locales/base.sv.yml
+++ b/config/locales/base.sv.yml
@@ -157,7 +157,9 @@ sv:
             disconnect: 'Koppla från'
             disconnected: 'Marknadsdataleverantör frånkopplad.'
         platform:
-            option: 'Deltabadger.com — klistra in anslutningskoden'
+            option: 'Deltabadger.com'
+            subscription_title: 'Self-hosted-prenumeration'
+            subscription_html: 'En <a href="https://deltabadger.com" target="_blank" rel="noopener">Deltabadger</a> Self-hosted-prenumeration inkluderar Market Data API och en fast IP-adress att vitlista hos börserna.'
             code: 'Anslutningskod'
             connect: 'Anslut'
             connected_with_proxies: 'Ansluten till Deltabadger.com för marknadsdata och börsproxyservrar.'
@@ -168,7 +170,6 @@ sv:
             title: 'Aktier'
             title_html: 'Aktier (<a href="https://alpaca.markets/" target="_blank">Alpaca</a>)'
             deltabadger_configured: 'Aktiekatalogen tillhandahålls av %{provider_name}. Användare ansluter sina egna Alpaca-nycklar när de skapar en bot.'
-            instructions_html: 'Gå till <a href="https://alpaca.markets" target="_blank">Alpaca-panelen</a> och hitta API Keys-sektionen i höger sidofält. Klicka på Generate New Keys och spara de genererade API-uppgifterna.'
             enabled: 'Aktier aktiverade. Synkroniserar tillgångar från Alpaca...'
             disconnected: 'Alpaca frånkopplad. Aktiekatalogen uppdateras inte längre; befintliga botar och API-nycklar påverkas inte.'
             configured: 'Ansluten till Alpaca (%{mode}). Aktietillgångar är synkroniserade.'

--- a/test/controllers/settings/platform_connections_controller_test.rb
+++ b/test/controllers/settings/platform_connections_controller_test.rb
@@ -11,10 +11,42 @@ class Settings::PlatformConnectionsControllerTest < ActionDispatch::IntegrationT
 
     assert_response :success
     assert_select 'turbo-frame#market_data_settings' do
-      assert_select 'input[type=radio][name=market_data_provider][value=""]'
-      assert_select 'input[type=radio][name=market_data_provider][value=coingecko]'
-      assert_select 'input[type=radio][name=market_data_provider][value=deltabadger]'
-      assert_select "form[action='#{settings_platform_connection_path}'] input[name=claim_code]"
+      # The provider is one segmented control over a hidden field, submitted as soon as it moves.
+      # Fluid: the labels differ in length, so each option takes its own width.
+      assert_select '.segmented.segmented--fluid[role=radiogroup]' do
+        assert_select '.segmented__option.is-on[data-value=""]', text: I18n.t('settings.market_data.none')
+        assert_select '.segmented__option[data-value=coingecko]', text: 'CoinGecko'
+        assert_select '.segmented__option[data-value=deltabadger]', text: 'Deltabadger.com'
+      end
+      assert_select 'input[type=hidden][name=market_data_provider]', count: 1
+      assert_select 'input[type=radio][name=market_data_provider]', count: 0
+      # The claim is the same connect card, with what the subscription brings in place of a walkthrough.
+      assert_select '[data-form--market-data-target=deltabadgerButtons] .set-api--connect' do
+        assert_select '.set-api__mark svg', count: 1
+        assert_select 'h2.set-api__title', text: 'Connect Deltabadger.com'
+        assert_select "form[action='#{settings_platform_connection_path}'] input[name=claim_code].form__input"
+        assert_select 'input[type=submit][value=Connect]'
+        assert_select '.set-api__instructions h3.set-api__eyebrow', text: I18n.t('settings.platform.subscription_title')
+        assert_select '.set-api__instructions p a[href="https://deltabadger.com"]', text: 'Deltabadger'
+      end
+    end
+  end
+
+  test 'choosing CoinGecko without a key shows the connect card, walkthrough below' do
+    # A stored blank beats whatever key the environment happens to carry (a developer's .env).
+    AppConfig.coingecko_api_key = ''
+    patch settings_update_market_data_path, params: { market_data_provider: MarketDataSettings::PROVIDER_COINGECKO },
+                                            as: :turbo_stream
+
+    assert_response :success
+    # Two cards ride in the widget now (the claim one hidden), so look inside the CoinGecko slot.
+    assert_select '[data-form--market-data-target=coingeckoFields]:not([hidden]) .set-api--connect' do
+      assert_select '.set-api__mark svg', count: 1
+      assert_select 'h2.set-api__title', text: 'Connect CoinGecko'
+      assert_select 'input[type=hidden][name=market_data_provider][value=coingecko]', minimum: 1
+      assert_select 'input[name=coingecko_api_key].form__input', count: 1
+      assert_select 'input[type=submit][value=Connect]'
+      assert_select '.set-api__instructions ol li', count: 7
     end
   end
 
@@ -25,9 +57,13 @@ class Settings::PlatformConnectionsControllerTest < ActionDispatch::IntegrationT
     get settings_connect_path
 
     assert_response :success
-    assert_select 'input[type=radio][name=market_data_provider][value=deltabadger][disabled]', count: 1
+    assert_select 'turbo-frame#market_data_settings' do
+      assert_select '.segmented', count: 0
+      assert_select 'input[name=market_data_provider]', count: 0
+      assert_match 'Deltabadger Cloud', response.body
+    end
     assert_select "form[action='#{settings_platform_connection_path}']", count: 0
-    assert_select 'input[type=radio][name=market_data_provider][value=coingecko]', count: 0
+    assert_select '[data-value=coingecko]', count: 0
   end
 
   test 'admin can connect with a claim code' do
@@ -86,8 +122,9 @@ class Settings::PlatformConnectionsControllerTest < ActionDispatch::IntegrationT
     get settings_connect_path
 
     assert_response :success
-    assert_select 'input[type=radio][name=market_data_provider][value=deltabadger]' \
-                  '[data-action="form--market-data#selectConnectedDeltabadger"]'
+    # Connected, so choosing Deltabadger is a plain switch rather than a claim: the widget says so.
+    assert_select '[data-controller="form--market-data"][data-form--market-data-platform-connected-value="true"]'
+    assert_select '.segmented__option[data-value=deltabadger]'
 
     patch settings_update_market_data_path,
           params: { market_data_provider: MarketDataSettings::PROVIDER_DELTABADGER }, as: :turbo_stream
@@ -118,6 +155,22 @@ class Settings::PlatformConnectionsControllerTest < ActionDispatch::IntegrationT
     assert_response :unprocessable_entity
     assert_select 'turbo-stream[action=replace][target=market_data_settings]'
     assert_includes response.body, 'That claim code is invalid or has expired.'
+  end
+
+  test 'a failed claim keeps Deltabadger selected even while CoinGecko is the stored provider' do
+    AppConfig.market_data_provider = MarketDataSettings::PROVIDER_COINGECKO
+    AppConfig.coingecko_api_key = 'saved-key'
+    Platform::RedeemClaim.expects(:call).with(code: 'expired').returns(
+      Result::Failure.new('That claim code is invalid or has expired.')
+    )
+
+    post settings_platform_connection_path, params: { claim_code: 'expired' }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+    assert_select '.segmented__option.is-on[data-value=deltabadger]', count: 1
+    assert_select 'input[type=hidden][name=market_data_provider][value=deltabadger]', count: 1
+    assert_select '[data-form--market-data-target=deltabadgerButtons]:not([hidden]) input[name=claim_code]'
+    assert_select '[data-form--market-data-target=coingeckoFields][hidden]', count: 1
   end
 
   test 'platform connection writes are admin-only' do
@@ -196,7 +249,8 @@ class Settings::PlatformConnectionsControllerTest < ActionDispatch::IntegrationT
   end
 
   test 'platform connection copy exists in every locale' do
-    settings_keys = %w[option code connect connected_with_proxies connected_without_proxies disconnect disconnected]
+    settings_keys = %w[option code connect connected_with_proxies connected_without_proxies disconnect disconnected
+                       subscription_title subscription_html]
     setup_keys = %w[prompt code connect connected_with_proxies connected_without_proxies]
 
     I18n.available_locales.each do |locale|

--- a/test/integration/connect_step_test.rb
+++ b/test/integration/connect_step_test.rb
@@ -56,7 +56,8 @@ class ConnectStepTest < ActionDispatch::IntegrationTest
       # One line of help, not a numbered list.
       assert_select '.set-api__instructions' do
         assert_select 'h3.set-api__eyebrow', text: 'How to get API keys from Alpaca'
-        assert_select 'p a[href="https://app.alpaca.markets/"]', text: 'Alpaca'
+        assert_select 'p a[href="https://app.alpaca.markets/"]'
+        assert_select 'p', text: /Trading API/
         assert_select 'ol', count: 0
       end
     end

--- a/test/integration/settings_stocks_test.rb
+++ b/test/integration/settings_stocks_test.rb
@@ -118,7 +118,29 @@ class SettingsStocksTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'turbo-frame#stocks_settings input[name=alpaca_api_key]'
     assert_select "turbo-frame#stocks_settings a[href='#{settings_disconnect_stocks_path}']"
-    assert_select 'turbo-frame#stocks_settings input[name=alpaca_mode][value=paper][checked]'
+    assert_select 'turbo-frame#stocks_settings input[type=hidden][name=alpaca_mode][value=paper]'
+    assert_select 'turbo-frame#stocks_settings .segmented__option.is-on[data-value=paper]'
+  end
+
+  # The widget is the same connect card as the bot wizard's key step: mark, "Connect Alpaca",
+  # Paper or Live as the segmented control, the fields, and the one walkthrough under a label.
+  test 'the stocks widget is the connect card, with the shared Alpaca walkthrough below the form' do
+    get settings_connect_path
+
+    assert_response :success
+    assert_select 'turbo-frame#stocks_settings .set-api--connect' do
+      assert_select '.set-api__mark svg', count: 1
+      assert_select 'h2.set-api__title', text: 'Connect Alpaca'
+      assert_select '.segmented[role=radiogroup] .segmented__option', count: 2
+      assert_select 'input[type=hidden][name=alpaca_mode][value=live]', count: 1, message: 'live stays the default for the catalog credential'
+      assert_select '.form__radio', count: 0
+      assert_select 'input[type=submit][value=Connect]'
+      assert_select '.set-api__instructions' do
+        assert_select 'h3.set-api__eyebrow', text: 'How to get API keys from Alpaca'
+        assert_select 'p a[href="https://app.alpaca.markets/"]'
+        assert_select 'p', text: /Trading API/
+      end
+    end
   end
 
   test 'stocks widget shows ON with a sync note when a catalog exists without a credential' do


### PR DESCRIPTION
Re-lands #331 on main. That PR was based on `connect-card-css`, so merging it landed there rather than on main, and it went in before the last two fixes. This is the whole settings change, final version, as one commit on main.

**Stocks.** The widget is the connect card: the Alpaca mark, "Connect Alpaca", Paper or Live as the segmented control (posted through a hidden field), the key fields, Connect beside Disconnect when a credential is stored, and the walkthrough under its label below the form. The card partial gained a `method` and an `actions` slot for this.

**One Alpaca walkthrough.** The fuller text Settings already had is now the venue's shared walkthrough, shown in the wizards and the re-key modal too, and it points at the Trading API rather than the Broker API. It lives under `bot.api.alpaca.instructions` in all 15 locales; the settings-only copy is gone.

**Market data.** None, CoinGecko and Deltabadger.com are one fluid, centred segmented control over a hidden `market_data_provider` field. The switch controller fills the field and submits; the server re-renders the widget in whatever state the provider needs. CoinGecko without a key shows the same connect card as the index wizard's step. An unclaimed Deltabadger.com shows the same card too, with the connect-code field and, in place of a walkthrough, what a Self-hosted subscription includes. A failed claim keeps Deltabadger.com selected.

Tests pin the stocks card, the market-data control and hidden field, both cards, the failed-claim state, the hosted layout, and the new copy in every locale. Full suite green.
