### PR TITLE
Give MCP and the REST API their own settings view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/doorkeeper-gem/doorkeeper.git
-  revision: 655ba5cdaf8ab472acdf650f37cad19ad7f0f85c
+  revision: 079fb94d41674d19231ecbaba37908c65751c0d2
   specs:
     doorkeeper (6.0.0.beta2)
       railties (>= 5)
@@ -128,7 +128,7 @@ GEM
     bls12-381 (0.4.0)
       bigdecimal
       h2c (>= 0.2.1, < 0.3)
-    bootsnap (1.25.0)
+    bootsnap (1.26.0)
       msgpack (~> 1.5)
     builder (3.3.0)
     bundle-audit (0.2.0)
@@ -494,23 +494,23 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
-    sass-embedded (1.103.1-aarch64-linux-gnu)
+    sass-embedded (1.104.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-aarch64-linux-musl)
+    sass-embedded (1.104.0-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-arm-linux-gnueabihf)
+    sass-embedded (1.104.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-arm-linux-musleabihf)
+    sass-embedded (1.104.0-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-arm64-darwin)
+    sass-embedded (1.104.0-arm64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-x64-mingw-ucrt)
+    sass-embedded (1.104.0-x64-mingw-ucrt)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-x86_64-darwin)
+    sass-embedded (1.104.0-x86_64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-x86_64-linux-gnu)
+    sass-embedded (1.104.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.103.1-x86_64-linux-musl)
+    sass-embedded (1.104.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     scrypt (3.1.0)
       ffi-compiler (>= 1.0, < 2.0)
@@ -692,7 +692,7 @@ CHECKSUMS
   bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bls12-381 (0.4.0) sha256=b05e35b997acc5400b226d91f8b35e8e1fd88a34966ad1ca32de66bb3d539f46
-  bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
+  bootsnap (1.26.0) sha256=ca96237015e6cd74a02963d5821cf00ac5ea134653b323e8cd6d702a7718bf1b
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundle-audit (0.2.0) sha256=cb499708f7fbc56d2d2e8bab09a1184f8f5b548bdbd628b757e5a1856874ca12
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
@@ -850,15 +850,15 @@ CHECKSUMS
   ruby-technical-analysis (1.0.4)
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
-  sass-embedded (1.103.1-aarch64-linux-gnu) sha256=48790fb0be3c57177121f28626a7c5cfc258a06aa499f09fd80a55054cc46c09
-  sass-embedded (1.103.1-aarch64-linux-musl) sha256=fb0bfcbab2e7baf8e6a59890e2729037cd1651859718e7c7a5878d5f9e2a6e8c
-  sass-embedded (1.103.1-arm-linux-gnueabihf) sha256=1388f692fd7c76d3fe03fb8d79a45ca89586a1fa19a8718faf875f457bed4169
-  sass-embedded (1.103.1-arm-linux-musleabihf) sha256=9e2a3cf86576d96fd16ebd1fbd4333e72c3df6b1990e5273d5a3b4d2e1eec4ac
-  sass-embedded (1.103.1-arm64-darwin) sha256=b4afa0515a8bdb9949675bc85a3625b676bd11080b4d5b5134282729762a2261
-  sass-embedded (1.103.1-x64-mingw-ucrt) sha256=1f6bc232d8d9f29b6e9923e8dbe8ef6a5da9b603c9d346307ef369bd2e84c251
-  sass-embedded (1.103.1-x86_64-darwin) sha256=75514c8f62a849e5e2e98fe89268176278fb0900751208a7ae3322451a0b5285
-  sass-embedded (1.103.1-x86_64-linux-gnu) sha256=1056cb8031fbceee992a3d07c39e9118864aa280e1ba03d85bc5397bd4479333
-  sass-embedded (1.103.1-x86_64-linux-musl) sha256=2f52d9f70030a2d8ddbff8289049df1d38f20f55ba05a87a0049d99fbaa1108c
+  sass-embedded (1.104.0-aarch64-linux-gnu) sha256=99e2b95e8101928f8976c7a3f7cced5c5e4289ceb8aca0e1dedd9bb13645e417
+  sass-embedded (1.104.0-aarch64-linux-musl) sha256=d54f9dc45e753d29a999021f24cfc126b49c61f14bcb8e96209a02288cde22c3
+  sass-embedded (1.104.0-arm-linux-gnueabihf) sha256=5dfe35be85c0816131648da14312bc4981b1283d3c3aaaab7254b572420b6d93
+  sass-embedded (1.104.0-arm-linux-musleabihf) sha256=43d61264663409b268d46f33d2312b0084cb18b9af0c3d181563f5e05ab0053f
+  sass-embedded (1.104.0-arm64-darwin) sha256=b1409415e06931b43c2a498fc430fe8ddbad9706be5bb3c4e20b60c14f56b122
+  sass-embedded (1.104.0-x64-mingw-ucrt) sha256=459f4a5473ff4404187be615652dac9a666bac0e41898f25016afe31415779d4
+  sass-embedded (1.104.0-x86_64-darwin) sha256=d463b65e6fefcae614352f7a4dcea61d399f35a1238822b38d88471cee954717
+  sass-embedded (1.104.0-x86_64-linux-gnu) sha256=7aeaa07beff7db254836599f1524ac7b67216729613ebc57e3828b94345f0488
+  sass-embedded (1.104.0-x86_64-linux-musl) sha256=bc14555f68aa7057e923d400726c1623bb603101eef6340962e4e80ee89e67ba
   scrypt (3.1.0) sha256=67fde35bc7e3b7fe906c5be9c242acf95fe4a886c89572f405f6b11df30aa6af
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simpleidn (0.3.0) sha256=12ca730bed2f3db04d11e9bfd1bca3e11fb37f55b21eb2e9793fb5814bf54d03

--- a/app/assets/stylesheets/new/_base.sass
+++ b/app/assets/stylesheets/new/_base.sass
@@ -15,6 +15,8 @@ dialog
 // of it. Everywhere else the bar is the only sign there is — see menu_controller.js.
 html[data-menu-visit] .turbo-progress-bar
   display: none !important
+p, ol, ul
+    font-size: 1.75rem
 ol, ul
     padding-left: 3.5rem
     display: flex

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -26,6 +26,8 @@ class SettingsController < ApplicationController
     set_account_instance_variables
   end
 
+  def api; end
+
   def update_name
     if current_user.update(update_name_params)
       flash.now[:notice] = t('settings.name.updated')

--- a/app/views/layouts/navbar/_signed_in.html.haml
+++ b/app/views/layouts/navbar/_signed_in.html.haml
@@ -20,11 +20,14 @@
   = link_to rules_path, class: "menu-mobile__item menu-mobile__item--rules #{'menu-mobile__item--active' if current_page?(rules_path)}" do
     = t('links.rules')
 
+  = link_to settings_account_path, class: "menu-mobile__item menu-mobile__item--account #{'menu-mobile__item--active' if current_page?(settings_account_path)}" do
+    = t('links.account')
+
   = link_to settings_connect_path, class: "menu-mobile__item menu-mobile__item--connections #{'menu-mobile__item--active' if current_page?(settings_connect_path)}" do
     = t('links.connections')
 
-  = link_to settings_account_path, class: "menu-mobile__item menu-mobile__item--account #{'menu-mobile__item--active' if current_page?(settings_account_path)}" do
-    = t('links.account')
+  = link_to settings_api_path, class: "menu-mobile__item menu-mobile__item--api #{'menu-mobile__item--active' if current_page?(settings_api_path)}" do
+    = t('links.api')
 
   = render 'layouts/navbar/hide_balances_toggle', item_class: 'menu-mobile__item'
   = render 'layouts/navbar/display_currency_picker', item_class: 'menu-mobile__item'
@@ -67,8 +70,9 @@
       .menu__item.menu__button{ data: { dropdown_target: "trigger" } }
         = render 'svg/24x24_sliders'
       .dropdown
-        = link_to t('links.connections'), settings_connect_path, class: "dropdown__item"
         = link_to t('links.account'), settings_account_path, class: "dropdown__item"
+        = link_to t('links.connections'), settings_connect_path, class: "dropdown__item"
+        = link_to t('links.api'), settings_api_path, class: "dropdown__item"
         = render 'layouts/navbar/hide_balances_toggle', item_class: 'dropdown__item'
         = render 'layouts/navbar/display_currency_picker', item_class: 'dropdown__item'
         .dropdown__item.dropdown__item--divider

--- a/app/views/settings/account.html.erb
+++ b/app/views/settings/account.html.erb
@@ -11,6 +11,8 @@
       <%= render partial: 'settings/widgets/registration' %>
     <% end %>
 
+    <%= render partial: 'settings/widgets/advanced_bots' %>
+
     <% if current_user.admin? %>
       <%= render partial: 'settings/widgets/email_notifications' %>
     <% end %>

--- a/app/views/settings/api.html.erb
+++ b/app/views/settings/api.html.erb
@@ -1,0 +1,13 @@
+<div class="page-head">
+  <div class="stitle"><%= t('links.api') %></div>
+</div>
+
+<div class="columns">
+  <div class="column gap-1">
+    <%= render partial: 'settings/widgets/mcp' %>
+  </div>
+
+  <div class="column gap-1">
+    <%= render partial: 'settings/widgets/rest' %>
+  </div>
+</div>

--- a/app/views/settings/connect.html.erb
+++ b/app/views/settings/connect.html.erb
@@ -4,8 +4,14 @@
 
 <div class="columns">
   <div class="column gap-1">
-    <%= render partial: 'settings/widgets/mcp' %>
-    <%= render partial: 'settings/widgets/rest' %>
+    <% if current_user.admin? %>
+      <%= render partial: 'settings/widgets/market_data' %>
+    <% end %>
+
+    <%= render partial: 'settings/widgets/api_keys', locals: {
+      trading_api_keys: @trading_api_keys,
+      withdrawal_api_keys: @withdrawal_api_keys
+    } %>
   </div>
 
   <div class="column gap-1">
@@ -15,16 +21,5 @@
       <%= render partial: 'settings/widgets/stocks' %>
     <% end %>
     <%= render partial: 'settings/widgets/ibkr' %>
-
-    <%= render partial: 'settings/widgets/api_keys', locals: {
-      trading_api_keys: @trading_api_keys,
-      withdrawal_api_keys: @withdrawal_api_keys
-    } %>
-
-    <%= render partial: 'settings/widgets/advanced_bots' %>
-
-    <% if current_user.admin? %>
-      <%= render partial: 'settings/widgets/market_data' %>
-    <% end %>
   </div>
 </div>

--- a/config/locales/base.en.yml
+++ b/config/locales/base.en.yml
@@ -105,6 +105,7 @@ en:
         tracker: Tracker
         settings: Settings
         connections: Connect
+        api: 'MCP & REST API'
         account: Account
         sign_up: 'Sign up'
     settings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
       }
       get :connect
       get :account
+      get :api
       patch :update_password
       patch :update_email
       patch :update_name

--- a/test/integration/settings_connected_client_permissions_test.rb
+++ b/test/integration/settings_connected_client_permissions_test.rb
@@ -27,7 +27,7 @@ class SettingsConnectedClientPermissionsTest < ActionDispatch::IntegrationTest
   # ---- the list -----------------------------------------------------------
 
   test 'lists the connected client' do
-    get settings_connect_path
+    get settings_api_path
 
     assert_response :success
     assert_match 'Acme Connector', response.body
@@ -36,7 +36,7 @@ class SettingsConnectedClientPermissionsTest < ActionDispatch::IntegrationTest
   test 'a client whose tokens are all revoked drops off the list' do
     @token.update!(revoked_at: Time.current)
 
-    get settings_connect_path
+    get settings_api_path
 
     assert_response :success
     assert_no_match(/Acme Connector/, response.body)
@@ -45,7 +45,7 @@ class SettingsConnectedClientPermissionsTest < ActionDispatch::IntegrationTest
   test 'a client with a live token but no grant record is still listed and revokable' do
     @client.destroy!
 
-    get settings_connect_path
+    get settings_api_path
 
     assert_response :success
     assert_match 'Acme Connector', response.body
@@ -64,7 +64,7 @@ class SettingsConnectedClientPermissionsTest < ActionDispatch::IntegrationTest
       redirect_uri: 'http://localhost/callback', scopes: 'mcp'
     )
 
-    get settings_connect_path
+    get settings_api_path
 
     assert_match 'Acme Connector', response.body
 
@@ -81,7 +81,7 @@ class SettingsConnectedClientPermissionsTest < ActionDispatch::IntegrationTest
       redirect_uri: 'http://localhost/callback', scopes: 'mcp'
     )
 
-    get settings_connect_path
+    get settings_api_path
 
     assert_no_match(/Acme Connector/, response.body)
   end

--- a/test/integration/settings_mcp_test.rb
+++ b/test/integration/settings_mcp_test.rb
@@ -14,13 +14,13 @@ class SettingsMcpTest < ActionDispatch::IntegrationTest
   end
 
   test 'mcp widget shows URL' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select '#mcp_url_display'
   end
 
   test 'mcp widget shows connected clients section' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select '#mcp_connected_clients'
   end
@@ -30,7 +30,7 @@ class SettingsMcpTest < ActionDispatch::IntegrationTest
     Doorkeeper::AccessToken.create!(application: app, resource_owner_id: @admin.id, token: SecureRandom.hex(32), expires_in: 3600)
     ConnectedClient.create!(user: @admin, oauth_application: app, mcp_tools: AppConfig::MCP_TOOL_GROUPS['read'])
 
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select '#mcp_connected_clients', /Test Client/
   end
@@ -70,13 +70,13 @@ class SettingsMcpTest < ActionDispatch::IntegrationTest
     regular_user = create(:user, setup_completed: true)
     sign_in regular_user
 
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select 'turbo-frame#mcp_settings'
   end
 
   test 'the MCP url copies through a Stimulus action, not an inline handler' do
-    get settings_connect_path
+    get settings_api_path
 
     assert_response :success
     assert_select '#mcp_url_display[data-controller=?][data-action=?]',

--- a/test/integration/settings_mcp_tool_permissions_test.rb
+++ b/test/integration/settings_mcp_tool_permissions_test.rb
@@ -11,7 +11,7 @@ class SettingsMcpToolPermissionsTest < ActionDispatch::IntegrationTest
   end
 
   test 'mcp widget shows tool toggles' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select '#mcp_tool_permissions'
   end

--- a/test/integration/settings_rest_token_test.rb
+++ b/test/integration/settings_rest_token_test.rb
@@ -22,7 +22,7 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
     assert_equal 0, Doorkeeper::Application.where(personal_owner_id: @user.id,
                                                   personal_access_token: true).count
 
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
 
     # Post-condition: exactly one personal app + token, both surfaced in the page.
@@ -33,10 +33,10 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
   end
 
   test 'GET /settings/connect on a second visit reuses the same token (no churn)' do
-    get settings_connect_path
+    get settings_api_path
     first = @user.reload.personal_api_application.access_tokens.where(revoked_at: nil).first
 
-    get settings_connect_path
+    get settings_api_path
     second = @user.reload.personal_api_application.access_tokens.where(revoked_at: nil).first
 
     assert_equal first.id, second.id
@@ -47,7 +47,7 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
 
   test 'POST /settings/regenerate_api_token revokes old token and issues a new one (verified via /api/v1/bots)' do
     # 1. Surface the token + enable list_bots so REST is reachable.
-    get settings_connect_path
+    get settings_api_path
     @user.set_rest_tool_enabled('list_bots', true)
     old_token_str = @user.reload.personal_api_token.token
 
@@ -72,7 +72,7 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
   end
 
   test 'POST /settings/regenerate_api_token re-renders the REST widget with the new token visible' do
-    get settings_connect_path
+    get settings_api_path
     old_token = @user.reload.personal_api_token.token
 
     post settings_regenerate_api_token_path
@@ -89,10 +89,10 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
   # ---- isolation from MCP widget ------------------------------------------
 
   test 'MCP Connected clients section does NOT list the personal application' do
-    get settings_connect_path # triggers lazy mint
+    get settings_api_path # triggers lazy mint
     @user.reload
 
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     # The personal app's name appears nowhere in the MCP Connected clients section
     # (which has the `#mcp_connected_clients` DOM id from the MCP widget).
@@ -114,11 +114,11 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
   test 'regenerate scopes by current_user — user A cannot affect user B token' do
     other = create(:user, setup_completed: true)
     sign_in other
-    get settings_connect_path # triggers lazy mint for `other`
+    get settings_api_path # triggers lazy mint for `other`
     other_token = other.reload.personal_api_token.token
 
     sign_in @user
-    get settings_connect_path
+    get settings_api_path
     my_token_before = @user.reload.personal_api_token.token
 
     post settings_regenerate_api_token_path
@@ -130,7 +130,7 @@ class SettingsRestTokenTest < ActionDispatch::IntegrationTest
   end
 
   test 'the REST url and token copy through a Stimulus action, not an inline handler' do
-    get settings_connect_path
+    get settings_api_path
 
     assert_response :success
     assert_select '#rest_api_url_display[data-controller=?][data-action=?][data-clipboard-text-value=?]',

--- a/test/integration/settings_rest_tool_permissions_test.rb
+++ b/test/integration/settings_rest_tool_permissions_test.rb
@@ -13,20 +13,20 @@ class SettingsRestToolPermissionsTest < ActionDispatch::IntegrationTest
   # ---- widget render ------------------------------------------------------
 
   test 'connect page renders the REST tool permissions block' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select '#rest_tool_permissions'
   end
 
   test 'REST widget renders alongside the MCP widget (both present on the page)' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select 'turbo-frame#mcp_settings'
     assert_select 'turbo-frame#rest_settings'
   end
 
   test 'REST widget exposes a Download API docs link' do
-    get settings_connect_path
+    get settings_api_path
     assert_response :success
     assert_select 'a[href=?]', settings_download_api_docs_path
   end


### PR DESCRIPTION
Settings had one page called Connect carrying five unrelated things: the MCP server, the REST API, exchange API keys, the stocks/IBKR connections, market data, and a toggle for advanced bot types.

**MCP and REST API** get their own view at `/settings/api`. That is a different question from "which exchange am I connected to" — it is about handing another program access to this instance, and it now has the room to say so.

**Advanced bots** is an account preference, not a connection. It moves to Account, under Multiple Accounts.

**Connect** keeps the connections: market data first, then exchange keys, stocks and IBKR.

Menu order is Account, Connect, MCP & REST API, in both the sidebar dropdown and the mobile drawer.

Also here: base font size for `p`, `ol` and `ul`, and a routine dependency bump in `Gemfile.lock`.
