### PR TITLE
Ask the wash-sale question once, in one layout

### DIFF
--- a/app/assets/stylesheets/new/_small-random.sass
+++ b/app/assets/stylesheets/new/_small-random.sass
@@ -30,6 +30,8 @@
 .wash-sale-question
     display: flex
     flex-direction: column
+    // .setting-form centres its items, and the question is a block of text, not a control.
+    width: 100%
     gap: 2rem
     margin-bottom: 3rem
     text-align: left

--- a/app/controllers/bots/liquidations_controller.rb
+++ b/app/controllers/bots/liquidations_controller.rb
@@ -45,11 +45,7 @@ class Bots::LiquidationsController < ApplicationController
   def wash_sale_answer_recorded?
     return true if current_user.wash_sale_decided?
 
-    answer = params.dig(:wash_sale, :enabled)
-    return false if answer.blank?
-
-    record_wash_sale_decision(enabled: ActiveModel::Type::Boolean.new.cast(answer),
-                              jurisdiction: params.dig(:wash_sale, :jurisdiction))
+    record_wash_sale_answer == true
   end
 
   def refuse(message)

--- a/app/controllers/bots/wash_sale_prompts_controller.rb
+++ b/app/controllers/bots/wash_sale_prompts_controller.rb
@@ -11,14 +11,10 @@ class Bots::WashSalePromptsController < ApplicationController
   # reason, not a 500. Nothing is enqueued and nothing is written on a refusal, so the question
   # comes back exactly as it was.
   def create
-    answer = params.dig(:wash_sale, :enabled)
-    return render_refusal(t('settings.wash_sale.prompt_missing')) if answer.blank?
-
-    if record_wash_sale_decision(enabled: ActiveModel::Type::Boolean.new.cast(answer),
-                                 jurisdiction: params.dig(:wash_sale, :jurisdiction))
-      render turbo_stream: turbo_stream_prepend_flash
-    else
-      render_refusal(current_user.errors.full_messages.to_sentence)
+    case record_wash_sale_answer
+    when nil then render_refusal(t('settings.wash_sale.prompt_missing'))
+    when false then render_refusal(current_user.errors.full_messages.to_sentence)
+    else render turbo_stream: turbo_stream_prepend_flash
     end
   end
 

--- a/app/controllers/concerns/wash_sale_promptable.rb
+++ b/app/controllers/concerns/wash_sale_promptable.rb
@@ -23,6 +23,18 @@ module WashSalePromptable
     turbo_stream.replace('modal', partial: 'bots/wash_sale_prompts/dialog', locals: { bot: bot })
   end
 
+  # Record the answer as the question partial submits it — the same shape from the modal, the Sell
+  # confirmation and the account box, because they render the same partial. nil when neither choice
+  # was picked, so a caller can refuse rather than record a "no" nobody made; false when the answer
+  # itself was rejected.
+  def record_wash_sale_answer
+    answer = params.dig(:wash_sale, :enabled)
+    return nil if answer.blank?
+
+    record_wash_sale_decision(enabled: ActiveModel::Type::Boolean.new.cast(answer),
+                              jurisdiction: params.dig(:wash_sale, :jurisdiction))
+  end
+
   # One writer for the decision, wherever it is answered: the account box, the modal, or the Sell
   # confirmation. Switching it on re-walks the account ledger, so a window that started before the
   # answer is still served. Returns false on an unknown jurisdiction, so the caller can refuse.

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -118,11 +118,12 @@ class SettingsController < ApplicationController
   # Turning it ON re-arms from history: the ledger walk covers the trailing 31 days, so a user who
   # switches this on today is protected by sales they already made rather than starting from blank.
   def update_wash_sale
-    if record_wash_sale_decision(enabled: params.dig(:user, :wash_sale_enabled) == '1',
-                                 jurisdiction: params.dig(:user, :wash_sale_jurisdiction))
-      redirect_back fallback_location: settings_account_path, status: :see_other
-    else
-      render_preference_error
+    case record_wash_sale_answer
+    when nil
+      flash.now[:alert] = t('settings.wash_sale.prompt_missing')
+      render turbo_stream: turbo_stream_prepend_flash, status: :unprocessable_entity
+    when false then render_preference_error
+    else redirect_back fallback_location: settings_account_path, status: :see_other
     end
   end
 

--- a/app/views/bots/wash_sale_prompts/_question.html.erb
+++ b/app/views/bots/wash_sale_prompts/_question.html.erb
@@ -9,11 +9,14 @@
 
     The targets gate the submit until one of the two is picked (form--checkbox-enables reads
     `.checked`, which a radio has). They are inert wherever no such controller is an ancestor. %>
+<%# `checked` is the tri-state answer: nil where nothing has been decided (the prompt), true/false
+    where the account already answered (the settings box, which has to show its own state). %>
+<% checked = local_assigns[:checked] %>
 <div class="wash-sale-question">
   <p class="text-inactive"><%= t('settings.wash_sale.prompt_body') %></p>
 
   <label class="form__radio">
-    <%= radio_button_tag 'wash_sale[enabled]', '1', false,
+    <%= radio_button_tag 'wash_sale[enabled]', '1', checked == true,
                          data: { form__checkbox_enables_target: 'checkbox' } %>
     <span class="conversational conversational--small">
       <% select_html = capture do %>
@@ -29,7 +32,7 @@
   </label>
 
   <label class="form__radio">
-    <%= radio_button_tag 'wash_sale[enabled]', '0', false,
+    <%= radio_button_tag 'wash_sale[enabled]', '0', checked == false,
                          data: { form__checkbox_enables_target: 'checkbox' } %>
     <span class="conversational conversational--small"><%= t('settings.wash_sale.prompt_decline') %></span>
   </label>

--- a/app/views/settings/widgets/_wash_sale.html.erb
+++ b/app/views/settings/widgets/_wash_sale.html.erb
@@ -1,61 +1,31 @@
 <%# Wash-sale protection, at the scope it belongs to: the taxpayer. Two bots holding the same asset
-    would otherwise undo each other's harvest, and one person cannot have two tax residences. The
-    rule chrome is the bot page's, because that is what this is — a rule every bot obeys — but it is
-    set once, here. %>
-<% decided = current_user.wash_sale_decided? %>
-<% active = current_user.wash_sale_enabled? %>
+    would otherwise undo each other's harvest, and one person cannot have two tax residences.
+
+    The same question the modal asks, from the same partial — a second layout for one setting is a
+    second wording to keep in step, and the user meets both. What is only here is the list of what
+    the rule is doing right now across every bot. %>
 <% locked = current_user.locked_assets %>
-<% options = Tax::Jurisdictions.wash_sale_options.map { |code, _, _| [wash_sale_option_label(code), code] } %>
 <%= turbo_frame_tag 'wash_sale' do %>
   <div class="widget widget--settings">
     <h4 class="modal__title"><%= t('settings.wash_sale.title') %></h4>
 
-    <%= form_with model: current_user, url: settings_update_wash_sale_path, method: :patch,
-                  class: "rule #{active ? 'rule--active' : 'rule--inactive'}",
-                  data: {
-                    controller: "class-toggle form--submit",
-                    class_toggle_target: "togglable",
-                    class_toggle_toggle_classes_value: ["rule--active", "rule--inactive"],
-                    turbo_frame: "wash_sale"
-                  } do |f| %>
-      <div class="toggle-group">
-        <div class="toggle">
-          <%= f.check_box :wash_sale_enabled, checked: active,
-                          data: { action: "change->form--submit#submit change->class-toggle#toggle" } %>
-          <div class="toggle__style"></div>
-        </div>
-        <div class="toggle-group__info">
-          <div class="toggle-group__info__label">
-            <%# f.label, so clicking the sentence works the toggle. A click landing on the select is
-                interactive content — the browser opens the dropdown and does not forward it here. %>
-            <%= f.label :wash_sale_enabled, class: "conversational conversational--small conversational--disabled" do %>
-              <% select_html = capture do %>
-                <div class="sinput sinput--select">
-                  <%= wash_sale_option_label(current_user.wash_sale_jurisdiction) %>
-                  <%= f.select :wash_sale_jurisdiction, options, { selected: current_user.wash_sale_jurisdiction },
-                               data: { action: "change->form--submit#submit" } %>
-                </div>
-              <% end %>
-              <%= t('settings.wash_sale.sentence_html', select_html: select_html).html_safe %>
-              <small class="small-info"><%= t('settings.wash_sale.note') %></small>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-
-    <%# Undecided is a state of its own. A toggle left off cannot say whether the user chose "no" or
-        never looked, so while it is nil this records the "no" explicitly — and once anything is
-        decided, here or in the prompt, the button never comes back. %>
-    <% unless decided %>
-      <%= button_to t('settings.wash_sale.confirm'), settings_update_wash_sale_path,
-                    method: :patch, params: { user: { wash_sale_enabled: '0' } },
-                    class: 'button button--outline', form: { data: { turbo_frame: 'wash_sale' } } %>
+    <%# .setting-form is where this page's buttons get their width, exactly as in the name, email
+        and password widgets. Confirm is dead until an answer is picked — on a decided account one
+        radio is already checked, so it is live from the start. %>
+    <%= form_with url: settings_update_wash_sale_path, method: :patch, class: 'setting-form',
+                  data: { controller: 'form--checkbox-enables',
+                          action: 'change->form--checkbox-enables#toggleSubmitButton',
+                          turbo_frame: 'wash_sale' } do %>
+      <%= render 'bots/wash_sale_prompts/question', checked: current_user.wash_sale_enabled %>
+      <%= button_tag t('settings.wash_sale.confirm'), type: :submit,
+                     disabled: !current_user.wash_sale_decided?,
+                     class: 'button button--sky',
+                     data: { form__checkbox_enables_target: 'submit' } %>
     <% end %>
 
     <%# What the rule is doing right now, across every bot — the one place the whole picture is
         visible, since a bot's own panel only shows the names that bot trades. %>
-    <% if active %>
+    <% if current_user.wash_sale_enabled? %>
       <div class="settings-prefs__notes">
         <span class="label"><%= t('settings.wash_sale.locked_title') %></span>
         <% if locked.any? %>

--- a/test/controllers/settings/wash_sale_test.rb
+++ b/test/controllers/settings/wash_sale_test.rb
@@ -14,32 +14,64 @@ class Settings::WashSaleTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
-  test 'undecided renders the toggle AND a Confirm button' do
+  test 'the account box asks exactly what the modal asks' do
     get settings_account_path
 
     assert_response :success
-    assert_select '#wash_sale form select[name=?]', 'user[wash_sale_jurisdiction]' do
+    # One question, one partial, one wording.
+    assert_select '#wash_sale .wash-sale-question'
+    assert_select '#wash_sale form select[name=?]', 'wash_sale[jurisdiction]' do
       assert_select 'option', count: Tax::Jurisdictions.wash_sale_options.size
     end
-    assert_select '#wash_sale .rule--inactive'
-    assert_select '#wash_sale', text: /#{I18n.t('settings.wash_sale.confirm')}/,
-                                message: 'a toggle left off cannot say whether the user chose no or never looked'
+    assert_select "#wash_sale input[name='wash_sale[enabled]']", count: 2
   end
 
-  test 'Confirm records the no, and the button never comes back' do
-    patch settings_update_wash_sale_path, params: { user: { wash_sale_enabled: '0' } }
+  test 'undecided preselects neither answer and leaves Confirm dead' do
+    get settings_account_path
+
+    assert_select "#wash_sale input[name='wash_sale[enabled]'][checked]", count: 0,
+                                                                          message: 'a preselected answer is not a decision'
+    assert_select '#wash_sale button[type=submit][disabled]'
+  end
+
+  test 'a decided account sees its own answer, and can change it' do
+    @user.update!(wash_sale_enabled: true, wash_sale_jurisdiction: 'IE')
+
+    get settings_account_path
+
+    assert_select "#wash_sale input[name='wash_sale[enabled]'][value='1'][checked]"
+    assert_select '#wash_sale button[type=submit][disabled]', count: 0
+    assert_select '#wash_sale option[value=IE][selected]'
+  end
+
+  test 'the button matches the rest of the page' do
+    get settings_account_path
+
+    # Full width comes from .setting-form, like every other widget on this page.
+    assert_select '#wash_sale form.setting-form button.button--sky'
+  end
+
+  test 'an empty answer changes nothing' do
+    patch settings_update_wash_sale_path, params: { wash_sale: { jurisdiction: 'IE' } }
+
+    assert_response :unprocessable_entity
+    assert_not_predicate @user.reload, :wash_sale_decided?
+  end
+
+  test 'Confirm records the no, and the answer sticks' do
+    patch settings_update_wash_sale_path, params: { wash_sale: { enabled: '0' } }
 
     @user.reload
     assert_predicate @user, :wash_sale_decided?
     assert_not_predicate @user, :wash_sale_enabled?
 
     get settings_account_path
-    assert_select '#wash_sale', text: /#{I18n.t('settings.wash_sale.confirm')}/, count: 0
+    assert_select "#wash_sale input[name='wash_sale[enabled]'][value='0'][checked]"
   end
 
   test 'switching it on stores the window and decides' do
     patch settings_update_wash_sale_path,
-          params: { user: { wash_sale_enabled: '1', wash_sale_jurisdiction: 'IE' } }
+          params: { wash_sale: { enabled: '1', jurisdiction: 'IE' } }
 
     assert_equal 28, @user.reload.wash_sale_days
     assert_predicate @user, :wash_sale_decided?
@@ -48,7 +80,7 @@ class Settings::WashSaleTest < ActionDispatch::IntegrationTest
   test 'switching it off keeps the chosen window for next time' do
     @user.update!(wash_sale_enabled: true, wash_sale_jurisdiction: 'IE')
 
-    patch settings_update_wash_sale_path, params: { user: { wash_sale_enabled: '0' } }
+    patch settings_update_wash_sale_path, params: { wash_sale: { enabled: '0' } }
 
     assert_equal 0, @user.reload.wash_sale_days
     assert_equal 'IE', @user.wash_sale_jurisdiction, 'the choice survives the switch'
@@ -56,7 +88,7 @@ class Settings::WashSaleTest < ActionDispatch::IntegrationTest
 
   test 'turning it on re-arms from history' do
     assert_enqueued_with(job: Tracker::LedgerJob) do
-      patch settings_update_wash_sale_path, params: { user: { wash_sale_enabled: '1' } }
+      patch settings_update_wash_sale_path, params: { wash_sale: { enabled: '1' } }
     end
   end
 
@@ -64,13 +96,13 @@ class Settings::WashSaleTest < ActionDispatch::IntegrationTest
     @user.update!(wash_sale_enabled: true)
 
     assert_no_enqueued_jobs(only: Tracker::LedgerJob) do
-      patch settings_update_wash_sale_path, params: { user: { wash_sale_enabled: '0' } }
+      patch settings_update_wash_sale_path, params: { wash_sale: { enabled: '0' } }
     end
   end
 
   test 'an unknown code is refused without changing anything' do
     patch settings_update_wash_sale_path,
-          params: { user: { wash_sale_enabled: '1', wash_sale_jurisdiction: 'XX' } }
+          params: { wash_sale: { enabled: '1', jurisdiction: 'XX' } }
 
     assert_response :unprocessable_entity
     assert_not_predicate @user.reload, :wash_sale_enabled?


### PR DESCRIPTION
The account box had its own layout for the same setting the modal asks about: a
toggle and a sentence there, two radios and the same sentence in the modal. Two
wordings to keep in step for one decision, and a user meets both.

The box now renders the modal's own question partial and shows its own answer —
the radio matching the account's state is checked, and neither is while nothing
has been decided. Confirm is a `.setting-form` submit like the name, email and
password widgets, so it takes the page's own button width, and it stays dead
until an answer is picked.

**The two param shapes collapse into one.** This is why the partial could not be
shared before: the settings form posted `user[wash_sale_enabled]` while the modal
and the Sell confirmation posted `wash_sale[enabled]`. Worse, a blank answer
meant different things on the two sides — the POST paths refused with 422, while
settings coerced `nil == '1'` to `false` and silently recorded a "no" nobody
made. One reader (`record_wash_sale_answer`) now serves all three seams and
refuses a blank everywhere.
