### PR TITLE
Lay the wash-sale widget out like the rules beside it

### DIFF
--- a/app/views/bots/settings/_wash_sale.html.erb
+++ b/app/views/bots/settings/_wash_sale.html.erb
@@ -1,28 +1,29 @@
-<%# The wash-sale window. Not a trigger and not toggled: "None" is the off position, and the rule is
-    a fact about the user's tax residence rather than a strategy the bot could be talked out of. %>
-<% active = bot.wash_sale_days.positive? %>
+<%# The wash-sale window. NOT a rule with a toggle, and deliberately not styled as one: the other
+    widgets in this column are triggers the bot can be switched on and off, while this is a fact
+    about the user's tax residence that the sale legs consult. "No time" is the off position and it
+    is right there in the dropdown, so a toggle would be a second switch for the same state — and
+    an inactive-looking rule with no toggle reads as broken rather than as off. Always painted
+    active, so the select looks like the live control it is. %>
 <% options = [[t('bot.settings.wash_sale.none'), '']] +
              Tax::Jurisdictions.wash_sale_options.map { |code, name, days| [t('bot.settings.wash_sale.option', country: name, days: days), code] } %>
-<% current = active ? t('bot.settings.wash_sale.option', country: Tax::Jurisdictions.for(bot.wash_sale_jurisdiction)[:name], days: bot.wash_sale_days) : t('bot.settings.wash_sale.none') %>
+<% current = bot.wash_sale_days.positive? ? t('bot.settings.wash_sale.option', country: Tax::Jurisdictions.for(bot.wash_sale_jurisdiction)[:name], days: bot.wash_sale_days) : t('bot.settings.wash_sale.none') %>
 <%= form_with model: bot, url: path, method: method,
-              class: "widget rule #{active ? 'rule--active' : 'rule--inactive'}",
-              data: { controller: "form--submit", turbo_stream: true } do |f| %>
-  <div class="toggle-group">
-    <div class="toggle-group__info">
-      <div class="toggle-group__info__label">
-        <%# A div, not f.label: the sentence contains a select, and a select inside a label breaks focus. %>
-        <div class="conversational conversational--small conversational--disabled">
-          <% select_html = capture do %>
-            <div class="sinput sinput--select">
-              <%= current %>
-              <%= f.select :wash_sale_jurisdiction, options, { selected: bot.wash_sale_jurisdiction.to_s },
-                           data: { action: "change->form--submit#submit" } %>
-            </div>
-          <% end %>
-          <%= t('bot.settings.wash_sale.sentence_html', select_html: select_html).html_safe %>
+              class: 'widget rule rule--active',
+              data: { controller: 'form--submit', turbo_stream: true } do |f| %>
+  <div class="toggle-group__info">
+    <%# A div, not f.label: the sentence contains a select, and a select inside a label breaks focus.
+        The note goes INSIDE the conversational sentence, as every other widget's does — the flex row
+        that wraps it is what puts it on its own full-width line instead of in a second column. %>
+    <div class="conversational conversational--small">
+      <% select_html = capture do %>
+        <div class="sinput sinput--select">
+          <%= current %>
+          <%= f.select :wash_sale_jurisdiction, options, { selected: bot.wash_sale_jurisdiction.to_s },
+                       data: { action: "change->form--submit#submit" } %>
         </div>
-        <small class="small-info"><%= t('bot.settings.wash_sale.note') %></small>
-      </div>
+      <% end %>
+      <%= t('bot.settings.wash_sale.sentence_html', select_html: select_html).html_safe %>
+      <small class="small-info"><%= t('bot.settings.wash_sale.note') %></small>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
The wash-sale widget rendered wrong: the sentence broke across two lines with the note stacked into a second column beside it, and with no toggle and inactive styling it read as a broken or disabled rule.

Two causes.

**The note was in the wrong place.** It sat as a sibling of the sentence inside `toggle-group__info__label`, which is a flex row — so it became a second column. Every other widget renders its note *inside* the conversational sentence, where the wrap puts it on its own full-width line. Moved.

**The toggle-group shell did not belong.** The other widgets in that column are rules the bot switches on and off. This is not one: it is a fact about the user's tax residence that the sale legs consult, and "no time" is already the off position in the dropdown, so a toggle would be a second switch for the same state. But a widget with the rule chrome, no toggle and inactive colours reads as broken. It now drops the toggle-group shell and paints active, so the select looks like the live control it is; the selected value carries the state.
