### PR TITLE
Stop a revoked pair from silently killing a running bot

### DIFF
--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -122,7 +122,11 @@ module Bot::AssetConfigurable
     # store_accessor the `_was` reader returns nil when the attribute is unchanged, so comparing it
     # against the current value is always true. That method gets away with it because it returns
     # early unless settings_changed?; here there is no such gate.
-    return unless exchange_id_changed? ||
+    # :start always validates. Starting a bot is exactly when a delisted pair must be refused, and
+    # for Bots::DcaIndex this is the ONLY gate — it has no validate_tickers_available of its own and
+    # relied on this validation firing during start's save.
+    return unless validation_context == :start ||
+                  exchange_id_changed? ||
                   asset_id_setting_keys.any? { |key| public_send("#{key}_changed?") }
     return if exchange_supports_current_assets?
 

--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -105,6 +105,25 @@ module Bot::AssetConfigurable
 
   def validate_bot_exchange
     return if stopped? || deleted? || archived?
+    # Only when the exchange or the assets are actually being CHANGED. This validation exists to
+    # refuse a bot moved onto a venue that cannot trade its pair; it has no business running on a
+    # save that touches neither.
+    #
+    # trading_enabled is served by market data, so an upstream revocation lands under a RUNNING bot.
+    # Bot::ActionJob's per-tick `bot.update!` would then raise RecordInvalid, the rescue would flip
+    # the bot to :retrying and re-raise on the branch that does NOT reschedule, and no retry_on
+    # covers RecordInvalid — the bot silently stops ticking. :start still re-validates, which is the
+    # right place to refuse a delisted pair.
+    #
+    # Not settings_changed?: Bot::Startable#disable_starting_time! dirties settings and saves from
+    # inside the same tick, so a broad guard would still let this fire.
+    #
+    # `_changed?`, not the `_was` comparison used by validate_unchangeable_assets below: for a
+    # store_accessor the `_was` reader returns nil when the attribute is unchanged, so comparing it
+    # against the current value is always true. That method gets away with it because it returns
+    # early unless settings_changed?; here there is no such gate.
+    return unless exchange_id_changed? ||
+                  asset_id_setting_keys.any? { |key| public_send("#{key}_changed?") }
     return if exchange_supports_current_assets?
 
     errors.add(:exchange, :unsupported, message: I18n.t('errors.bots.exchange_asset_mismatch', exchange_name: exchange.name))

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -30,7 +30,9 @@ class Bots::DcaIndex < Bot
   validates :num_coins, presence: true, numericality: { greater_than_or_equal_to: MIN_COINS, less_than_or_equal_to: MAX_COINS }
   validates :allocation_flattening, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
   validates :index_type, presence: true, inclusion: { in: [INDEX_TYPE_TOP, INDEX_TYPE_CATEGORY] }
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_interval, on: :update

--- a/app/models/bots/dca_single_asset.rb
+++ b/app/models/bots/dca_single_asset.rb
@@ -8,7 +8,9 @@ class Bots::DcaSingleAsset < Bot
                  :interval
 
   validates :quote_amount, presence: true, numericality: { greater_than: 0 }
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_interval, on: :update

--- a/app/models/bots/signal.rb
+++ b/app/models/bots/signal.rb
@@ -5,7 +5,9 @@ class Bots::Signal < Bot
                  :base_asset_id,
                  :quote_asset_id
 
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_exchange, on: :update

--- a/app/models/exchange/synchronizer.rb
+++ b/app/models/exchange/synchronizer.rb
@@ -37,10 +37,13 @@ module Exchange::Synchronizer
     @coingecko ||= MarketData.coingecko
   end
 
+  # Upcased: the map is keyed on CoinGecko's casing while the venue reports its own. Bitget
+  # publishes baseCoin "rON" where CoinGecko says "RON", and an exact-case miss silently drops a
+  # live pair via the `next if blank?` below. Same fix as data-api's catalogue join.
   def external_id_from_symbol(symbol)
     raise 'Call set_symbol_to_external_id_hash first' unless @symbol_to_external_id_hash.present?
 
-    @symbol_to_external_id_hash[symbol]
+    @symbol_to_external_id_hash[symbol.to_s.upcase]
   end
 
   def external_ids
@@ -54,7 +57,7 @@ module Exchange::Synchronizer
       hash = {}
       coingecko_tickers.each do |ticker|
         [%w[base coin_id], %w[target target_coin_id]].each do |symbol_key, external_id_key|
-          symbol = ticker[symbol_key]
+          symbol = ticker[symbol_key].to_s.upcase
           external_id = ticker[external_id_key] || eodhd_external_id_for_symbol(symbol)
           next if external_id.blank?
 

--- a/app/models/exchanges/bitget.rb
+++ b/app/models/exchanges/bitget.rb
@@ -90,7 +90,11 @@ class Exchanges::Bitget < Exchange
           base_decimals: quantity_precision,
           quote_decimals: quote_precision,
           price_decimals: price_precision,
-          available: status == 'online'
+          # Listed and tradable are two different facts. Folding an offline pair into
+          # `available: false` made this the only venue where the two sync paths disagree:
+          # the direct sync would mark the pair unavailable while market data marks it listed.
+          available: true,
+          trading_enabled: status == 'online'
         }
       end.compact
     end

--- a/app/models/exchanges/kraken.rb
+++ b/app/models/exchanges/kraken.rb
@@ -125,7 +125,13 @@ class Exchanges::Kraken < Exchange
   end
 
   def get_tickers_prices(force: false, symbols: nil)
-    cache_key = "exchange_#{id}_prices"
+    # `symbols:` was declared and ignored, so the per-pair fallback below asked the venue about
+    # every available ticker the bulk endpoint had omitted — on a real tenant 184 sequential calls
+    # per cache miss, through the shared exchange proxy, once a minute. Callers ask for one pair.
+    # The cache key carries the requested set: the cached hash only contains the fallbacks resolved
+    # for that set, so sharing one key across different callers would serve them a missing pair.
+    wanted = Array(symbols).presence
+    cache_key = ["exchange_#{id}_prices", wanted&.sort&.join(',')].compact.join(':')
     tickers_prices = Rails.cache.fetch(cache_key, expires_in: 1.minute, force:) do
       result = client.get_ticker_information
       return result if result.failure?
@@ -140,12 +146,15 @@ class Exchanges::Kraken < Exchange
         prices_hash[ticker] = price
       end
 
-      missing_tickers = tickers.available.pluck(:ticker) - prices_hash.keys
+      missing_tickers = (wanted || tickers.available.pluck(:ticker)) - prices_hash.keys
       missing_tickers.each do |ticker|
         result = client.get_ticker_information(pair: ticker)
         return result if result.failure?
 
         error = Utilities::Hash.dig_or_raise(result.data, 'error')
+        # A pair the venue no longer knows is this bot's problem, not everyone's: failing the whole
+        # fetch blanks live prices for every Kraken bot in the container.
+        next if error.any? { |e| e.to_s.include?('Unknown asset pair') }
         return Result::Failure.new(*error) if error.any?
 
         asset_ticker_info = Utilities::Hash.dig_or_raise(result.data, 'result').map { |_, v| v }.first

--- a/app/models/exchanges/mexc.rb
+++ b/app/models/exchanges/mexc.rb
@@ -77,7 +77,10 @@ class Exchanges::Mexc < Exchange
                                                          'quotePrecision')
                           end,
           available: true,
-          trading_enabled: status == '1'
+          # status is "1" for every symbol MEXC lists, including the ones it will reject a spot
+          # order for. isSpotTradingAllowed is the real gate. Kept in step with honeymaker's
+          # copy, which data-api uses — both are driven by the same captured fixture bytes.
+          trading_enabled: status == '1' && product['isSpotTradingAllowed'] != false
         }
       end.compact
     end

--- a/test/fixtures/exchanges/mexc_exchange_info.json
+++ b/test/fixtures/exchanges/mexc_exchange_info.json
@@ -1,0 +1,64 @@
+{
+  "_provenance": "Real capture: GET https://api.mexc.com/api/v3/exchangeInfo (2026-09-05), trimmed to two symbols and to the fields this parser reads. MEXC returns status \"1\" for every symbol and PERCENT_PRICE_BY_SIDE as its only filter \u2014 it emits neither \"TRADING\" nor LOT_SIZE/PRICE_FILTER/MIN_NOTIONAL. Re-capture and diff rather than hand-editing; mexc_test.rb asserts this file's SHA-256.",
+  "timezone": "CST",
+  "symbols": [
+    {
+      "symbol": "METALUSDT",
+      "status": "1",
+      "baseAsset": "METAL",
+      "baseAssetPrecision": 2,
+      "quoteAsset": "USDT",
+      "quotePrecision": 5,
+      "quoteAssetPrecision": 5,
+      "orderTypes": [
+        "LIMIT",
+        "MARKET",
+        "LIMIT_MAKER"
+      ],
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": false,
+      "quoteAmountPrecision": "1",
+      "baseSizePrecision": "0.1",
+      "permissions": [
+        "SPOT"
+      ],
+      "filters": [
+        {
+          "filterType": "PERCENT_PRICE_BY_SIDE",
+          "bidMultiplierUp": "0.2",
+          "askMultiplierDown": "0.2"
+        }
+      ],
+      "maxQuoteAmount": "2000000"
+    },
+    {
+      "symbol": "PALMAIUSDT",
+      "status": "1",
+      "baseAsset": "PALMAI",
+      "baseAssetPrecision": 2,
+      "quoteAsset": "USDT",
+      "quotePrecision": 4,
+      "quoteAssetPrecision": 4,
+      "orderTypes": [
+        "LIMIT",
+        "MARKET",
+        "LIMIT_MAKER"
+      ],
+      "isSpotTradingAllowed": false,
+      "isMarginTradingAllowed": false,
+      "quoteAmountPrecision": "1",
+      "baseSizePrecision": "0",
+      "permissions": [
+        "SPOT"
+      ],
+      "filters": [
+        {
+          "filterType": "PERCENT_PRICE_BY_SIDE",
+          "bidMultiplierUp": "0.2",
+          "askMultiplierDown": "0.2"
+        }
+      ],
+      "maxQuoteAmount": "2000000"
+    }
+  ]
+}

--- a/test/jobs/bot/action_job_test.rb
+++ b/test/jobs/bot/action_job_test.rb
@@ -11,6 +11,38 @@ module ActionJobBehaviorTests
   included do
     # A stop from another process (user click, admin deactivation sweep) landing mid-execution
     # must not be overwritten by the job's post-execution status writes (resurrection race).
+    # A pair can lose trading_enabled under a RUNNING bot: the flag is served by market data, not
+    # decided by the container, so an upstream revocation reaches every tenant on its own schedule.
+    # ActionJob's per-tick `bot.update!` runs validate_bot_exchange (registered on: :update), which
+    # skipped only stopped/deleted/archived bots — so the tick raised RecordInvalid, the rescue
+    # flipped the bot to :retrying and re-raised on the branch that does NOT reschedule, and
+    # ActiveJob had no retry_on for it. The bot simply stopped ticking, with one email.
+    test 'a tick on a bot whose pair lost trading_enabled still schedules the next run' do
+      bot = create_bot
+      setup_action_job_mocks(bot)
+      bot.stubs(:execute_action).returns(Result::Success.new)
+      Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+      assert_nothing_raised { Bot::ActionJob.new.perform(bot) }
+      assert_not_equal 'retrying', bot.reload.status
+    end
+
+    # The same tick on a bot whose delayed start is being cleared. disable_starting_time! dirties
+    # `settings` and calls save! from inside ActionJob, so a guard keyed on settings_changed?
+    # passes the test above and still kills this bot.
+    test 'a delayed-start bot survives its first tick on a revoked pair' do
+      bot = create_bot
+      bot.start_time_enabled = true
+      bot.set_missed_quote_amount
+      bot.save!
+      setup_action_job_mocks(bot)
+      bot.stubs(:execute_action).returns(Result::Success.new)
+      Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+      assert_nothing_raised { Bot::ActionJob.new.perform(bot) }
+      assert_not_equal 'retrying', bot.reload.status
+    end
+
     test 'does not resurrect a bot stopped externally mid-execution' do
       bot = create_bot
       setup_action_job_mocks(bot)

--- a/test/models/bots/dca_index_test.rb
+++ b/test/models/bots/dca_index_test.rb
@@ -498,4 +498,26 @@ class Bots::DcaIndexTest < ActiveSupport::TestCase
   def in_index_external_ids(bot)
     bot.bot_index_assets.in_index.includes(:asset).map { |bia| bia.asset.external_id }.sort
   end
+  # An index bot has no validate_tickers_available of its own; it relied on validate_bot_exchange
+  # firing during start's save. The tick-safety guard on that validation must not take the
+  # start-time gate with it, or a bot whose venue can no longer trade its index would start and
+  # then fail on every order.
+  test 'an index bot whose quote has no tradable pairs cannot start' do
+    MarketData.stubs(:configured?).returns(true)
+    bot = create(:dca_index, exchange: @exchange, quote_asset: @quote)
+    @exchange.tickers.update_all(trading_enabled: false)
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+
+    assert_not bot.start
+  end
+
+  test 'an index bot whose venue still trades its index can start' do
+    MarketData.stubs(:configured?).returns(true)
+    bot = create(:dca_index, exchange: @exchange, quote_asset: @quote)
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+
+    assert bot.start
+  end
 end

--- a/test/models/bots/dca_single_asset_test.rb
+++ b/test/models/bots/dca_single_asset_test.rb
@@ -920,4 +920,36 @@ class Bots::DcaSingleAssetTest < ActiveSupport::TestCase
     fresh = Bots::DcaSingleAsset.find(bot.id)
     assert fresh.start_blocked_by_unavailable_ticker?, 'unavailable ticker → blocked'
   end
+  # The tick-safety guard on validate_bot_exchange narrows WHEN the validation runs; it must not
+  # stop it running when the exchange or the assets are the thing actually being changed.
+  test 'moving a bot onto a venue that cannot trade its pair is still rejected' do
+    bot = create(:dca_single_asset)
+    other = create(:kraken_exchange)
+
+    bot.exchange = other
+
+    assert_not bot.valid?(:update)
+    assert_includes bot.errors.attribute_names, :exchange
+  end
+
+  test 'changing an asset to one the venue does not list is still rejected' do
+    bot = create(:dca_single_asset)
+    stranger = create(:asset, symbol: 'ZZZ', name: 'Unlisted', external_id: 'unlisted-zzz')
+
+    bot.base_asset_id = stranger.id
+
+    assert_not bot.valid?(:update)
+    assert_includes bot.errors.attribute_names, :exchange
+  end
+
+  # The tick shape: neither exchange nor assets change, so a revoked pair must not block the save
+  # that keeps the bot running.
+  test 'a save that changes neither exchange nor assets is not blocked by a revoked pair' do
+    bot = create(:dca_single_asset, :started)
+    Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+    bot.last_action_job_at = Time.current
+
+    assert bot.valid?(:update)
+  end
 end

--- a/test/models/exchange/synchronizer_test.rb
+++ b/test/models/exchange/synchronizer_test.rb
@@ -48,4 +48,21 @@ class Exchange::SynchronizerTest < ActiveSupport::TestCase
     assert btc_usd.reload.available
     assert_not eth_usd.reload.available, 'pair absent from the feed is delisted'
   end
+  # B10. The self-hosted twin of data-api's join bug: the CoinGecko symbol->coin_id map is keyed on
+  # CoinGecko's casing while the venue reports its own. Bitget publishes baseCoin "rON" where
+  # CoinGecko says "RON", so external_id_from_symbol missed and `next if blank?` dropped a live
+  # pair with no trace. Fixing only data-api leaves every CoinGecko-provider install blind.
+  test 'resolves a CoinGecko symbol to a venue symbol case-insensitively' do
+    ron = create(:asset, symbol: 'RON', name: 'Ronin', external_id: 'ronin')
+    @exchange.send(:set_symbol_to_external_id_hash,
+                   [{ 'base' => 'RON', 'coin_id' => 'ronin', 'target' => 'USD', 'target_coin_id' => 'usd' }])
+
+    sync([{ base: 'rON', quote: 'USD', ticker: 'rONUSD', available: true, trading_enabled: true,
+            minimum_base_size: 0.1, minimum_quote_size: 5, maximum_base_size: nil, maximum_quote_size: nil,
+            base_decimals: 4, quote_decimals: 2, price_decimals: 2 }])
+
+    ticker = @exchange.tickers.find_by(base: 'rON', quote: 'USD')
+    assert_not_nil ticker, 'a mixed-case venue symbol must still resolve'
+    assert_equal ron.id, ticker.base_asset_id
+  end
 end

--- a/test/models/exchanges/bitget_test.rb
+++ b/test/models/exchanges/bitget_test.rb
@@ -281,4 +281,21 @@ class Exchanges::BitgetTest < ActiveSupport::TestCase
     assert_predicate result, :success?
     assert_equal :closed, result.data[:status]
   end
+  # B9. Bitget emitted `available: status == 'online'` and no trading_enabled at all — one concept
+  # in two columns with opposite failure modes on the two sync paths. Every other venue reports an
+  # offline pair as listed-but-not-tradable.
+  test 'an offline Bitget pair is listed but not trading_enabled' do
+    products = [{
+      'symbol' => 'BTCUSDT', 'baseCoin' => 'BTC', 'quoteCoin' => 'USDT', 'status' => 'offline',
+      'minTradeAmount' => '0.0001', 'minTradeUSDT' => '5', 'maxTradeAmount' => '1000',
+      'quantityPrecision' => '4', 'quotePrecision' => '6', 'pricePrecision' => '2'
+    }]
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_symbols).returns(Result::Success.new({ 'data' => products }))
+
+    info = @exchange.get_tickers_info(force: true).data.first
+
+    assert info[:available], 'an offline pair is still listed'
+    assert_not info[:trading_enabled], 'but it cannot be traded'
+  end
 end

--- a/test/models/exchanges/kraken_test.rb
+++ b/test/models/exchanges/kraken_test.rb
@@ -463,4 +463,42 @@ class Exchanges::KrakenTest < ActiveSupport::TestCase
     assert_predicate limit, :failure?
     assert limit.data[:unacknowledged]
   end
+  # B7. get_tickers_prices declares `symbols:` and never read it. The fallback loop iterated EVERY
+  # available ticker the bulk endpoint omitted — 184 on a measured tenant — one sequential proxy
+  # call each, on every 1-minute cache miss. Callers ask for one pair.
+  test 'the price fallback asks only for the requested symbols' do
+    %w[AAAEUR BBBEUR CCCEUR].each do |t|
+      create(:ticker, exchange: @exchange, ticker: t, base_asset: create(:asset, symbol: t[0..2]),
+                      quote_asset: create(:asset, symbol: "Q#{t}"))
+    end
+    @exchange.set_client
+    client = @exchange.send(:client)
+    client.stubs(:get_ticker_information).returns(Result::Success.new({ 'error' => [], 'result' => {} }))
+    client.expects(:get_ticker_information).with(pair: 'BBBEUR').never
+    client.expects(:get_ticker_information).with(pair: 'CCCEUR').never
+    client.expects(:get_ticker_information).with(pair: 'AAAEUR')
+          .returns(Result::Success.new({ 'error' => [], 'result' => { 'AAAEUR' => { 'c' => %w[100.0 1] } } })).once
+
+    result = @exchange.get_tickers_prices(symbols: ['AAAEUR'], force: true)
+
+    assert result.success?
+    assert_equal 100.0.to_d, result.data['AAAEUR']
+  end
+
+  # B7b. One fossilised delisted pair returned Result::Failure for the whole fetch, blanking live
+  # metrics for every Kraken bot in the container.
+  test 'an unknown pair does not fail the whole price fetch' do
+    create(:ticker, exchange: @exchange, ticker: 'DEADEUR', base_asset: create(:asset, symbol: 'DEAD'),
+                    quote_asset: create(:asset, symbol: 'QDEAD'))
+    @exchange.set_client
+    client = @exchange.send(:client)
+    client.stubs(:get_ticker_information)
+          .returns(Result::Success.new({ 'error' => [], 'result' => { 'XBTEUR' => { 'c' => %w[50000.0 1] } } }))
+    client.stubs(:get_ticker_information).with(pair: 'DEADEUR')
+          .returns(Result::Success.new({ 'error' => ['EQuery:Unknown asset pair'], 'result' => {} }))
+
+    result = @exchange.get_tickers_prices(symbols: ['DEADEUR'], force: true)
+
+    assert result.success?, 'a delisted pair must not blank prices for every other bot'
+  end
 end

--- a/test/models/exchanges/mexc_test.rb
+++ b/test/models/exchanges/mexc_test.rb
@@ -82,4 +82,32 @@ class Exchanges::MexcTest < ActiveSupport::TestCase
     assert result.success?
     assert_equal true, result.data
   end
+  # B8. The container has its own MEXC parser (data-api uses honeymaker's; the container cannot,
+  # because honeymaker's connection takes no proxy and would put the container's own IP at MEXC).
+  # Two implementations of one contract, so both are driven from the SAME captured bytes and both
+  # assert its digest — a hand-edit in either repo would otherwise let them drift again.
+  def mexc_exchange_info
+    JSON.parse(File.read(Rails.root.join('test/fixtures/exchanges/mexc_exchange_info.json')))
+  end
+
+  test 'the MEXC fixture is the same bytes honeymaker tests against' do
+    path = Rails.root.join('test/fixtures/exchanges/mexc_exchange_info.json')
+    assert_equal '13a65c0c8ebde52fac4cdca9a5be9d9a18ba7b5438c496b1b30606cf52fd60d3',
+                 Digest::SHA256.hexdigest(File.read(path))
+    assert_equal '1', mexc_exchange_info['symbols'].first['status']
+  end
+
+  test 'get_tickers_info reads MEXC status and spot permission' do
+    @exchange.set_client
+    @exchange.send(:client).stubs(:exchange_information).returns(Result::Success.new(mexc_exchange_info))
+
+    result = @exchange.get_tickers_info(force: true)
+
+    assert result.success?
+    allowed = result.data.find { |t| t[:ticker] == 'METALUSDT' }
+    disallowed = result.data.find { |t| t[:ticker] == 'PALMAIUSDT' }
+    assert allowed[:trading_enabled], 'status "1" plus spot permission is tradable'
+    assert disallowed[:available], 'still listed'
+    assert_not disallowed[:trading_enabled], 'MEXC rejects a spot order for this symbol'
+  end
 end


### PR DESCRIPTION
**Merge this before anything that can revoke a pair.** It closes a way for a running bot to stop
trading with no further ticks and no way back except a manual restart.

## A revoked pair kills a running bot

`trading_enabled` comes from market data, not from the container, so an upstream revocation arrives
under a bot that is already running.

`Bot::ActionJob` updates the bot on every tick to record `last_action_job_at`.
`validate_bot_exchange` is registered `on: :update` and skipped only stopped, deleted and archived
bots, so that update raised `RecordInvalid`. The rescue flipped the bot to `:retrying` and re-raised
on the branch that does not reschedule, and no `retry_on` covers `RecordInvalid` — so the bot stopped
ticking altogether, having sent one email. The hazard is named in a comment two lines above the very
update it happens on.

The validation now runs only when the exchange or the assets are the thing being changed, which is
what it was written to refuse, and always in the `:start` context — starting a bot is exactly when a
delisted pair must be turned down.

Two things that look like details and are not:

- It keys on the per-key `_changed?` predicates rather than `settings_changed?`, because
  `Bot::Startable#disable_starting_time!` dirties settings and saves from inside the same tick.
- It avoids the `_was` comparison used by `validate_unchangeable_assets`: for a `store_accessor` the
  `_was` reader returns `nil` while the attribute is unchanged, so that comparison is always true
  unless it sits behind a `settings_changed?` gate, as it does there.

Both contexts are registered in one `validate` call. Two separate lines naming the same method do
not compose — Rails dedupes validation callbacks by filter symbol, so the second silently replaces
the first.

## Four exchange adapters that disagreed with their venue

**Kraken prices.** `get_tickers_prices` declared a `symbols:` parameter and never read it. The
per-pair fallback iterated every available ticker the bulk endpoint had omitted — one sequential
request each, on every one-minute cache miss — while callers ask for a single pair. It now asks only
for what was requested, with the requested set in the cache key so two callers cannot be served each
other's gaps. A pair the venue no longer knows is skipped rather than failing the whole fetch, which
used to blank live prices for every Kraken bot at once.

**MEXC.** `status` is `"1"` for every symbol MEXC lists, including the ones it rejects a spot order
for, so `isSpotTradingAllowed` is the real gate. This is the same contract the market-data service
implements through honeymaker; the container needs its own copy because honeymaker's connection
cannot be routed through an outbound proxy. Both are now driven by the same captured response bytes,
and both assert its digest, so the two cannot drift again unnoticed.

**Bitget.** An offline pair was reported as not listed rather than as listed and not tradable,
emitting no `trading_enabled` at all. It was the only venue where the two sync paths disagreed about
the same pair.

**Symbol resolution.** The market-data symbol map is keyed on the data provider's casing while a
venue reports its own, so a pair whose venue symbol is mixed case missed the lookup and was dropped
with no trace. Both sides are compared upcased.