### PR TITLE
Let the FX fallback read the feed it actually gets

### DIFF
--- a/app/models/tax/ecb_fx_rates.rb
+++ b/app/models/tax/ecb_fx_rates.rb
@@ -58,7 +58,11 @@ module Tax
 
       def last_expected_publication_date
         # ECB publishes ~16:00 CET on TARGET business days; "yesterday" is always safe.
-        Date.current - 1
+        # Walk back over the weekend too, or Saturday through Monday would each judge
+        # Friday's rate stale and refetch the whole 1999-onwards history on every run.
+        date = Date.current - 1
+        date -= 1 while date.saturday? || date.sunday?
+        date
       end
 
       def fetch_history_csv
@@ -86,10 +90,11 @@ module Tax
         @connection ||= Faraday.new(request: { open_timeout: TIMEOUT, timeout: TIMEOUT })
       end
 
-      # Bundesbank ships a metadata preamble and uses "." for unpublished days, so keep only
-      # rows that are a date plus a number.
+      # Bundesbank ships a UTF-8 BOM, a metadata preamble, and "." for unpublished days.
+      # The BOM has to go before parsing: it sits immediately in front of an empty quoted
+      # field, so CSV reads its bytes as field content and then trips over the quote.
       def bundesbank_to_sdmx(body, currency)
-        CSV.parse(body).filter_map do |row|
+        CSV.parse(body.dup.force_encoding(Encoding::UTF_8).delete_prefix("\uFEFF")).filter_map do |row|
           date, value = row
           next unless date&.match?(/\A\d{4}-\d{2}-\d{2}\z/)
           next unless value&.match?(/\A\d+(\.\d+)?\z/)

--- a/test/models/tax/ecb_fx_rates_test.rb
+++ b/test/models/tax/ecb_fx_rates_test.rb
@@ -5,6 +5,10 @@ class Tax::EcbFxRatesTest < ActiveSupport::TestCase
     FxRate.create!(currency: currency, date: date, rate: rate)
   end
 
+  def sdmx(currency, date, rate)
+    "CURRENCY,TIME_PERIOD,OBS_VALUE\n#{currency},#{date},#{rate}\n"
+  end
+
   test 'rate is a multiplier: amount_in_to = amount_in_from * rate' do
     seed('USD', Date.new(2025, 3, 3), '1.10'.to_d)
     seed('GBP', Date.new(2025, 3, 3), '0.85'.to_d)
@@ -68,5 +72,51 @@ class Tax::EcbFxRatesTest < ActiveSupport::TestCase
     CSV
 
     assert_equal expected, Tax::EcbFxRates.send(:bundesbank_to_sdmx, csv, 'USD')
+  end
+
+  # The Bundesbank feed opens with a UTF-8 BOM immediately followed by an empty quoted
+  # field, and its metadata preamble is only partly quoted. CSV.parse on the raw body
+  # reads the BOM bytes as field content and then hits a quote mid-field.
+  test 'bundesbank_to_sdmx parses the live feed shape: BOM, half-quoted preamble, "." for no value' do
+    csv = "\uFEFF#{<<~CSV}"
+      "",BBEX3.D.USD.EUR.BB.AC.000,BBEX3.D.USD.EUR.BB.AC.000_FLAGS
+      "",Euro foreign exchange reference rate of the ECB / EUR 1 = USD / United States,
+      Comment (in english),"The ECB publishes daily euro foreign exchange reference rates, which are calculated on the basis of the concertation between central banks at 14.15.",
+      Decimals,4,
+      last update,2026-09-07 15:58:27,
+      1999-01-01,.,No value available
+      1999-01-04,1.1789,
+      2026-09-04,1.1712,
+    CSV
+
+    expected = <<~CSV
+      USD,1999-01-04,1.1789
+      USD,2026-09-04,1.1712
+    CSV
+
+    assert_equal expected, Tax::EcbFxRates.send(:bundesbank_to_sdmx, csv, 'USD')
+  end
+
+  # The ECB only publishes on business days, so from Saturday until Monday's publication
+  # the newest stored rate is Friday's. Comparing against a plain "yesterday" made that
+  # look stale and refetched the whole 1999-onwards history on every single job run.
+  test 'no refetch over the weekend: Friday satisfies Saturday through Monday' do
+    seed('USD', Date.new(2026, 9, 4), '1.1712'.to_d) # Friday
+
+    Tax::EcbFxRates.stubs(:fetch_history_csv).returns(sdmx('USD', '2026-09-07', '9.9999'))
+    [Date.new(2026, 9, 5), Date.new(2026, 9, 6), Date.new(2026, 9, 7)].each do |today|
+      travel_to(today) { Tax::EcbFxRates.ensure_loaded! }
+    end
+
+    assert_equal 1, FxRate.count, 'refetched the full history while the ECB had published nothing new'
+  end
+
+  test 'refetches on Tuesday once Monday publication is due' do
+    seed('USD', Date.new(2026, 9, 4), '1.1712'.to_d) # Friday
+
+    Tax::EcbFxRates.stubs(:fetch_history_csv).returns(sdmx('USD', '2026-09-07', '1.1690'))
+    travel_to(Date.new(2026, 9, 8)) { Tax::EcbFxRates.ensure_loaded! }
+
+    assert_equal '1.1690'.to_d, FxRate.find_by(currency: 'USD', date: Date.new(2026, 9, 7))&.rate
   end
 end


### PR DESCRIPTION
Tax reports convert fiat amounts with ECB euro reference rates, loaded once and topped up daily. Two bugs in that loader, one hiding behind the other.

## The fallback could never parse its own source

`fetch_history_csv` falls back to the Bundesbank republication of the same ECB series whenever the ECB endpoint is unavailable. That feed opens with a UTF-8 BOM sitting immediately in front of an empty quoted field:

```
efbbbf 22 22 2c   →   ﻿"",BBEX3.D.USD.EUR.BB.AC.000,...
```

`CSV.parse` reads the BOM bytes as ordinary field content and then hits a quote in the middle of that field, so the whole fetch dies on `CSV::MalformedCSVError: Illegal quoting in line 1`. Every fall back to this source has failed this way since it was added — the fallback has never once produced a rate.

The existing test passed because its fixture was written from the endpoint's documented shape rather than its bytes: fully quoted, no BOM. The new test uses the real thing.

## The fallback was reached far more often than it should have been

`ensure_loaded!` refetches when the newest stored rate is older than `last_expected_publication_date`, which was `Date.current - 1`. The ECB publishes only on TARGET business days, so from Saturday morning until Monday afternoon the newest stored rate is Friday's — and measured against a plain "yesterday", Friday always looks stale.

The result was that every report or ledger run across a weekend redownloaded the full history back to 1999, tens of megabytes, to learn nothing had changed. That is also a fetch tight enough to time out against the 15s cap, and a timeout is exactly what drops into the fallback above.

Walking the expected publication date back over the weekend fixes both the waste and the frequency: one fetch per business day.

## Impact

None visible in a report. `per_eur` already looks back up to seven days, so Friday's rate covered Saturday through Monday while the loader failed silently behind it. The failure was logged as a warning and swallowed.

## Tests

- `bundesbank_to_sdmx` parses the live feed shape — BOM, half-quoted metadata preamble, `.` for unpublished days.
- No refetch on Saturday, Sunday or Monday when Friday's rate is stored.
- Still refetches on Tuesday, once Monday's publication is due.

Verified against the live Bundesbank endpoint: 7,087 rows, 1999-01-04 through today.
