### PR TITLE
Refuse to start a bot that can sell until the question is answered

### DIFF
--- a/app/controllers/bots/starts_controller.rb
+++ b/app/controllers/bots/starts_controller.rb
@@ -4,9 +4,18 @@ class Bots::StartsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_bot
 
-  def edit; end
+  # The restart question — or, while the wash-sale question is still owed, that one instead. Both
+  # land in the same modal frame, and answering is what makes this one reachable.
+  def edit
+    render partial: 'bots/wash_sale_prompts/dialog', locals: { bot: @bot } if wash_sale_prompt_due?(@bot)
+  end
 
+  # Starting a bot that can sell is the loudest "I am about to trade" there is, so it is where the
+  # question is finally owed rather than merely offered: refused until it is answered, with the
+  # question itself as the answer. 422 keeps the modal up, and the stream reaches the bots index
+  # too, which has the layout's modal frame and no start template of its own.
   def update
+    return render turbo_stream: wash_sale_prompt_stream(@bot), status: :unprocessable_entity if wash_sale_prompt_due?(@bot)
     return if @bot.start(start_fresh: Utilities::String.to_boolean(params[:start_fresh]))
 
     flash.now[:alert] = @bot.errors.messages.values.flatten.to_sentence

--- a/test/controllers/bots/start_wash_sale_test.rb
+++ b/test/controllers/bots/start_wash_sale_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+# Starting a bot that can sell is the loudest "I am about to trade" there is, and it happens on the
+# bots index as often as on a bot's own page. The question has to be answered first — not asked
+# afterwards, when the bot is already scheduled.
+class Bots::StartWashSaleTest < ActionDispatch::IntegrationTest
+  TURBO_STREAM_ACCEPT = 'text/vnd.turbo-stream.html, text/html'.freeze
+
+  setup do
+    create(:user, admin: true, setup_completed: true) # onboarding gate
+    @user = create(:user)
+    sign_in @user
+    @buyer = create(:dca_single_asset, user: @user)
+    @seller = create(:dca_single_asset, user: @user, exchange: @buyer.exchange,
+                                        base_asset: Asset.find_by(symbol: 'BTC'),
+                                        quote_asset: Asset.find_by(symbol: 'USD'))
+    @seller.update_column(:settings, @seller.settings.merge('direction' => 'selling'))
+
+    Bot::ActionJob.stubs(:perform_later)
+    Bot::ActionJob.stubs(:set).returns(stub(perform_later: true))
+    Bot::BroadcastAfterScheduledActionJob.stubs(:perform_later)
+    Bots::DcaSingleAsset.any_instance.stubs(:check_missed_quote_amount_was_set).returns(true)
+  end
+
+  # `restarting?` is stopped + a past run, and last_action_job_at is a transient_data accessor.
+  def stopped_after_a_run(bot)
+    bot.update_columns(status: Bot.statuses[:stopped],
+                       transient_data: bot.transient_data.merge('last_action_job_at' => 1.hour.ago))
+  end
+
+  def start(bot)
+    patch bot_start_path(bot_id: bot.id, start_fresh: true), headers: { 'Accept' => TURBO_STREAM_ACCEPT }
+  end
+
+  test 'a bot that can sell will not start while the question is unanswered' do
+    start(@seller)
+
+    assert_response :unprocessable_entity
+    assert_not_predicate @seller.reload, :scheduled?
+    assert_match 'wash-sale-question', response.body, 'and the question comes back with the refusal'
+  end
+
+  test 'the refusal is the question, not a dead end' do
+    start(@seller)
+
+    assert_match 'wash_sale[enabled]', response.body
+    assert_match 'target="modal"', response.body,
+                 'the bots index has no start template of its own, only the layout modal frame'
+  end
+
+  test 'answering once is enough — the next start goes through' do
+    @user.update!(wash_sale_enabled: false)
+
+    start(@seller)
+
+    assert_response :success
+    assert_predicate @seller.reload, :scheduled?
+  end
+
+  test 'a buy-only bot is not held up by a tax question about selling' do
+    start(@buyer)
+
+    assert_response :success
+    assert_predicate @buyer.reload, :scheduled?
+  end
+
+  test 'the restart question is replaced by the wash-sale question while it is due' do
+    stopped_after_a_run(@seller)
+
+    get edit_bot_start_path(bot_id: @seller.id)
+
+    assert_response :success
+    assert_select '.wash-sale-question'
+    # The start question must not be reachable behind the one that gates it.
+    assert_select 'form[action=?]', bot_start_path(bot_id: @seller.id), count: 0
+  end
+
+  test 'once answered, the restart question is the restart question again' do
+    @user.update!(wash_sale_enabled: false)
+    stopped_after_a_run(@seller)
+
+    get edit_bot_start_path(bot_id: @seller.id)
+
+    assert_select '.wash-sale-question', count: 0
+    assert_select 'form[action^=?]', bot_start_path(bot_id: @seller.id)
+  end
+end


### PR DESCRIPTION
Starting a bot that can sell is the loudest "I am about to trade" there is, and
it was the one such action that asked nothing.

The gap is structural rather than a missed call site. There are two start seams,
and the common one — a tile's Start button on the bots index — submits straight
to `PATCH /bots/:id/start` with `turbo_frame: "_top"`. No page render happens, so
the `content_for :modal_src` catch-all on the bot page never fires, and the
start's own turbo_stream targets `settings` and `exchange_select`, ids that do
not exist on the index at all.

So the start itself refuses while the question is owed, and answers **with** the
question: 422 keeps the modal up, and a `turbo_stream.replace("modal", …)`
lands equally well on the index, which carries the layout's modal frame. The
restart confirmation — the other seam, taken when a stopped bot has run before —
shows the same question in place of its own.

**A buy-only bot starts exactly as before.** The reason for asking at the first
thing that can sell was never to put a tax question to someone who only ever
buys, so the gate is `sell_capable?`, the same predicate the other three seams
use: set to selling, a trigger armed to flip into selling, rebalancing on, a
composition bot holding a position, or an enabled sell rule.

**The API's `start_bot` is deliberately not gated.** There is no modal to show a
headless caller, and refusing there would break automation over a question it
cannot answer; an API user sets the rule through the settings endpoints instead.
