### PR TITLE
Fill in the advanced-settings and rebalancing manual pages

### DIFF
--- a/manual/11-advanced-bot-settings.md
+++ b/manual/11-advanced-bot-settings.md
@@ -1,0 +1,25 @@
+# Advanced bot settings
+
+Advanced triggers were designed for single-asset bots. On a multi-asset bot you also pick which asset the trigger watches.
+
+A **Start buying** trigger fires once and is then deactivated, while **Buy only** works continuously.
+
+## Pick a starting time
+
+You can pick a day of the week, a calendar date, or just an hour.
+
+## Price threshold
+
+Buy only in a certain price range.
+
+## Moving averages
+
+Use a certain EMA or SMA as a trigger.
+
+## RSI
+
+Use a certain RSI level as a trigger. The app uses the standard 14-candle setting for RSI.
+
+## Set a spending limit
+
+The bot stops buying after investing a certain amount.

--- a/manual/12-portfolio-rebalancing.md
+++ b/manual/12-portfolio-rebalancing.md
@@ -1,0 +1,17 @@
+# Portfolio rebalancing
+
+Any multi-asset bot can become a portfolio rebalancer. By default it uses **rebalanced DCA**, where every purchase is aimed at restoring your target allocation, but nothing is ever sold. That is a great approach for tax purposes while you are still accumulating.
+
+Full rebalancing can be switched on as well, and it works independently from DCA. When it is on, it **places orders whether DCA is on or off**. While DCA is running, full rebalancing is triggered very rarely — only when buying alone cannot restore the target allocation.
+
+Deltabadger rebalances whenever an asset drifts further from its target than the threshold you set. It checks every four hours, and it refreshes the bot's targets first, so a bot that has been stopped for a while never rebalances towards an outdated allocation.
+
+> [!NOTE]
+> Traditional portfolio rebalancing was usually executed on a fixed schedule, but beta tests clearly show the superiority of threshold-based rebalancing. Every transaction costs fees and slippage, so it pays to act only when the price movement is big enough. On top of that, time-based rebalancing can miss the right moment completely.
+
+## Index bot
+
+Rebalancing works on [index bots](13-direct-indexing.md) as well, but assets that drop out of the index are not sold automatically. You sell them yourself, one at a time, from the **Left the index** table.
+
+> [!IMPORTANT]
+> Assets tend to leave an index and come back later. Selling them automatically would liquidate a large position the moment any other asset drifted out of its band, while an asset that left at 0.1% of the portfolio would never trip the band and would sit there forever. Each sale is also a taxable event, so the timing is yours to pick. For now, this is a manual step.


### PR DESCRIPTION
Two manual pages were empty placeholders.

**11 — Advanced bot settings.** The triggers (starting time, price threshold, moving averages, RSI, spending limit), plus the distinction between a **Start buying** trigger, which fires once, and **Buy only**, which applies continuously.

**12 — Portfolio rebalancing.** Rebalanced DCA (buy-only, restores the target allocation with each purchase) versus full rebalancing (a separate leg that trades whether DCA is on or off, triggered by drift past a threshold rather than on a schedule). The index section explains why assets that drop out of an index are sold manually from the **Left the index** table instead of automatically: an index constituent often returns, automatic selling would liquidate a large position on another asset's drift while never touching a 0.1% one, and each sale is a taxable event.