### PR TITLE
Use the current Rack symbol for 422 in the API envelope

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -54,7 +54,7 @@ module Api
           success: :ok,
           created: :created,
           accepted: :accepted,
-          validation_failed: :unprocessable_entity,
+          validation_failed: :unprocessable_content,
           permission_denied: :forbidden,
           not_found: :not_found,
           upstream_failed: :bad_gateway,

--- a/test/controllers/hooks_controller_test.rb
+++ b/test/controllers/hooks_controller_test.rb
@@ -23,8 +23,10 @@ class HooksControllerTest < ActionDispatch::IntegrationTest
     ActionController::Base.allow_forgery_protection = false
   end
 
+  # +body: Rack rewrites the request body's encoding in place, which a frozen string literal
+  # (the default from Ruby 4 on) would not survive.
   def fire(token = @signal.token, body: 'BUY BTCUSDT', content_type: 'text/plain')
-    post "/hook/#{token}", params: body, headers: { 'CONTENT_TYPE' => content_type }
+    post "/hook/#{token}", params: +body, headers: { 'CONTENT_TYPE' => content_type }
   end
 
   # The job carries the claim time so it can refuse a call that sat in the queue too long.


### PR DESCRIPTION
Rack 3.2 renamed the 422 status symbol to `:unprocessable_content` and deprecated `:unprocessable_entity`.

`Api::V1::BaseController#status_for` resolves its symbol through `Rack::Utils.status_code`, so every API validation failure emitted a deprecation warning. Switched to the current name.

Also unfreezes the request body in the hook controller test — Rack rewrites the body's encoding in place, which a frozen string literal (the default from Ruby 4 on) would not survive.

`:unprocessable_entity` still resolves to 422 through Rails' `render status:`, so the remaining ~145 call sites keep working and are left for a separate sweep.

Full suite: 5317 runs, 22134 assertions, 0 failures, 0 errors.
