### PR TITLE
Answer "can I trade this here" from one relation per screen

### DIFF
--- a/app/controllers/concerns/bots/searchable.rb
+++ b/app/controllers/concerns/bots/searchable.rb
@@ -19,7 +19,7 @@ module Bots::Searchable
 
     # Exchanges are display-only, so resolve them for the page rows only — never for the full
     # (now ~10k-asset) result set. See attach_exchanges.
-    attach_exchanges(page)
+    attach_exchanges(page, bot, asset_type)
   end
 
   def render_asset_page(bot:, asset_field:)
@@ -46,27 +46,24 @@ module Bots::Searchable
   end
 
   # Resolve the exchanges each row trades on, for the (≤ ASSET_PAGE_SIZE) page rows ONLY.
-  # Same source as before — exchange_assets.available + Exchange.available — so output is
-  # identical, but membership is a scoped `WHERE asset_id IN (…page ids)` instead of an
-  # O(assets × Σ exchange_assets) Array#include? over every asset. binance_name is derived
-  # independently of the page (Binance available + has assets), so the binance_us → binance
-  # collapse still applies on pages that contain no Binance asset.
-  def attach_exchanges(rows)
+  #
+  # Same relation as the rows themselves (Bot#offered_tickers), a different pluck. It used to be
+  # exchange_assets — "is this asset listed on this venue" — while the rows and the exchange step
+  # ask "is this pair tradable here". The two answers diverged three ways: exchange_assets is never
+  # revoked, it ignores trading_enabled, and it knows nothing about the bot's chosen counterpart or
+  # venue. A row could therefore advertise a venue the very next screen refused.
+  def attach_exchanges(rows, bot, asset_type)
     return rows if rows.empty?
 
-    ids = rows.map(&:first)
     available_exchanges = Exchange.available.index_by(&:id)
     exchanges_by_asset = Hash.new { |hash, key| hash[key] = [] }
-    ExchangeAsset.available
-                 .where(asset_id: ids, exchange_id: available_exchanges.keys)
-                 .pluck(:asset_id, :exchange_id)
-                 .each do |asset_id, exchange_id|
+    bot.offered_exchange_ids_by_asset(rows.map(&:first), asset_type:).each do |asset_id, exchange_id|
       exchange = available_exchanges[exchange_id]
       exchanges_by_asset[asset_id] << [exchange.name_id, exchange.name] if exchange
     end
 
     binance = available_exchanges.values.find { |exchange| exchange.name_id == 'binance' }
-    binance_name = binance.name if binance && ExchangeAsset.available.where(exchange_id: binance.id).exists?
+    binance_name = binance.name if binance && Ticker.available.trading_enabled.exists?(exchange_id: binance.id)
 
     rows.map do |id, symbol, name, color, category, image_url|
       [id, symbol, name, color, category, image_url, parse_exchanges(exchanges_by_asset[id], binance_name)]

--- a/app/jobs/index/sync_from_coingecko_job.rb
+++ b/app/jobs/index/sync_from_coingecko_job.rb
@@ -43,8 +43,14 @@ class Index::SyncFromCoingeckoJob < ApplicationJob
       # Take top 5 for display purposes
       top_coins_for_display = valid_coins.first(Index::ExchangeAvailability::TOP_COINS_COUNT)
 
-      # Calculate available exchanges from live database using ALL valid coins
-      available_exchanges = Index.calculate_available_exchanges(top_coins: valid_coins)
+      # Top coins per exchange FIRST, then availability qualified against exactly those coins.
+      # Qualifying on the whole category while exporting only the top ten offered venues whose
+      # quote picker was then empty, because the picker restricts itself to the exported set.
+      top_coins_by_exchange = calculate_top_coins_by_exchange(valid_coins)
+      available_exchanges = top_coins_by_exchange.filter_map do |exchange_type, coins|
+        count = Index.calculate_available_exchanges(top_coins: coins)[exchange_type]
+        [exchange_type, count] if count
+      end.to_h
 
       # Skip indices with no exchange availability
       next if available_exchanges.empty?
@@ -53,9 +59,6 @@ class Index::SyncFromCoingeckoJob < ApplicationJob
         external_id: category['id'],
         source: Index::SOURCE_COINGECKO
       )
-
-      # Calculate top coins per exchange
-      top_coins_by_exchange = calculate_top_coins_by_exchange(valid_coins)
 
       attrs = {
         name: strip_brackets(category['name']),
@@ -97,7 +100,7 @@ class Index::SyncFromCoingeckoJob < ApplicationJob
     result = {}
 
     Exchange.available.each do |exchange|
-      exchange_coin_ids = exchange.tickers.available
+      exchange_coin_ids = exchange.tickers.available.trading_enabled
                                   .joins(:base_asset)
                                   .where(assets: { external_id: valid_coins })
                                   .pluck('assets.external_id')

--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -40,24 +40,42 @@ module Bot::AssetConfigurable
     Exchange.where(id: exchange_ids)
   end
 
+  # The single relation behind the asset step: every ticker this bot could pick an asset from,
+  # given its current venue and counterpart. The rows on the step and the exchange logos beside
+  # them are two different plucks off THIS — so they cannot disagree, which they previously did
+  # (the rows came from here, the logos from exchange_assets).
+  #
   # @param asset_type: :base_asset or :quote_asset
-  def available_assets_for_current_settings(asset_type:, include_exchanges: false)
+  def offered_tickers(asset_type:)
     available_exchanges = exchange.present? ? [exchange] : Exchange.available
+    scope = Ticker.available.trading_enabled.where(exchange: available_exchanges)
 
     case asset_type
     when :base_asset
-      scope = Ticker.available.trading_enabled
-                    .where(exchange: available_exchanges)
-                    .where.not(base_asset_id: [base_asset_id, quote_asset_id])
+      scope = scope.where.not(base_asset_id: [base_asset_id, quote_asset_id])
       scope = scope.where(quote_asset_id:) if quote_asset_id.present?
     when :quote_asset
-      scope = Ticker.available.trading_enabled
-                    .where(exchange: available_exchanges)
-                    .where.not(quote_asset_id: [base_asset_id, quote_asset_id])
+      scope = scope.where.not(quote_asset_id: [base_asset_id, quote_asset_id])
       scope = scope.where(base_asset_id:) if base_asset_id.present?
     end
-    asset_ids = scope.pluck("#{asset_type}_id").uniq
-    include_exchanges ? Asset.includes(:exchanges).where(id: asset_ids) : Asset.where(id: asset_ids)
+    scope
+  end
+
+  # @param asset_type: :base_asset or :quote_asset
+  def available_assets_for_current_settings(asset_type:)
+    Asset.where(id: offered_tickers(asset_type:).distinct.pluck("#{asset_type}_id"))
+  end
+
+  # [[asset_id, exchange_id], ...] for the given asset ids only. The id filter goes into SQL:
+  # offered_tickers is not narrowed by asset, so on a stock venue it spans thousands of rows and
+  # plucking it whole on every wizard render would be a per-render regression.
+  def offered_exchange_ids_by_asset(ids, asset_type:)
+    return [] if ids.blank?
+
+    offered_tickers(asset_type:)
+      .where("#{asset_type}_id": ids)
+      .distinct
+      .pluck("#{asset_type}_id", :exchange_id)
   end
 
   private

--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -122,7 +122,11 @@ module Bot::AssetConfigurable
     # store_accessor the `_was` reader returns nil when the attribute is unchanged, so comparing it
     # against the current value is always true. That method gets away with it because it returns
     # early unless settings_changed?; here there is no such gate.
-    return unless exchange_id_changed? ||
+    # :start always validates. Starting a bot is exactly when a delisted pair must be refused, and
+    # for Bots::DcaIndex this is the ONLY gate — it has no validate_tickers_available of its own and
+    # relied on this validation firing during start's save.
+    return unless validation_context == :start ||
+                  exchange_id_changed? ||
                   asset_id_setting_keys.any? { |key| public_send("#{key}_changed?") }
     return if exchange_supports_current_assets?
 

--- a/app/models/bot/asset_configurable.rb
+++ b/app/models/bot/asset_configurable.rb
@@ -105,6 +105,25 @@ module Bot::AssetConfigurable
 
   def validate_bot_exchange
     return if stopped? || deleted? || archived?
+    # Only when the exchange or the assets are actually being CHANGED. This validation exists to
+    # refuse a bot moved onto a venue that cannot trade its pair; it has no business running on a
+    # save that touches neither.
+    #
+    # trading_enabled is served by market data, so an upstream revocation lands under a RUNNING bot.
+    # Bot::ActionJob's per-tick `bot.update!` would then raise RecordInvalid, the rescue would flip
+    # the bot to :retrying and re-raise on the branch that does NOT reschedule, and no retry_on
+    # covers RecordInvalid — the bot silently stops ticking. :start still re-validates, which is the
+    # right place to refuse a delisted pair.
+    #
+    # Not settings_changed?: Bot::Startable#disable_starting_time! dirties settings and saves from
+    # inside the same tick, so a broad guard would still let this fire.
+    #
+    # `_changed?`, not the `_was` comparison used by validate_unchangeable_assets below: for a
+    # store_accessor the `_was` reader returns nil when the attribute is unchanged, so comparing it
+    # against the current value is always true. That method gets away with it because it returns
+    # early unless settings_changed?; here there is no such gate.
+    return unless exchange_id_changed? ||
+                  asset_id_setting_keys.any? { |key| public_send("#{key}_changed?") }
     return if exchange_supports_current_assets?
 
     errors.add(:exchange, :unsupported, message: I18n.t('errors.bots.exchange_asset_mismatch', exchange_name: exchange.name))

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -114,8 +114,12 @@ class Bots::DcaIndex < Bot
     Exchange.where(id: exchange_ids)
   end
 
+  # Index bots have no base_asset_id of their own, so they cannot share the single-pair
+  # offered_tickers; they narrow by the index's member coins instead. Same contract: the step's
+  # rows and its exchange logos are two plucks off this one relation.
+  #
   # @param asset_type: :quote_asset (only quote_asset supported for Index bots)
-  def available_assets_for_current_settings(asset_type:, include_exchanges: false)
+  def offered_tickers(asset_type: :quote_asset)
     available_exchanges = exchange.present? ? [exchange] : Exchange.available
     scope = Ticker.available.trading_enabled.where(exchange: available_exchanges)
 
@@ -129,10 +133,16 @@ class Bots::DcaIndex < Bot
       end
     end
 
-    asset_ids = scope.group(:quote_asset_id)
-                     .having('COUNT(*) >= ?', Index::ExchangeAvailability::MINIMUM_SUPPORTED_COINS)
-                     .pluck(:quote_asset_id)
-    include_exchanges ? Asset.includes(:exchanges).where(id: asset_ids) : Asset.where(id: asset_ids)
+    scope
+  end
+
+  # @param asset_type: :quote_asset (only quote_asset supported for Index bots)
+  def available_assets_for_current_settings(asset_type:)
+    asset_ids = offered_tickers(asset_type:)
+                .group(:quote_asset_id)
+                .having('COUNT(*) >= ?', Index::ExchangeAvailability::MINIMUM_SUPPORTED_COINS)
+                .pluck(:quote_asset_id)
+    Asset.where(id: asset_ids)
   end
 
   # Returns { quote_asset_id => [Asset, Asset, ...] } for the bot's current

--- a/app/models/bots/dca_index.rb
+++ b/app/models/bots/dca_index.rb
@@ -30,7 +30,9 @@ class Bots::DcaIndex < Bot
   validates :num_coins, presence: true, numericality: { greater_than_or_equal_to: MIN_COINS, less_than_or_equal_to: MAX_COINS }
   validates :allocation_flattening, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
   validates :index_type, presence: true, inclusion: { in: [INDEX_TYPE_TOP, INDEX_TYPE_CATEGORY] }
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_interval, on: :update

--- a/app/models/bots/dca_multi_asset.rb
+++ b/app/models/bots/dca_multi_asset.rb
@@ -131,7 +131,10 @@ class Bots::DcaMultiAsset < Bot
     Exchange.where(id: eligible_pairs(venues: Exchange.tradeable).map(&:first).uniq)
   end
 
-  def available_assets_for_current_settings(asset_type:, include_exchanges: false)
+  # Exchange.tradeable, not Exchange.available: a retired venue must never re-enter the basket
+  # picker. That difference is why the three bot types keep their own offered_tickers rather than
+  # sharing one scope.
+  def offered_tickers(asset_type:)
     venues = exchange_id? ? Exchange.tradeable.where(id: exchange_id) : Exchange.tradeable
     scope = tickers_on(eligible_pairs(venues:))
     case asset_type
@@ -140,8 +143,11 @@ class Bots::DcaMultiAsset < Bot
     when :quote_asset
       scope = scope.where(base_asset_id: base_asset_ids) if base_asset_ids.any?
     end
-    asset_ids = scope.pluck("#{asset_type}_id").uniq
-    include_exchanges ? Asset.includes(:exchanges).where(id: asset_ids) : Asset.where(id: asset_ids)
+    scope
+  end
+
+  def available_assets_for_current_settings(asset_type:)
+    Asset.where(id: offered_tickers(asset_type:).distinct.pluck("#{asset_type}_id"))
   end
 
   def assets

--- a/app/models/bots/dca_single_asset.rb
+++ b/app/models/bots/dca_single_asset.rb
@@ -8,7 +8,9 @@ class Bots::DcaSingleAsset < Bot
                  :interval
 
   validates :quote_amount, presence: true, numericality: { greater_than: 0 }
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_interval, on: :update

--- a/app/models/bots/signal.rb
+++ b/app/models/bots/signal.rb
@@ -5,7 +5,9 @@ class Bots::Signal < Bot
                  :base_asset_id,
                  :quote_asset_id
 
-  validate :validate_bot_exchange, if: :exchange_id?, on: :update
+  # Both contexts, one registration: Rails dedupes validation callbacks by filter symbol, so a
+  # second `validate :validate_bot_exchange` would silently replace this one rather than add to it.
+  validate :validate_bot_exchange, if: :exchange_id?, on: %i[update start]
   validate :validate_external_ids, on: :update
   validate :validate_unchangeable_assets, on: :update
   validate :validate_unchangeable_exchange, on: :update

--- a/app/models/exchange/synchronizer.rb
+++ b/app/models/exchange/synchronizer.rb
@@ -37,10 +37,13 @@ module Exchange::Synchronizer
     @coingecko ||= MarketData.coingecko
   end
 
+  # Upcased: the map is keyed on CoinGecko's casing while the venue reports its own. Bitget
+  # publishes baseCoin "rON" where CoinGecko says "RON", and an exact-case miss silently drops a
+  # live pair via the `next if blank?` below. Same fix as data-api's catalogue join.
   def external_id_from_symbol(symbol)
     raise 'Call set_symbol_to_external_id_hash first' unless @symbol_to_external_id_hash.present?
 
-    @symbol_to_external_id_hash[symbol]
+    @symbol_to_external_id_hash[symbol.to_s.upcase]
   end
 
   def external_ids
@@ -54,7 +57,7 @@ module Exchange::Synchronizer
       hash = {}
       coingecko_tickers.each do |ticker|
         [%w[base coin_id], %w[target target_coin_id]].each do |symbol_key, external_id_key|
-          symbol = ticker[symbol_key]
+          symbol = ticker[symbol_key].to_s.upcase
           external_id = ticker[external_id_key] || eodhd_external_id_for_symbol(symbol)
           next if external_id.blank?
 

--- a/app/models/exchanges/bitget.rb
+++ b/app/models/exchanges/bitget.rb
@@ -90,7 +90,11 @@ class Exchanges::Bitget < Exchange
           base_decimals: quantity_precision,
           quote_decimals: quote_precision,
           price_decimals: price_precision,
-          available: status == 'online'
+          # Listed and tradable are two different facts. Folding an offline pair into
+          # `available: false` made this the only venue where the two sync paths disagree:
+          # the direct sync would mark the pair unavailable while market data marks it listed.
+          available: true,
+          trading_enabled: status == 'online'
         }
       end.compact
     end

--- a/app/models/exchanges/kraken.rb
+++ b/app/models/exchanges/kraken.rb
@@ -125,7 +125,13 @@ class Exchanges::Kraken < Exchange
   end
 
   def get_tickers_prices(force: false, symbols: nil)
-    cache_key = "exchange_#{id}_prices"
+    # `symbols:` was declared and ignored, so the per-pair fallback below asked the venue about
+    # every available ticker the bulk endpoint had omitted — on a real tenant 184 sequential calls
+    # per cache miss, through the shared exchange proxy, once a minute. Callers ask for one pair.
+    # The cache key carries the requested set: the cached hash only contains the fallbacks resolved
+    # for that set, so sharing one key across different callers would serve them a missing pair.
+    wanted = Array(symbols).presence
+    cache_key = ["exchange_#{id}_prices", wanted&.sort&.join(',')].compact.join(':')
     tickers_prices = Rails.cache.fetch(cache_key, expires_in: 1.minute, force:) do
       result = client.get_ticker_information
       return result if result.failure?
@@ -140,12 +146,15 @@ class Exchanges::Kraken < Exchange
         prices_hash[ticker] = price
       end
 
-      missing_tickers = tickers.available.pluck(:ticker) - prices_hash.keys
+      missing_tickers = (wanted || tickers.available.pluck(:ticker)) - prices_hash.keys
       missing_tickers.each do |ticker|
         result = client.get_ticker_information(pair: ticker)
         return result if result.failure?
 
         error = Utilities::Hash.dig_or_raise(result.data, 'error')
+        # A pair the venue no longer knows is this bot's problem, not everyone's: failing the whole
+        # fetch blanks live prices for every Kraken bot in the container.
+        next if error.any? { |e| e.to_s.include?('Unknown asset pair') }
         return Result::Failure.new(*error) if error.any?
 
         asset_ticker_info = Utilities::Hash.dig_or_raise(result.data, 'result').map { |_, v| v }.first

--- a/app/models/exchanges/mexc.rb
+++ b/app/models/exchanges/mexc.rb
@@ -77,7 +77,10 @@ class Exchanges::Mexc < Exchange
                                                          'quotePrecision')
                           end,
           available: true,
-          trading_enabled: status == '1'
+          # status is "1" for every symbol MEXC lists, including the ones it will reject a spot
+          # order for. isSpotTradingAllowed is the real gate. Kept in step with honeymaker's
+          # copy, which data-api uses — both are driven by the same captured fixture bytes.
+          trading_enabled: status == '1' && product['isSpotTradingAllowed'] != false
         }
       end.compact
     end

--- a/app/models/index/exchange_availability.rb
+++ b/app/models/index/exchange_availability.rb
@@ -6,23 +6,29 @@ module Index::ExchangeAvailability
   DISPLAY_COINS_COUNT = 5
 
   class_methods do
-    # Calculate which exchanges support enough coins from the index
-    # @param top_coins [Array<String>] Array of CoinGecko coin IDs (external_ids)
+    # Which exchanges can actually host this index, and with how many coins.
+    #
+    # Counted PER QUOTE and over tradable pairs only, because that is the question the quote picker
+    # then asks (Bots::DcaIndex#available_assets_for_current_settings groups by quote_asset_id and
+    # requires MINIMUM_SUPPORTED_COINS per quote). Counting listed pairs across every quote at once
+    # offered venues whose quote list then came back empty — the same "the offer is not the answer"
+    # divergence as the asset step.
+    #
+    # @param top_coins [Array<String>] CoinGecko coin ids — the coins actually exported for the
+    #   venue, so availability can never be qualified on a wider set than the picker will use.
     # @return [Hash] Exchange types with coin counts, e.g. {"Exchanges::Binance" => 9}
     def calculate_available_exchanges(top_coins:)
       return {} if top_coins.blank?
 
-      result = {}
-
-      # Get asset IDs for the top coins
-      asset_ids_by_external_id = Asset.where(external_id: top_coins).pluck(:external_id, :id).to_h
-      asset_ids = asset_ids_by_external_id.values
-
+      asset_ids = Asset.where(external_id: top_coins).pluck(:id)
       return {} if asset_ids.empty?
 
-      # Count how many coins each exchange supports
+      result = {}
       Exchange.available.each do |exchange|
-        matching_count = exchange.tickers.available.where(base_asset_id: asset_ids).count
+        # `|| 0`: max on no matching tickers is nil, and nil >= MINIMUM_SUPPORTED_COINS raises.
+        matching_count = exchange.tickers.available.trading_enabled
+                                 .where(base_asset_id: asset_ids)
+                                 .group(:quote_asset_id).count.values.max || 0
         result[exchange.type] = matching_count if matching_count >= MINIMUM_SUPPORTED_COINS
       end
 
@@ -50,9 +56,20 @@ module Index::ExchangeAvailability
     available_exchanges[exchange_type.to_s] || 0
   end
 
-  # Recalculate available exchanges from current database state
+  # Recalculate available exchanges from current database state. Qualifies each venue against the
+  # coins actually exported for it, matching Index::SyncFromCoingeckoJob — otherwise a manual
+  # refresh would quietly restore the wider, wrong universe.
   def refresh_available_exchanges!
-    new_availability = self.class.calculate_available_exchanges(top_coins: top_coins)
+    per_exchange = top_coins_by_exchange.presence
+    new_availability =
+      if per_exchange
+        per_exchange.filter_map do |exchange_type, coins|
+          count = self.class.calculate_available_exchanges(top_coins: coins)[exchange_type]
+          [exchange_type, count] if count
+        end.to_h
+      else
+        self.class.calculate_available_exchanges(top_coins: top_coins)
+      end
     update!(available_exchanges: new_availability)
   end
 end

--- a/test/controllers/bots/asset_searches_controller_test.rb
+++ b/test/controllers/bots/asset_searches_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+# B3. The residual half of the divergence, on a screen the original report never named: an existing
+# bot re-picking an asset. attach_exchanges knew nothing about the bot's venue, so it advertised
+# every exchange that listed the asset — including ones this bot can never trade on, because a
+# started bot's exchange is fixed.
+class Bots::AssetSearchesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true)
+    @user = create(:user, setup_completed: true)
+    sign_in @user
+
+    @binance = create(:binance_exchange)
+    @kraken = create(:kraken_exchange)
+    @bot = create(:dca_single_asset, user: @user, exchange: @binance)
+  end
+
+  test 're-picking an asset on an existing bot offers only its own venue' do
+    eth = create(:asset, symbol: 'ETH', name: 'Ethereum', external_id: 'ethereum-b3')
+    create(:ticker, exchange: @binance, base_asset: eth, quote_asset: @bot.quote_asset)
+    create(:ticker, exchange: @kraken, base_asset: eth, quote_asset: @bot.quote_asset)
+
+    get edit_bot_asset_search_path(bot_id: @bot.id, asset_field: 'base_asset_id')
+
+    assert_response :ok
+    assert_match 'ETH', response.body
+    assert_match 'title="Binance"', response.body
+    assert_no_match 'title="Kraken"', response.body,
+                    'the bot trades on Binance; Kraken is not an option for it'
+  end
+end

--- a/test/controllers/bots/dca_single_assets/pick_buyable_assets_controller_test.rb
+++ b/test/controllers/bots/dca_single_assets/pick_buyable_assets_controller_test.rb
@@ -29,20 +29,50 @@ class Bots::DcaSingleAssets::PickBuyableAssetsControllerTest < ActionDispatch::I
     assert_match 'title="Kraken"', response.body
   end
 
+  # B1. The logos were read from exchange_assets ("is this asset listed here") while the exchange
+  # step that follows asks tickers ("is this pair tradable here"). The two disagreed, so a venue
+  # could be advertised on the row and then refused on the next screen — the reported symptom.
+  test 'an exchange whose pair is listed but not trading_enabled shows no logo on the search row' do
+    kraken = create(:kraken_exchange)
+    eth = listed(:ethereum)
+    create(:ticker, exchange: kraken, base_asset: eth, quote_asset: @usd, trading_enabled: false)
+
+    get step_path
+    assert_response :ok
+    assert_match 'title="Binance"', response.body
+    assert_no_match 'title="Kraken"', response.body
+  end
+
+  # B2. The same divergence with no ticker at all: an exchange_asset row left behind by a sync that
+  # wrote it before deciding the pair was unusable. Nothing revokes those, so they accumulate.
+  test 'an exchange asset with no ticker at all shows no logo' do
+    kraken = create(:kraken_exchange)
+    eth = listed(:ethereum)
+    create(:exchange_asset, exchange: kraken, asset: eth, available: true)
+
+    get step_path
+    assert_response :ok
+    assert_match 'title="Binance"', response.body
+    assert_no_match 'title="Kraken"', response.body
+  end
+
   # The binance_us → binance collapse must survive page-deferred exchange resolution:
   # binance_name has to come from "is Binance available with assets", NOT from the page rows
   # (a page can legitimately contain a binance_us asset but no binance asset).
   test 'collapses binance_us to Binance even when no Binance asset is on the page' do
-    filler = create(:asset, symbol: 'FILL', name: 'Filler')
-    create(:exchange_asset, exchange: @binance, asset: filler, available: true)
-
+    # The Binance presence that drives the collapse must be a real tradable ticker, and it must sit
+    # OFF this page: if the Binance asset appeared among the rows it would supply title="Binance"
+    # from its own row and stop exercising the page-independent derivation. Ordering is
+    # (market_cap_rank IS NULL, market_cap_rank, symbol) and all of these are nil-rank, so the
+    # twenty A* rows fill page one and ZZZ falls to page two.
     binance_us = create(:binance_us_exchange)
-    aaa = create(:asset, symbol: 'AAA', name: 'Alpha')
-    create(:ticker, exchange: binance_us, base_asset: aaa, quote_asset: @usd)
+    20.times { |i| listed(exchange: binance_us, symbol: format('A%02d', i), name: "Alpha #{i}") }
+    listed(exchange: @binance, symbol: 'ZZZ', name: 'Omega')
 
     get step_path
     assert_response :ok
-    assert_match 'AAA', response.body
+    assert_match 'A00', response.body
+    assert_no_match(/ZZZ/, response.body)
     assert_match 'title="Binance"', response.body, 'binance_us should render under the Binance label'
     assert_no_match 'Binance.US', response.body
   end

--- a/test/controllers/bots/spendable_asset_steps_test.rb
+++ b/test/controllers/bots/spendable_asset_steps_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+# B5. The asset step's rows and its exchange logos now come from one relation per bot type
+# (Bot#offered_tickers). Index and multi-asset bots have no base_asset_id store_accessor, so a
+# single shared implementation reading one would raise NoMethodError on exactly these two screens —
+# which had no controller coverage at all. These render the steps for both types.
+#
+# The index step renders a quote_asset_result partial rather than the exchange-chip cell, so the
+# meaningful assertion there is that it renders; the multi step does render chips.
+class Bots::SpendableAssetStepsTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:user, admin: true)
+    @user = create(:user, setup_completed: true)
+    sign_in @user
+    configure_deltabadger_market_data
+
+    @binance = create(:binance_exchange)
+    @usd = create(:asset, :usd)
+    @coins = %w[bitcoin ethereum solana].map do |id|
+      asset = create(:asset, symbol: id[0..2].upcase, name: id, external_id: id)
+      create(:ticker, exchange: @binance, base_asset: asset, quote_asset: @usd)
+      asset
+    end
+  end
+
+  test 'the index asset step renders' do
+    Index.create!(external_id: 'layer-1', source: Index::SOURCE_COINGECKO, name: 'Layer 1', weight: 100,
+                  top_coins: @coins.map(&:external_id),
+                  top_coins_by_exchange: { 'Exchanges::Binance' => @coins.map(&:external_id) },
+                  available_exchanges: { 'Exchanges::Binance' => 3 })
+    post bots_dca_indexes_pick_index_path,
+         params: { index_type: Bots::DcaIndex::INDEX_TYPE_CATEGORY,
+                   index_category_id: 'layer-1', index_name: 'Layer 1' }
+    post bots_dca_indexes_pick_exchange_path,
+         params: { bots_dca_index: { exchange_id: @binance.id } }
+
+    get new_bots_dca_indexes_pick_spendable_asset_path
+    assert_response :ok
+  end
+
+  test 'the multi-asset asset step renders its exchange chips' do
+    post bots_dca_single_assets_order_path, params: { flow: 'asset_first' }
+    @coins.first(2).each do |asset|
+      post bots_dca_single_assets_pick_buyable_asset_path,
+           params: { bots_dca_single_asset: { base_asset_id: asset.id } }
+    end
+    post advance_bots_dca_single_assets_pick_buyable_asset_path
+    post bots_dca_multi_assets_pick_exchange_path,
+         params: { bots_dca_multi_asset: { exchange_id: @binance.id } }
+
+    get new_bots_dca_multi_assets_pick_spendable_asset_path
+    assert_response :ok
+    assert_match 'title="Binance"', response.body
+  end
+
+  # B6. Exchange.tradeable, not Exchange.available, is what keeps a retired venue out of the basket
+  # picker. A refactor that flattened the three bot types onto one scope would re-admit it.
+  test 'the multi-asset step does not offer a retired venue' do
+    retired = create(:bitmart_exchange)
+    @coins.each { |c| create(:ticker, exchange: retired, base_asset: c, quote_asset: @usd) }
+
+    post bots_dca_single_assets_order_path, params: { flow: 'asset_first' }
+    @coins.first(2).each do |asset|
+      post bots_dca_single_assets_pick_buyable_asset_path,
+           params: { bots_dca_single_asset: { base_asset_id: asset.id } }
+    end
+    post advance_bots_dca_single_assets_pick_buyable_asset_path
+    post bots_dca_multi_assets_pick_exchange_path,
+         params: { bots_dca_multi_asset: { exchange_id: @binance.id } }
+
+    get new_bots_dca_multi_assets_pick_spendable_asset_path
+    assert_response :ok
+    assert_no_match 'title="BitMart"', response.body
+  end
+end

--- a/test/fixtures/exchanges/mexc_exchange_info.json
+++ b/test/fixtures/exchanges/mexc_exchange_info.json
@@ -1,0 +1,64 @@
+{
+  "_provenance": "Real capture: GET https://api.mexc.com/api/v3/exchangeInfo (2026-09-05), trimmed to two symbols and to the fields this parser reads. MEXC returns status \"1\" for every symbol and PERCENT_PRICE_BY_SIDE as its only filter \u2014 it emits neither \"TRADING\" nor LOT_SIZE/PRICE_FILTER/MIN_NOTIONAL. Re-capture and diff rather than hand-editing; mexc_test.rb asserts this file's SHA-256.",
+  "timezone": "CST",
+  "symbols": [
+    {
+      "symbol": "METALUSDT",
+      "status": "1",
+      "baseAsset": "METAL",
+      "baseAssetPrecision": 2,
+      "quoteAsset": "USDT",
+      "quotePrecision": 5,
+      "quoteAssetPrecision": 5,
+      "orderTypes": [
+        "LIMIT",
+        "MARKET",
+        "LIMIT_MAKER"
+      ],
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": false,
+      "quoteAmountPrecision": "1",
+      "baseSizePrecision": "0.1",
+      "permissions": [
+        "SPOT"
+      ],
+      "filters": [
+        {
+          "filterType": "PERCENT_PRICE_BY_SIDE",
+          "bidMultiplierUp": "0.2",
+          "askMultiplierDown": "0.2"
+        }
+      ],
+      "maxQuoteAmount": "2000000"
+    },
+    {
+      "symbol": "PALMAIUSDT",
+      "status": "1",
+      "baseAsset": "PALMAI",
+      "baseAssetPrecision": 2,
+      "quoteAsset": "USDT",
+      "quotePrecision": 4,
+      "quoteAssetPrecision": 4,
+      "orderTypes": [
+        "LIMIT",
+        "MARKET",
+        "LIMIT_MAKER"
+      ],
+      "isSpotTradingAllowed": false,
+      "isMarginTradingAllowed": false,
+      "quoteAmountPrecision": "1",
+      "baseSizePrecision": "0",
+      "permissions": [
+        "SPOT"
+      ],
+      "filters": [
+        {
+          "filterType": "PERCENT_PRICE_BY_SIDE",
+          "bidMultiplierUp": "0.2",
+          "askMultiplierDown": "0.2"
+        }
+      ],
+      "maxQuoteAmount": "2000000"
+    }
+  ]
+}

--- a/test/jobs/bot/action_job_test.rb
+++ b/test/jobs/bot/action_job_test.rb
@@ -11,6 +11,38 @@ module ActionJobBehaviorTests
   included do
     # A stop from another process (user click, admin deactivation sweep) landing mid-execution
     # must not be overwritten by the job's post-execution status writes (resurrection race).
+    # A pair can lose trading_enabled under a RUNNING bot: the flag is served by market data, not
+    # decided by the container, so an upstream revocation reaches every tenant on its own schedule.
+    # ActionJob's per-tick `bot.update!` runs validate_bot_exchange (registered on: :update), which
+    # skipped only stopped/deleted/archived bots — so the tick raised RecordInvalid, the rescue
+    # flipped the bot to :retrying and re-raised on the branch that does NOT reschedule, and
+    # ActiveJob had no retry_on for it. The bot simply stopped ticking, with one email.
+    test 'a tick on a bot whose pair lost trading_enabled still schedules the next run' do
+      bot = create_bot
+      setup_action_job_mocks(bot)
+      bot.stubs(:execute_action).returns(Result::Success.new)
+      Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+      assert_nothing_raised { Bot::ActionJob.new.perform(bot) }
+      assert_not_equal 'retrying', bot.reload.status
+    end
+
+    # The same tick on a bot whose delayed start is being cleared. disable_starting_time! dirties
+    # `settings` and calls save! from inside ActionJob, so a guard keyed on settings_changed?
+    # passes the test above and still kills this bot.
+    test 'a delayed-start bot survives its first tick on a revoked pair' do
+      bot = create_bot
+      bot.start_time_enabled = true
+      bot.set_missed_quote_amount
+      bot.save!
+      setup_action_job_mocks(bot)
+      bot.stubs(:execute_action).returns(Result::Success.new)
+      Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+      assert_nothing_raised { Bot::ActionJob.new.perform(bot) }
+      assert_not_equal 'retrying', bot.reload.status
+    end
+
     test 'does not resurrect a bot stopped externally mid-execution' do
       bot = create_bot
       setup_action_job_mocks(bot)

--- a/test/models/bots/dca_index_test.rb
+++ b/test/models/bots/dca_index_test.rb
@@ -498,4 +498,26 @@ class Bots::DcaIndexTest < ActiveSupport::TestCase
   def in_index_external_ids(bot)
     bot.bot_index_assets.in_index.includes(:asset).map { |bia| bia.asset.external_id }.sort
   end
+  # An index bot has no validate_tickers_available of its own; it relied on validate_bot_exchange
+  # firing during start's save. The tick-safety guard on that validation must not take the
+  # start-time gate with it, or a bot whose venue can no longer trade its index would start and
+  # then fail on every order.
+  test 'an index bot whose quote has no tradable pairs cannot start' do
+    MarketData.stubs(:configured?).returns(true)
+    bot = create(:dca_index, exchange: @exchange, quote_asset: @quote)
+    @exchange.tickers.update_all(trading_enabled: false)
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+
+    assert_not bot.start
+  end
+
+  test 'an index bot whose venue still trades its index can start' do
+    MarketData.stubs(:configured?).returns(true)
+    bot = create(:dca_index, exchange: @exchange, quote_asset: @quote)
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+
+    assert bot.start
+  end
 end

--- a/test/models/bots/dca_single_asset_test.rb
+++ b/test/models/bots/dca_single_asset_test.rb
@@ -920,4 +920,36 @@ class Bots::DcaSingleAssetTest < ActiveSupport::TestCase
     fresh = Bots::DcaSingleAsset.find(bot.id)
     assert fresh.start_blocked_by_unavailable_ticker?, 'unavailable ticker → blocked'
   end
+  # The tick-safety guard on validate_bot_exchange narrows WHEN the validation runs; it must not
+  # stop it running when the exchange or the assets are the thing actually being changed.
+  test 'moving a bot onto a venue that cannot trade its pair is still rejected' do
+    bot = create(:dca_single_asset)
+    other = create(:kraken_exchange)
+
+    bot.exchange = other
+
+    assert_not bot.valid?(:update)
+    assert_includes bot.errors.attribute_names, :exchange
+  end
+
+  test 'changing an asset to one the venue does not list is still rejected' do
+    bot = create(:dca_single_asset)
+    stranger = create(:asset, symbol: 'ZZZ', name: 'Unlisted', external_id: 'unlisted-zzz')
+
+    bot.base_asset_id = stranger.id
+
+    assert_not bot.valid?(:update)
+    assert_includes bot.errors.attribute_names, :exchange
+  end
+
+  # The tick shape: neither exchange nor assets change, so a revoked pair must not block the save
+  # that keeps the bot running.
+  test 'a save that changes neither exchange nor assets is not blocked by a revoked pair' do
+    bot = create(:dca_single_asset, :started)
+    Ticker.where(exchange_id: bot.exchange_id).update_all(trading_enabled: false)
+
+    bot.last_action_job_at = Time.current
+
+    assert bot.valid?(:update)
+  end
 end

--- a/test/models/exchange/synchronizer_test.rb
+++ b/test/models/exchange/synchronizer_test.rb
@@ -48,4 +48,21 @@ class Exchange::SynchronizerTest < ActiveSupport::TestCase
     assert btc_usd.reload.available
     assert_not eth_usd.reload.available, 'pair absent from the feed is delisted'
   end
+  # B10. The self-hosted twin of data-api's join bug: the CoinGecko symbol->coin_id map is keyed on
+  # CoinGecko's casing while the venue reports its own. Bitget publishes baseCoin "rON" where
+  # CoinGecko says "RON", so external_id_from_symbol missed and `next if blank?` dropped a live
+  # pair with no trace. Fixing only data-api leaves every CoinGecko-provider install blind.
+  test 'resolves a CoinGecko symbol to a venue symbol case-insensitively' do
+    ron = create(:asset, symbol: 'RON', name: 'Ronin', external_id: 'ronin')
+    @exchange.send(:set_symbol_to_external_id_hash,
+                   [{ 'base' => 'RON', 'coin_id' => 'ronin', 'target' => 'USD', 'target_coin_id' => 'usd' }])
+
+    sync([{ base: 'rON', quote: 'USD', ticker: 'rONUSD', available: true, trading_enabled: true,
+            minimum_base_size: 0.1, minimum_quote_size: 5, maximum_base_size: nil, maximum_quote_size: nil,
+            base_decimals: 4, quote_decimals: 2, price_decimals: 2 }])
+
+    ticker = @exchange.tickers.find_by(base: 'rON', quote: 'USD')
+    assert_not_nil ticker, 'a mixed-case venue symbol must still resolve'
+    assert_equal ron.id, ticker.base_asset_id
+  end
 end

--- a/test/models/exchanges/bitget_test.rb
+++ b/test/models/exchanges/bitget_test.rb
@@ -281,4 +281,21 @@ class Exchanges::BitgetTest < ActiveSupport::TestCase
     assert_predicate result, :success?
     assert_equal :closed, result.data[:status]
   end
+  # B9. Bitget emitted `available: status == 'online'` and no trading_enabled at all — one concept
+  # in two columns with opposite failure modes on the two sync paths. Every other venue reports an
+  # offline pair as listed-but-not-tradable.
+  test 'an offline Bitget pair is listed but not trading_enabled' do
+    products = [{
+      'symbol' => 'BTCUSDT', 'baseCoin' => 'BTC', 'quoteCoin' => 'USDT', 'status' => 'offline',
+      'minTradeAmount' => '0.0001', 'minTradeUSDT' => '5', 'maxTradeAmount' => '1000',
+      'quantityPrecision' => '4', 'quotePrecision' => '6', 'pricePrecision' => '2'
+    }]
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_symbols).returns(Result::Success.new({ 'data' => products }))
+
+    info = @exchange.get_tickers_info(force: true).data.first
+
+    assert info[:available], 'an offline pair is still listed'
+    assert_not info[:trading_enabled], 'but it cannot be traded'
+  end
 end

--- a/test/models/exchanges/kraken_test.rb
+++ b/test/models/exchanges/kraken_test.rb
@@ -463,4 +463,42 @@ class Exchanges::KrakenTest < ActiveSupport::TestCase
     assert_predicate limit, :failure?
     assert limit.data[:unacknowledged]
   end
+  # B7. get_tickers_prices declares `symbols:` and never read it. The fallback loop iterated EVERY
+  # available ticker the bulk endpoint omitted — 184 on a measured tenant — one sequential proxy
+  # call each, on every 1-minute cache miss. Callers ask for one pair.
+  test 'the price fallback asks only for the requested symbols' do
+    %w[AAAEUR BBBEUR CCCEUR].each do |t|
+      create(:ticker, exchange: @exchange, ticker: t, base_asset: create(:asset, symbol: t[0..2]),
+                      quote_asset: create(:asset, symbol: "Q#{t}"))
+    end
+    @exchange.set_client
+    client = @exchange.send(:client)
+    client.stubs(:get_ticker_information).returns(Result::Success.new({ 'error' => [], 'result' => {} }))
+    client.expects(:get_ticker_information).with(pair: 'BBBEUR').never
+    client.expects(:get_ticker_information).with(pair: 'CCCEUR').never
+    client.expects(:get_ticker_information).with(pair: 'AAAEUR')
+          .returns(Result::Success.new({ 'error' => [], 'result' => { 'AAAEUR' => { 'c' => %w[100.0 1] } } })).once
+
+    result = @exchange.get_tickers_prices(symbols: ['AAAEUR'], force: true)
+
+    assert result.success?
+    assert_equal 100.0.to_d, result.data['AAAEUR']
+  end
+
+  # B7b. One fossilised delisted pair returned Result::Failure for the whole fetch, blanking live
+  # metrics for every Kraken bot in the container.
+  test 'an unknown pair does not fail the whole price fetch' do
+    create(:ticker, exchange: @exchange, ticker: 'DEADEUR', base_asset: create(:asset, symbol: 'DEAD'),
+                    quote_asset: create(:asset, symbol: 'QDEAD'))
+    @exchange.set_client
+    client = @exchange.send(:client)
+    client.stubs(:get_ticker_information)
+          .returns(Result::Success.new({ 'error' => [], 'result' => { 'XBTEUR' => { 'c' => %w[50000.0 1] } } }))
+    client.stubs(:get_ticker_information).with(pair: 'DEADEUR')
+          .returns(Result::Success.new({ 'error' => ['EQuery:Unknown asset pair'], 'result' => {} }))
+
+    result = @exchange.get_tickers_prices(symbols: ['DEADEUR'], force: true)
+
+    assert result.success?, 'a delisted pair must not blank prices for every other bot'
+  end
 end

--- a/test/models/exchanges/mexc_test.rb
+++ b/test/models/exchanges/mexc_test.rb
@@ -82,4 +82,32 @@ class Exchanges::MexcTest < ActiveSupport::TestCase
     assert result.success?
     assert_equal true, result.data
   end
+  # B8. The container has its own MEXC parser (data-api uses honeymaker's; the container cannot,
+  # because honeymaker's connection takes no proxy and would put the container's own IP at MEXC).
+  # Two implementations of one contract, so both are driven from the SAME captured bytes and both
+  # assert its digest — a hand-edit in either repo would otherwise let them drift again.
+  def mexc_exchange_info
+    JSON.parse(File.read(Rails.root.join('test/fixtures/exchanges/mexc_exchange_info.json')))
+  end
+
+  test 'the MEXC fixture is the same bytes honeymaker tests against' do
+    path = Rails.root.join('test/fixtures/exchanges/mexc_exchange_info.json')
+    assert_equal '13a65c0c8ebde52fac4cdca9a5be9d9a18ba7b5438c496b1b30606cf52fd60d3',
+                 Digest::SHA256.hexdigest(File.read(path))
+    assert_equal '1', mexc_exchange_info['symbols'].first['status']
+  end
+
+  test 'get_tickers_info reads MEXC status and spot permission' do
+    @exchange.set_client
+    @exchange.send(:client).stubs(:exchange_information).returns(Result::Success.new(mexc_exchange_info))
+
+    result = @exchange.get_tickers_info(force: true)
+
+    assert result.success?
+    allowed = result.data.find { |t| t[:ticker] == 'METALUSDT' }
+    disallowed = result.data.find { |t| t[:ticker] == 'PALMAIUSDT' }
+    assert allowed[:trading_enabled], 'status "1" plus spot permission is tradable'
+    assert disallowed[:available], 'still listed'
+    assert_not disallowed[:trading_enabled], 'MEXC rejects a spot order for this symbol'
+  end
 end

--- a/test/models/index/exchange_availability_test.rb
+++ b/test/models/index/exchange_availability_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+# Index availability answers "can this index run on this venue". It has to answer the same
+# question the quote picker then asks — enough TRADABLE index coins against ONE quote — or the
+# exchange step offers a venue whose quote list comes back empty.
+class Index::ExchangeAvailabilityTest < ActiveSupport::TestCase
+  setup do
+    @binance = create(:binance_exchange)
+    @usd = create(:asset, :usd)
+    @eur = create(:asset, symbol: 'EUR', name: 'Euro', external_id: 'euro')
+    @coins = %w[bitcoin ethereum solana].map do |id|
+      create(:asset, symbol: id[0..2].upcase, name: id, external_id: id)
+    end
+  end
+
+  def list(asset, quote, trading_enabled: true)
+    create(:ticker, exchange: @binance, base_asset: asset, quote_asset: quote,
+                    trading_enabled: trading_enabled)
+  end
+
+  def availability(coins = @coins.map(&:external_id))
+    Index.calculate_available_exchanges(top_coins: coins)
+  end
+
+  test 'a venue whose index coins are all disabled is not available' do
+    @coins.each { |c| list(c, @usd, trading_enabled: false) }
+
+    assert_empty availability
+  end
+
+  test 'a venue whose index coins are split across quotes is not available' do
+    list(@coins[0], @usd)
+    list(@coins[1], @eur)
+    list(@coins[2], @eur)
+
+    assert_empty availability, 'two on EUR and one on USD is not a home for a three-coin index'
+  end
+
+  test 'a venue with enough coins on one quote is available' do
+    @coins.each { |c| list(c, @usd) }
+
+    assert_equal 3, availability['Exchanges::Binance']
+  end
+
+  test 'a venue with no matching tickers is absent rather than raising' do
+    assert_nothing_raised { availability }
+    assert_empty availability
+  end
+end


### PR DESCRIPTION
Searching for a tokenized stock showed five exchange logos; selecting it offered three.

The asset step listed its rows from tickers — *is this pair tradable for this bot* — and its exchange
logos from `exchange_assets` — *is this asset listed on this venue*. Two tables answering two
different questions, 28 lines apart in the same file, with nothing keeping them in agreement. A row
could advertise a venue the very next screen refused.

`exchange_assets` diverges from tickers three ways: nothing on the hosted sync path ever revokes it,
it has no notion of `trading_enabled`, and it knows nothing about the bot's chosen counterpart or
venue. All three were visible at once in that one search.

## One relation, two plucks

Each bot type exposes `offered_tickers`, and both the rows and the logos are plucks off it — same
venues, same `trading_enabled`, same counterpart, same narrowing to a bot's own exchange. They cannot
disagree because they are one query. The asset ids are pushed into SQL rather than filtered in Ruby;
the relation is not narrowed by asset, so on a stock venue it spans thousands of rows.

The types keep their own implementations rather than sharing a scope: index bots have no base asset
of their own, and multi-asset bots scope venues with `Exchange.tradeable` so a retired venue can
never re-enter the basket. There is a test for each of those, because a later refactor flattening
them onto one scope is the obvious thing to try.

`exchange_assets` keeps its writes and its other readers — withdrawal fees, ticker validation, and
the canonical-symbol lookup that resolves a transaction's asset on venues where the venue symbol
differs from the asset's. Only its use as an answer to *is this tradable* is gone, so there is no
migration and an image rollback stays safe.

## The index wizard had a third answer

It counted listed pairs across every quote at once, while the quote picker that follows requires
enough coins against **one** quote — so a venue holding three index coins spread over three quotes
was offered and then returned an empty list. It now counts tradable pairs per quote, and qualifies a
venue against the coins actually exported for it rather than the whole category.

## Merge order

After deltabadger#339, and after the market-data service is serving corrected tradability flags.
Landing this while those flags are still wrong would make search honour them and hide most of one
venue's assets for the window.