### PR TITLE
Fix jobs container reporting unhealthy in the Umbrel package

### DIFF
--- a/deltabadger/docker-compose.yml
+++ b/deltabadger/docker-compose.yml
@@ -58,3 +58,14 @@ services:
     depends_on:
       web:
         condition: service_healthy
+    # The image's HEALTHCHECK curls /up, which only the `web` command serves. This service runs
+    # Solid Queue with no web server, so the inherited probe can never pass and the container
+    # reports unhealthy while working normally. Match a worker procline instead: it also catches
+    # "supervisor alive, workers dead", which probing PID 1 would miss. The bracketed [w] keeps
+    # grep from matching its own cmdline, which would make the check pass in any container.
+    healthcheck:
+      test: ["CMD-SHELL", "grep -qa 'solid-queue.*[w]orker' /proc/[0-9]*/cmdline"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3


### PR DESCRIPTION
The image sets one `HEALTHCHECK` that curls `/up`. That is correct for the `web` command, but the
Umbrel compose runs the same image a second time as `jobs`, which starts Solid Queue and no web
server. The probe can never pass there, so the jobs container reports `unhealthy` for its entire
lifetime while processing jobs normally.

This overrides the healthcheck on the `jobs` service only. The `web` service and the image
healthcheck are unchanged.

```yaml
healthcheck:
  test: ["CMD-SHELL", "grep -qa 'solid-queue.*[w]orker' /proc/[0-9]*/cmdline"]
```

Why this probe:

- **A worker, not PID 1.** If the supervisor dies the container exits and `restart: on-failure`
  handles it, so probing PID 1 would be close to tautological. Matching a worker also catches a
  supervisor that is alive with all its workers dead.
- **`worker`, not `supervisor`.** Solid Queue builds the process title from the class name, so the
  supervisor appears as `solid-queue-supervisor` or `solid-queue-fork-supervisor` depending on
  version and mode. `SolidQueue::Worker` has no such variants, so `solid-queue-worker` is stable.
  No recurring task key contains `worker` either, so the scheduler's title cannot satisfy the
  pattern on its own.
- **The bracketed `[w]`.** Without it the pattern matches grep's own `/proc/<pid>/cmdline` and the
  check passes in *any* container, including one running no Solid Queue at all. Verified against
  both roles: the unbracketed form exits 0 in the web container, where it must fail; the bracketed
  form exits 1 in web and 0 in jobs.

The interval, timeout, start period and retries mirror the image's values — once `test` is
overridden the remaining fields fall back to Docker's defaults rather than to the image's, so the
60s start period has to be restated to keep the same grace on boot.

`/proc` is the only option available here: the image ships `curl` and `bash` but no `ps`, `pgrep`
or `sqlite3`, so process- and database-based probes would each mean a new dependency.
