### PR TITLE
Show the country the wash-sale dropdown is set to

### DIFF
--- a/app/views/bots/wash_sale_prompts/_question.html.erb
+++ b/app/views/bots/wash_sale_prompts/_question.html.erb
@@ -19,12 +19,19 @@
     <%= radio_button_tag 'wash_sale[enabled]', '1', checked == true,
                          data: { form__checkbox_enables_target: 'checkbox' } %>
     <span class="conversational conversational--small">
+      <%# The pill's select is invisible (.sinput--select) and the label beside it is what the user
+          reads, so the two only stay in step if something copies the picked option across. Every
+          other pill in the app gets that for free by submitting on change; this form waits for
+          Confirm, so it takes the form--select-display wiring instead — controller on the pill,
+          target on the label, action on the select. Without it the pill still said "US" after the
+          user picked another country, in the modal and in the account box alike. %>
       <% select_html = capture do %>
-        <div class="sinput sinput--select">
-          <%= wash_sale_option_label(current_user.wash_sale_jurisdiction) %>
+        <div class="sinput sinput--select" data-controller="form--select-display">
+          <span data-form--select-display-target="label"><%= wash_sale_option_label(current_user.wash_sale_jurisdiction) %></span>
           <%= select_tag 'wash_sale[jurisdiction]',
                          options_for_select(Tax::Jurisdictions.wash_sale_options.map { |code, _, _| [wash_sale_option_label(code), code] },
-                                            current_user.wash_sale_jurisdiction) %>
+                                            current_user.wash_sale_jurisdiction),
+                         data: { action: 'change->form--select-display#update' } %>
         </div>
       <% end %>
       <%= t('settings.wash_sale.sentence_html', select_html: select_html).html_safe %>

--- a/test/controllers/settings/wash_sale_test.rb
+++ b/test/controllers/settings/wash_sale_test.rb
@@ -44,6 +44,17 @@ class Settings::WashSaleTest < ActionDispatch::IntegrationTest
     assert_select '#wash_sale option[value=IE][selected]'
   end
 
+  test 'the jurisdiction pill can show a country other than the one it was rendered with' do
+    get settings_account_path
+
+    # The select is invisible; the label beside it is what the user reads. Nothing here submits on
+    # change, so without this wiring the pill keeps the country it was rendered with forever.
+    assert_select '#wash_sale .sinput--select[data-controller=?]', 'form--select-display' do
+      assert_select 'span[data-form--select-display-target=?]', 'label'
+      assert_select 'select[data-action=?]', 'change->form--select-display#update'
+    end
+  end
+
   test 'the button matches the rest of the page' do
     get settings_account_path
 


### PR DESCRIPTION
The wash-sale question asks which country's rule to apply through a dropdown pill. The pill hides its `<select>` and shows a label beside it, so the label is the part the user reads. Picking a different country left that label untouched: the sentence went on saying US while the user was answering it, in the modal and in the Account box alike, since both render the same partial.

The posted value was always the one picked, so answers were recorded for the right country — only the sentence was stale.

Every other `.sinput--select` pill in the app keeps the label in step by submitting on change and re-rendering. This question can't: it waits for Confirm. It now uses the `form--select-display` wiring the withdrawal and signal pills use for the same reason — controller on the pill, target on the label, action on the select.

A test asserts the wiring is present, since nothing else here would notice it going missing.
