### PR TITLE
See Kraken tokenized equity holdings instead of dropping them

### DIFF
--- a/app/models/exchanges/kraken.rb
+++ b/app/models/exchanges/kraken.rb
@@ -90,16 +90,25 @@ class Exchanges::Kraken < Exchange
   def get_tickers_info(force: false)
     cache_key = "exchange_#{id}_tickers_info"
     tickers_info = Rails.cache.fetch(cache_key, expires_in: 1.hour, force:) do
-      result = client.get_tradable_asset_pairs
+      # aclass_base: 'all' — without it Kraken serves only the 'currency' class and its tokenized
+      # equities (xStocks) are invisible. The two classes are disjoint.
+      result = client.get_tradable_asset_pairs(aclass_base: 'all')
       return result if result.failure?
 
       error = Utilities::Hash.dig_or_raise(result.data, 'error')
       return Result::Failure.new(*error) if error.any?
 
-      result.data['result'].map do |_, info|
+      # Every tokenized pair comes back twice, under an SPV key and an x key, sharing one wsname and
+      # altname; currency pairs are never duplicated. Keying by wsname collapses exactly those
+      # aliases — mapping the raw response would ingest each tokenized pair twice.
+      deduped = result.data['result'].each_with_object({}) do |(_, info), acc|
+        wsname = info['wsname']
+        acc[wsname] ||= info if wsname.present?
+      end
+
+      deduped.map do |wsname, info|
         ticker = Utilities::Hash.dig_or_raise(info, 'altname')
 
-        wsname = Utilities::Hash.dig_or_raise(info, 'wsname')
         base, quote = wsname.split('/')
         minimum_base_size = Utilities::Hash.dig_or_raise(info, 'ordermin').to_d
         # minimum_quote_size = (REAL_COSTMIN[quote] || Utilities::Hash.dig_or_raise(info, 'costmin')).to_d
@@ -116,7 +125,15 @@ class Exchanges::Kraken < Exchange
           quote_decimals: Utilities::Hash.dig_or_raise(info, 'cost_decimals'),
           price_decimals: Utilities::Hash.dig_or_raise(info, 'pair_decimals'),
           available: true,
-          trading_enabled: info.key?('status') ? info['status'] == 'online' : true
+          # Tokenized equities are listed but never tradable from here: AddOrder needs an
+          # asset_class parameter this client does not send, and Kraken closes the tokenized order
+          # books to EEA clients over the API in any case. Listing them is what lets a holding be
+          # resolved and valued instead of silently dropped.
+          trading_enabled: if info['aclass_base'] == 'tokenized_asset'
+                             false
+                           else
+                             info.key?('status') ? info['status'] == 'online' : true
+                           end
         }
       end.compact
     end
@@ -633,7 +650,23 @@ class Exchanges::Kraken < Exchange
   def asset_from_symbol(symbol)
     symbol = symbol.split('.').first
     symbol = ASSET_MAP[symbol] || symbol
-    super(symbol)
+    super(symbol) || tokenized_asset_from_symbol(symbol)
+  end
+
+  # Kraken reports a tokenized equity (xStock) holding under either of two asset codes — NVDAx or
+  # NVDASPV — which both carry altname "NVDAx", while the ticker base we store comes from market
+  # data as "NVDAX". get_balances drops any code it cannot resolve without a word, so without this
+  # the holding is invisible to the tracker and to tax reporting.
+  #
+  # Only consulted after the exact lookup fails, so it can never shadow an ordinary asset.
+  #
+  # ponytail: the SPV → x rewrite is Kraken's naming convention, not a documented contract (every
+  # SPV asset code in /0/public/Assets?aclass=tokenized_asset carries the x form as its altname).
+  # If it ever diverges, resolve altname from that endpoint instead of rewriting the suffix.
+  def tokenized_asset_from_symbol(symbol)
+    @tokenized_asset_from_symbol ||= tickers.available.includes(:base_asset)
+                                            .each_with_object({}) { |t, h| h[t.base.upcase] ||= t.base_asset }
+    @tokenized_asset_from_symbol[symbol.sub(/SPV\z/, 'x').upcase]
   end
 
   def get_ticker_information(ticker)

--- a/app/models/market_data.rb
+++ b/app/models/market_data.rb
@@ -252,9 +252,14 @@ class MarketData
       base_asset_id = asset_map[t['base_external_id']]
       quote_asset_id = asset_map[t['quote_external_id']]
       next unless base_asset_id && quote_asset_id
-      # Skip tickers without decimal precision — these are pairs the exchange API didn't return
-      # trading params for (e.g. Kraken tokenized stocks). They exist on the exchange but can't be
-      # traded via API yet. Decimal precision is per-ticker-per-exchange, not a safe default.
+      # Skip tickers without decimal precision — pairs the exchange API returned no trading params
+      # for. Decimal precision is per-ticker-per-exchange, not a safe default.
+      #
+      # This used to cite Kraken tokenized stocks as the example and claim they "can't be traded via
+      # API yet" because the venue returns no params. Both halves were wrong: Kraken supplies
+      # complete params for them (ordermin, costmin, lot/cost/pair decimals), and they were missing
+      # only because the catalogue call never asked for that asset class. The wrong comment is why
+      # nobody looked again for months — so it is worth the correction rather than the deletion.
       next unless t['base_decimals'] && t['quote_decimals'] && t['price_decimals']
 
       upsert_ticker_attributes(t, exchange_id: exchange.id, base_asset_id: base_asset_id, quote_asset_id: quote_asset_id)

--- a/test/models/exchanges/kraken_test.rb
+++ b/test/models/exchanges/kraken_test.rb
@@ -24,6 +24,34 @@ class Exchanges::KrakenTest < ActiveSupport::TestCase
                          status: :submitted, external_status: :open, **attrs)
   end
 
+  # The container fetches its own catalogue on the CoinGecko provider. Same two Kraken quirks as the
+  # market-data service: tokenized equities need aclass_base, and every tokenized pair is returned
+  # twice (SPV key + x key) under one shared wsname.
+  test 'get_tickers_info asks for every asset class' do
+    @exchange.set_client
+    @exchange.send(:client).expects(:get_tradable_asset_pairs).with(aclass_base: 'all')
+             .returns(Result::Success.new(kraken_pairs(status: 'online')))
+
+    assert @exchange.get_tickers_info(force: true).success?
+  end
+
+  test 'get_tickers_info lists a tokenized pair once, and not as tradable' do
+    tok = {
+      'altname' => 'NVDAxUSD', 'wsname' => 'NVDAx/USD', 'aclass_base' => 'tokenized_asset',
+      'ordermin' => '0.00000001', 'costmin' => '0.5', 'lot_decimals' => 8,
+      'cost_decimals' => 5, 'pair_decimals' => 2, 'status' => 'online'
+    }
+    body = { 'error' => [], 'result' => { 'NVDAxUSD' => tok, 'NVDASPVUSD' => tok.dup } }
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_tradable_asset_pairs).returns(Result::Success.new(body))
+
+    infos = @exchange.get_tickers_info(force: true).data.select { |t| t[:base] == 'NVDAx' }
+
+    assert_equal 1, infos.size, 'the SPV alias is the same pair'
+    assert infos.first[:available], 'listed, so a holding resolves'
+    assert_not infos.first[:trading_enabled], 'we cannot place these orders'
+  end
+
   test 'get_tickers_info marks an online pair available and trading_enabled' do
     @exchange.set_client
     @exchange.send(:client).stubs(:get_tradable_asset_pairs).returns(Result::Success.new(kraken_pairs(status: 'online')))
@@ -500,5 +528,59 @@ class Exchanges::KrakenTest < ActiveSupport::TestCase
     result = @exchange.get_tickers_prices(symbols: ['DEADEUR'], force: true)
 
     assert result.success?, 'a delisted pair must not blank prices for every other bot'
+  end
+  # Kraken tokenized equities (xStocks). Kraken reports a holding under either of two asset codes -
+  # NVDAx or NVDASPV - which both carry altname "NVDAx", while the ticker we store from market data
+  # is based on the upstream symbol "NVDAX". get_balances resolves every balance key through
+  # asset_from_symbol and does `next unless asset.present?`, so an unresolved code is dropped in
+  # silence: the holding simply does not exist as far as the tracker and the tax report are
+  # concerned. That is the whole bug - Kraken can be read, we just threw the answer away.
+  test 'resolves a tokenized holding reported under the x code' do
+    nvda = create(:asset, symbol: 'NVDAX', name: 'NVIDIA xStock', external_id: 'nvidia-xstock')
+    usd = create(:asset, :usd)
+    create(:ticker, exchange: @exchange, base_asset: nvda, quote_asset: usd,
+                    base: 'NVDAX', quote: 'USD', ticker: 'NVDAxUSD', trading_enabled: false)
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_extended_balance).returns(Result::Success.new(
+                                                                   { 'error' => [],
+                                                                     'result' => { 'NVDAx' => { 'balance' => '2.5', 'hold_trade' => '0' } } }
+                                                                 ))
+
+    balances = @exchange.get_balances(asset_ids: [nvda.id]).data
+
+    assert_equal 2.5.to_d, balances[nvda.id][:free]
+  end
+
+  test 'resolves a tokenized holding reported under the SPV code' do
+    nvda = create(:asset, symbol: 'NVDAX', name: 'NVIDIA xStock', external_id: 'nvidia-xstock')
+    usd = create(:asset, :usd)
+    create(:ticker, exchange: @exchange, base_asset: nvda, quote_asset: usd,
+                    base: 'NVDAX', quote: 'USD', ticker: 'NVDAxUSD', trading_enabled: false)
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_extended_balance).returns(Result::Success.new(
+                                                                   { 'error' => [],
+                                                                     'result' => { 'NVDASPV' => { 'balance' => '1.25', 'hold_trade' => '0.25' } } }
+                                                                 ))
+
+    balances = @exchange.get_balances(asset_ids: [nvda.id]).data
+
+    assert_equal 1.to_d, balances[nvda.id][:free]
+    assert_equal 0.25.to_d, balances[nvda.id][:locked]
+  end
+
+  # The alias rule must not swallow an ordinary asset whose code merely ends in those letters.
+  test 'does not mistake an ordinary asset for a tokenized alias' do
+    usd = create(:asset, :usd)
+    btc = create(:asset, :bitcoin)
+    create(:ticker, exchange: @exchange, base_asset: btc, quote_asset: usd, base: 'XBT', quote: 'USD')
+    @exchange.set_client
+    @exchange.send(:client).stubs(:get_extended_balance).returns(Result::Success.new(
+                                                                   { 'error' => [],
+                                                                     'result' => { 'XXBT' => { 'balance' => '0.5', 'hold_trade' => '0' } } }
+                                                                 ))
+
+    balances = @exchange.get_balances(asset_ids: [btc.id]).data
+
+    assert_equal 0.5.to_d, balances[btc.id][:free], 'the existing ASSET_MAP path still works'
   end
 end


### PR DESCRIPTION
A Kraken account can hold tokenized equities (xStocks), and we showed none of it. The holding was
absent from the portfolio, the tracker and tax reporting, with nothing logged — the balance was
discarded in silence.

Two causes, both ours.

**The catalogue never asked for the asset class.** Kraken serves tokenized pairs only under
`aclass_base`; the default response is the currency class alone, so no tokenized ticker existed to
resolve a holding against. Kraken also returns every tokenized pair twice — once per asset code,
sharing one `wsname` — so they are deduplicated by `wsname`, which collapses exactly those aliases
and leaves currency pairs untouched.

**Then the balance was dropped.** `get_balances` resolves every key through `asset_from_symbol` and
does `next unless asset.present?`. Kraken reports these holdings as `NVDAx` or `NVDASPV`, both
carrying altname `NVDAx`, while the ticker base we store from market data is `NVDAX`. Nothing
matched, so the balance vanished. Resolution now falls back to the alias form, and only *after* the
exact lookup fails, so it cannot shadow an ordinary asset — there is a test that an ordinary
`XXBT` balance still resolves through the existing map.

## Listed, not tradable

Tokenized pairs are `available: true, trading_enabled: false`, which is the honest state: placing an
order needs an `asset_class` parameter we do not send, and the venue closes those order books to EEA
clients over the API in any case. Bots therefore cannot select them, and after the asset-step change
they do not appear as a tradable venue either.

Valuation needs nothing new — the same asset is already priced from other venues that list it — so
none of the order-path plumbing is required to make a holding visible and reportable. That is what
keeps this small.

## Also

Corrects a comment in `MarketData#import_tickers!` claiming these pairs "can't be traded via API
yet" because the exchange returns no trading params. Kraken supplies complete params
(`ordermin`, `costmin`, lot/cost/pair decimals); they were absent only because the catalogue call
never asked for the asset class. The comment is corrected rather than deleted because it is the
reason this went unexamined.

## Requires

The matching honeymaker change, released and pinned — the container calls
`get_tradable_asset_pairs(aclass_base:)`, which older versions do not accept.

## Not done

Making them tradable. That needs `asset_class` threaded through the price, candle and order paths as
a per-pair flag (it is a mode switch, not a filter — sending it for a crypto pair breaks that pair),
and it would still not help an EEA customer, who cannot reach those order books over the API at all.