### PR TITLE
Fix the wash-sale question's layout and gate its Confirm

### DIFF
--- a/app/assets/stylesheets/new/_small-random.sass
+++ b/app/assets/stylesheets/new/_small-random.sass
@@ -25,37 +25,15 @@
     input
         align-self: flex-end
         width: 21.5rem
-// The one-time wash-sale question. Two stacked choices, neither preselected, sharing the radio
-// styling .form__radio already defines — this only stacks them and gives the sentence room.
+// The one-time wash-sale question. A stack of .form__radio choices, each sentence a
+// .conversational so its jurisdiction pill sits inside the line instead of breaking it.
 .wash-sale-question
     display: flex
     flex-direction: column
-    gap: 1.5rem
+    gap: 2rem
     margin-bottom: 3rem
     text-align: left
-    &__choice
-        display: flex
-        align-items: center
-        gap: 1.5rem
-        cursor: pointer
-        input[type="radio"]
-            appearance: none
-            width: 2.4rem
-            height: 2.4rem
-            border: .2rem solid var(--input-border)
-            border-radius: 50%
-            cursor: pointer
-            position: relative
-            flex-shrink: 0
-            &:checked
-                border-color: var(--link)
-                &::after
-                    content: ''
-                    position: absolute
-                    top: 50%
-                    left: 50%
-                    transform: translate(-50%, -50%)
-                    width: 1.2rem
-                    height: 1.2rem
-                    background: var(--link)
-                    border-radius: 50%
+    // .form__radio brings the radio and its centred row; the sentence takes the rest of the width
+    // so it wraps inside the line rather than pushing the pill onto one of its own.
+    .conversational
+        flex: 1

--- a/app/views/bots/liquidations/new.html.erb
+++ b/app/views/bots/liquidations/new.html.erb
@@ -36,14 +36,21 @@
           like every other modal form here; a refused sale answers 422 and the modal stays up
           carrying the reason. %>
       <%= form_with url: bot_liquidation_path(bot_id: @bot.id, symbol: @symbol), method: :post,
-                    data: { action: 'turbo:submit-end->modal--base#submitEnd' } do %>
+                    data: { controller: 'form--checkbox-enables',
+                            action: 'turbo:submit-end->modal--base#submitEnd ' \
+                                    'change->form--checkbox-enables#toggleSubmitButton' } do %>
         <%= render 'bots/wash_sale_prompts/question' unless current_user.wash_sale_decided? %>
 
         <div class="buttons buttons--row--2">
           <%= button_tag type: 'button', class: 'button button--outline button--large', data: { action: 'modal--base#animateOutCloseAndCleanUp' } do %>
             <%= t('button.cancel') %>
           <% end %>
+          <%# Dead while the question above is unanswered — the server refuses that submit anyway,
+              and a button that only 422s is worse than one that says it is not ready. Live from the
+              start once the account has decided, because then no radio exists to wake it. %>
           <%= button_tag t('bot.liquidation.sell'), type: :submit,
+                         disabled: !current_user.wash_sale_decided?,
+                         data: { form__checkbox_enables_target: 'submit' },
                          class: "button button--large #{@holding&.dig(:harvestable) ? 'button--success' : 'button--danger'}" %>
         </div>
       <% end %>

--- a/app/views/bots/wash_sale_prompts/_dialog.html.erb
+++ b/app/views/bots/wash_sale_prompts/_dialog.html.erb
@@ -6,11 +6,17 @@
     <div class="modal__body">
       <%# No close button and no cancel: the answer is what stops the question coming back, and
           "Don't apply" is one of the two answers rather than a way out of being asked. %>
+      <%# Confirm starts dead and the radios wake it: there is nothing to confirm before a choice,
+          and a live button over an unanswered question invites a submit that only 422s. %>
       <%= form_with url: bot_wash_sale_prompt_path(bot_id: bot.id), method: :post,
-                    data: { action: 'turbo:submit-end->modal--base#submitEnd' } do %>
+                    data: { controller: 'form--checkbox-enables',
+                            action: 'turbo:submit-end->modal--base#submitEnd ' \
+                                    'change->form--checkbox-enables#toggleSubmitButton' } do %>
         <%= render 'bots/wash_sale_prompts/question' %>
         <div class="buttons">
-          <%= button_tag t('settings.wash_sale.confirm'), type: :submit, class: 'button button--large' %>
+          <%= button_tag t('settings.wash_sale.confirm'), type: :submit, disabled: true,
+                         class: 'button button--sky button--large',
+                         data: { form__checkbox_enables_target: 'submit' } %>
         </div>
       <% end %>
     </div>

--- a/app/views/bots/wash_sale_prompts/_question.html.erb
+++ b/app/views/bots/wash_sale_prompts/_question.html.erb
@@ -1,13 +1,21 @@
 <%# The question itself, shared by the modal and the Sell confirmation, so the two seams cannot ask
     it differently — and worded with the account box's own sentence, so the answer and the setting
     the user later finds in Account read the same. Neither choice is preselected: a preselected
-    answer is not a decision, and this is the one thing the user has to decide for themselves. %>
+    answer is not a decision, and this is the one thing the user has to decide for themselves.
+
+    .conversational, not a bare span: it is a flex container whose nested `span` rule is what lets a
+    .sinput pill sit in the middle of a sentence. Without it the pill is block-level and the one
+    line becomes three. .form__radio carries the radio itself, as everywhere else in the app.
+
+    The targets gate the submit until one of the two is picked (form--checkbox-enables reads
+    `.checked`, which a radio has). They are inert wherever no such controller is an ancestor. %>
 <div class="wash-sale-question">
   <p class="text-inactive"><%= t('settings.wash_sale.prompt_body') %></p>
 
-  <label class="wash-sale-question__choice">
-    <%= radio_button_tag 'wash_sale[enabled]', '1', false %>
-    <span>
+  <label class="form__radio">
+    <%= radio_button_tag 'wash_sale[enabled]', '1', false,
+                         data: { form__checkbox_enables_target: 'checkbox' } %>
+    <span class="conversational conversational--small">
       <% select_html = capture do %>
         <div class="sinput sinput--select">
           <%= t('settings.wash_sale.option', country: Tax::Jurisdictions.for(current_user.wash_sale_jurisdiction)[:name],
@@ -21,8 +29,9 @@
     </span>
   </label>
 
-  <label class="wash-sale-question__choice">
-    <%= radio_button_tag 'wash_sale[enabled]', '0', false %>
-    <span><%= t('settings.wash_sale.prompt_decline') %></span>
+  <label class="form__radio">
+    <%= radio_button_tag 'wash_sale[enabled]', '0', false,
+                         data: { form__checkbox_enables_target: 'checkbox' } %>
+    <span class="conversational conversational--small"><%= t('settings.wash_sale.prompt_decline') %></span>
   </label>
 </div>

--- a/test/controllers/bots/liquidation_wash_sale_test.rb
+++ b/test/controllers/bots/liquidation_wash_sale_test.rb
@@ -28,6 +28,21 @@ class Bots::LiquidationWashSaleTest < ActionDispatch::IntegrationTest
     assert_select '.wash-sale-question', count: 0
   end
 
+  test 'Sell is dead until the question is answered' do
+    get new_bot_liquidation_path(bot_id: @bot.id, symbol: 'CCC')
+
+    assert_select 'button[type=submit][disabled]'
+  end
+
+  test 'a decided account gets a live Sell button' do
+    @user.update!(wash_sale_enabled: false)
+
+    get new_bot_liquidation_path(bot_id: @bot.id, symbol: 'CCC')
+
+    assert_select 'button[type=submit][disabled]', count: 0,
+                                                   message: 'no radios render, so nothing would ever re-enable it'
+  end
+
   test 'an unanswered question refuses the sale rather than selling first and asking later' do
     post bot_liquidation_path(bot_id: @bot.id, symbol: 'CCC')
 

--- a/test/controllers/bots/wash_sale_prompts_controller_test.rb
+++ b/test/controllers/bots/wash_sale_prompts_controller_test.rb
@@ -26,6 +26,29 @@ class Bots::WashSalePromptsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='wash_sale[enabled]'][value='0']"
   end
 
+  test 'the sentence flows as one, pill included' do
+    get new_bot_wash_sale_prompt_path(bot_id: @bot.id)
+
+    # A bare span leaves the pill block-level and breaks the sentence over three rows.
+    assert_select '.wash-sale-question .conversational .sinput--select'
+  end
+
+  test 'Confirm is dead until a choice is made' do
+    get new_bot_wash_sale_prompt_path(bot_id: @bot.id)
+
+    assert_select 'button[type=submit][disabled]'
+    assert_select "button[type=submit][data-form--checkbox-enables-target='submit']"
+    assert_select "input[name='wash_sale[enabled]'][data-form--checkbox-enables-target='checkbox']",
+                  count: 2
+    assert_select "form[data-controller~='form--checkbox-enables']"
+  end
+
+  test 'Confirm carries a colour — the bare class renders as browser chrome' do
+    get new_bot_wash_sale_prompt_path(bot_id: @bot.id)
+
+    assert_select 'button[type=submit].button--sky'
+  end
+
   test 'an account that has already answered is not asked again' do
     @user.update!(wash_sale_enabled: false)
 


### PR DESCRIPTION
Three problems with the one-time wash-sale question, all in the same modal.

**The sentence broke over three rows.** The choice wrapped it in a bare `<span>`.
`.conversational` is a flex container, and its nested `span { display: flex }`
rule is precisely what lets a `.sinput` pill sit inside a line of text — without
it the pill is block-level and pushes the words above and below onto their own
lines. The choices now use `.form__radio` and `.conversational`, like every other
sentence in the app, which also deletes the radio CSS the widget had duplicated.

**Confirm was grey.** It carried `button button--large` with no colour modifier,
and `.button` declares no background of its own, so it fell through to the
browser's default button chrome — under the white label the base class sets.
It is the primary action of the modal and now looks like one.

**Confirm was live before a choice was made.** There is nothing to confirm yet,
and pressing it only earned a 422. It now starts disabled and the radios wake it,
through the `form--checkbox-enables` controller already in the tree. The Sell
confirmation gets the same treatment and stays live from the start for an account
that has already answered — no radio renders there to wake it.
